### PR TITLE
Add test case and fix for issue #1

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,12 +3,14 @@ package growthbook
 import (
 	"encoding/json"
 	"net/url"
+	"reflect"
 )
 
 // Context contains the options for creating a new GrowthBook
 // instance.
 type Context struct {
 	Enabled          bool
+	Valid            bool
 	Attributes       Attributes
 	URL              *url.URL
 	Features         FeatureMap
@@ -28,7 +30,7 @@ type ExperimentCallback func(experiment *Experiment, result *ExperimentResult)
 // NewContext creates a context with default settings: enabled, but
 // all other fields empty.
 func NewContext() *Context {
-	return &Context{Enabled: true}
+	return &Context{Enabled: true, Valid: true}
 }
 
 // WithEnabled sets the enabled flag for a context.
@@ -39,7 +41,17 @@ func (ctx *Context) WithEnabled(enabled bool) *Context {
 
 // WithAttributes sets the attributes for a context.
 func (ctx *Context) WithAttributes(attributes Attributes) *Context {
-	ctx.Attributes = attributes
+	savedAttributes := Attributes{}
+	for k, v := range attributes {
+		// Skip attributes that are arrays: not allowed.
+		if reflect.ValueOf(v).Kind() == reflect.Array {
+			ctx.Valid = false
+			logError(ErrCtxArrayInAttributes, k)
+			continue
+		}
+		savedAttributes[k] = fixSliceTypes(v)
+	}
+	ctx.Attributes = savedAttributes
 	return ctx
 }
 

--- a/growthbook.go
+++ b/growthbook.go
@@ -20,6 +20,9 @@ type GrowthBook struct {
 
 // New created a new GrowthBook instance.
 func New(context *Context) *GrowthBook {
+	if !context.Valid {
+		return nil
+	}
 	return &GrowthBook{
 		context,
 		map[string]bool{},
@@ -105,6 +108,7 @@ func (gb *GrowthBook) Feature(key string) *FeatureResult {
 
 	// Loop through the feature rules (if any).
 	for _, rule := range feature.Rules {
+
 		// If the rule has a condition and the condition does not pass,
 		// skip this rule.
 		if rule.Condition != nil && !rule.Condition.Eval(gb.Attributes()) {

--- a/logging.go
+++ b/logging.go
@@ -10,6 +10,7 @@ const (
 	ErrJSONFailedToParse       = "failed parsing JSON input"
 	ErrJSONInvalidType         = "invalid JSON data type"
 	ErrCtxJSONInvalidURL       = "invalid URL in JSON context data"
+	ErrCtxArrayInAttributes    = "array values not permitted in attributes (use a slice)"
 	ErrExpJSONInvalidCondition = "invalid condition in JSON experiment data"
 	ErrCondJSONNot             = "invalid $not in JSON condition data"
 	ErrCondJSONSequence        = "something wrong in condition sequence"

--- a/regression_test.go
+++ b/regression_test.go
@@ -1,0 +1,151 @@
+package growthbook
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/franela/goblin"
+)
+
+var regressionTests = []func(g *G, itest int){
+	issue1, // https://github.com/growthbook/growthbook-golang/issues/1
+}
+
+func TestRegressions(t *testing.T) {
+	g := Goblin(t)
+	g.Describe("regressions", func() {
+		for itest, test := range regressionTests {
+			g.It(fmt.Sprintf("issue #%d", itest+1), func() {
+				test(g, itest+1)
+			})
+		}
+	})
+}
+
+const issue1FeaturesJson = `{
+	"banner_text": {
+		"defaultValue": "Welcome to Acme Donuts!",
+		"rules": [
+			{
+				"condition": { "country": "france" },
+				"force": "Bienvenue au Beignets Acme !"
+			},
+			{
+				"condition": { "country": "spain" },
+				"force": "¡Bienvenidos y bienvenidas a Donas Acme!"
+			}
+		]
+	},
+	"dark_mode": {
+		"defaultValue": false,
+		"rules": [
+			{
+				"condition": { "loggedIn": true },
+				"force": true,
+				"coverage": 0.5,
+				"hashAttribute": "id"
+			}
+		]
+	},
+	"donut_price": {
+		"defaultValue": 2.5,
+		"rules": [{ "condition": { "employee": true }, "force": 0 }]
+	},
+	"meal_overrides_gluten_free": {
+		"defaultValue": {
+			"meal_type": "standard",
+			"dessert": "Strawberry Cheesecake"
+		},
+		"rules": [
+			{
+				"condition": {
+					"dietaryRestrictions": { "$elemMatch": { "$eq": "gluten_free" } }
+				},
+				"force": { "meal_type": "gf", "dessert": "French Vanilla Ice Cream" }
+			}
+		]
+	}
+}`
+
+const issue1AttributesJson = `{"employee":false,"loggedIn":true,"dietaryRestrictions":["gluten_free"]}`
+
+const issue1ContextJson = `{
+  "attributes": {"employee":false,"loggedIn":true,"dietaryRestrictions":["gluten_free"]},
+  "features": {
+		"banner_text": {
+			"defaultValue": "Welcome to Acme Donuts!",
+			"rules": [
+				{
+					"condition": { "country": "france" },
+					"force": "Bienvenue au Beignets Acme !"
+				},
+				{
+					"condition": { "country": "spain" },
+					"force": "¡Bienvenidos y bienvenidas a Donas Acme!"
+				}
+			]
+		},
+		"dark_mode": {
+			"defaultValue": false,
+			"rules": [
+				{
+					"condition": { "loggedIn": true },
+					"force": true,
+					"coverage": 0.5,
+					"hashAttribute": "id"
+				}
+			]
+		},
+		"donut_price": {
+			"defaultValue": 2.5,
+			"rules": [{ "condition": { "employee": true }, "force": 0 }]
+		},
+		"meal_overrides_gluten_free": {
+			"defaultValue": {
+				"meal_type": "standard",
+				"dessert": "Strawberry Cheesecake"
+			},
+			"rules": [
+				{
+					"condition": {
+						"dietaryRestrictions": { "$elemMatch": { "$eq": "gluten_free" } }
+					},
+					"force": { "meal_type": "gf", "dessert": "French Vanilla Ice Cream" }
+				}
+			]
+		}
+  }
+}`
+
+const issue1ExpectedJson = `{ "meal_type": "gf", "dessert": "French Vanilla Ice Cream" }`
+
+type MealOverrides struct {
+	MealType string `json:"meal_type"`
+	Dessert  string `json:"dessert"`
+}
+
+func issue1(g *G, itest int) {
+	attrs := Attributes{
+		"id":                  "user-employee-123456789",
+		"loggedIn":            true,
+		"employee":            true,
+		"country":             "france",
+		"dietaryRestrictions": []string{"gluten_free"},
+	}
+
+	features := ParseFeatureMap([]byte(issue1FeaturesJson))
+
+	context := NewContext().
+		WithFeatures(features).
+		WithAttributes(attrs)
+
+	gb := New(context)
+
+	value := gb.Feature("meal_overrides_gluten_free").Value
+
+	expectedValue := map[string]interface{}{
+		"meal_type": "gf",
+		"dessert":   "French Vanilla Ice Cream",
+	}
+	g.Assert(value).Equal(expectedValue)
+}

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package growthbook
 import (
 	"hash/fnv"
 	"net/url"
+	"reflect"
 	"strconv"
 )
 
@@ -144,4 +145,24 @@ func truthy(v interface{}) bool {
 		return v.(float64) != 0
 	}
 	return true
+}
+
+// This function converts slices of concrete types to []interface{}.
+// This is needed to handle the common case where a user passes an
+// attribute as a []string (or []int), and this needs to be compared
+// against feature data deserialized from JSON, which always results
+// in []interface{} slices.
+func fixSliceTypes(vin interface{}) interface{} {
+	// Convert all type-specific slices to interface{} slices.
+	v := reflect.ValueOf(vin)
+	rv := vin
+	if v.Kind() == reflect.Slice {
+		srv := make([]interface{}, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			elem := v.Index(i).Interface()
+			srv[i] = elem
+		}
+		rv = srv
+	}
+	return rv
 }


### PR DESCRIPTION
### Features and Changes

In #1, @tinahollygb reported a problem arising from a Go demonstration program that appeared to originate in an incorrect implementation of the `$elemMatch` condition operator. In fact, the problem arose because of Go's handling of equality between different types of array-like values.

Normally, when arrays are deserialized from JSON, they are represented as values of `[]interface{}`. This is what I had been assuming would be the case everywhere in the attribute and feature representations in the SDK. However, it's obviously possible to create attributes (or less likely, features) programmatically with different types, for instance `[]string`, `[1]string`, and so on. Go considers all of those types to be different, so comparisons between them do not work.

Generally speaking, Go arrays (e.g. `[1]string`) shouldn't be used for passing values around, since they aren't reference types. Slice types should be used in all such cases (e.g. `[]string`). (See [here](https://go.dev/blog/slices-intro) for a description of the relationship between arrays and slices in Go.)

So I think that it's reasonable to disallow passing _arrays_ as attribute values. However, it _should_ be possible to pass a `[]string` value as an attribute, i.e. we shouldn't be requiring users to pass `[]interface{}` values everywhere.

**The changes in this PR modify the `WithAttributes` method of the `Context` type to convert all monomorphic slices to `[]interface{}`, and to disallow all array values.**

In practical terms, this means that line 28 in the demo code [here](https://github.com/growthbook/examples/pull/33/files) should read:

```
        "dietaryRestrictions": []string{"gluten_free"},
```
using a slice instead of an array. With the changes in this PR, the condition handling described in #1 works as required.

You can see exactly how this works in the `issue1` function in the `regression_test.go` file.

- Closes #1 

### Testing

These changes include a test case that matches the problem reported in the issue, apart from the one detail (arrays vs. slices) described above. This test case (defined in a new `regressions_test.go` file intended for regression tests for issues) runs as part of the normal test suite.
