### PR TITLE
Allow arrays in attributes; avoid nil context values

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,14 +3,12 @@ package growthbook
 import (
 	"encoding/json"
 	"net/url"
-	"reflect"
 )
 
 // Context contains the options for creating a new GrowthBook
 // instance.
 type Context struct {
 	Enabled          bool
-	Valid            bool
 	Attributes       Attributes
 	URL              *url.URL
 	Features         FeatureMap
@@ -30,7 +28,7 @@ type ExperimentCallback func(experiment *Experiment, result *ExperimentResult)
 // NewContext creates a context with default settings: enabled, but
 // all other fields empty.
 func NewContext() *Context {
-	return &Context{Enabled: true, Valid: true}
+	return &Context{Enabled: true}
 }
 
 // WithEnabled sets the enabled flag for a context.
@@ -43,12 +41,6 @@ func (ctx *Context) WithEnabled(enabled bool) *Context {
 func (ctx *Context) WithAttributes(attributes Attributes) *Context {
 	savedAttributes := Attributes{}
 	for k, v := range attributes {
-		// Skip attributes that are arrays: not allowed.
-		if reflect.ValueOf(v).Kind() == reflect.Array {
-			ctx.Valid = false
-			logError(ErrCtxArrayInAttributes, k)
-			continue
-		}
 		savedAttributes[k] = fixSliceTypes(v)
 	}
 	ctx.Attributes = savedAttributes

--- a/growthbook.go
+++ b/growthbook.go
@@ -20,9 +20,6 @@ type GrowthBook struct {
 
 // New created a new GrowthBook instance.
 func New(context *Context) *GrowthBook {
-	if !context.Valid {
-		return nil
-	}
 	return &GrowthBook{
 		context,
 		map[string]bool{},

--- a/regression_test.go
+++ b/regression_test.go
@@ -130,7 +130,7 @@ func issue1(g *G, itest int) {
 		"loggedIn":            true,
 		"employee":            true,
 		"country":             "france",
-		"dietaryRestrictions": []string{"gluten_free"},
+		"dietaryRestrictions": [1]string{"gluten_free"},
 	}
 
 	features := ParseFeatureMap([]byte(issue1FeaturesJson))

--- a/regression_test.go
+++ b/regression_test.go
@@ -7,16 +7,17 @@ import (
 	. "github.com/franela/goblin"
 )
 
-var regressionTests = []func(g *G, itest int){
-	issue1, // https://github.com/growthbook/growthbook-golang/issues/1
+var regressionTests = map[int]func(g *G){
+	1: issue1, // https://github.com/growthbook/growthbook-golang/issues/1
+	5: issue5, // https://github.com/growthbook/growthbook-golang/issues/5
 }
 
 func TestRegressions(t *testing.T) {
 	g := Goblin(t)
-	g.Describe("regressions", func() {
+	g.Describe("regression tests", func() {
 		for itest, test := range regressionTests {
-			g.It(fmt.Sprintf("issue #%d", itest+1), func() {
-				test(g, itest+1)
+			g.It(fmt.Sprintf("issue #%d", itest), func() {
+				test(g)
 			})
 		}
 	})
@@ -119,20 +120,7 @@ const issue1ContextJson = `{
 
 const issue1ExpectedJson = `{ "meal_type": "gf", "dessert": "French Vanilla Ice Cream" }`
 
-type MealOverrides struct {
-	MealType string `json:"meal_type"`
-	Dessert  string `json:"dessert"`
-}
-
-func issue1(g *G, itest int) {
-	attrs := Attributes{
-		"id":                  "user-employee-123456789",
-		"loggedIn":            true,
-		"employee":            true,
-		"country":             "france",
-		"dietaryRestrictions": [1]string{"gluten_free"},
-	}
-
+func issue1Like(g *G, attrs Attributes) {
 	features := ParseFeatureMap([]byte(issue1FeaturesJson))
 
 	context := NewContext().
@@ -148,4 +136,30 @@ func issue1(g *G, itest int) {
 		"dessert":   "French Vanilla Ice Cream",
 	}
 	g.Assert(value).Equal(expectedValue)
+}
+
+func issue1(g *G) {
+	// Check with slice value for attribute.
+	attrs := Attributes{
+		"id":                  "user-employee-123456789",
+		"loggedIn":            true,
+		"employee":            true,
+		"country":             "france",
+		"dietaryRestrictions": []string{"gluten_free"},
+	}
+
+	issue1Like(g, attrs)
+}
+
+func issue5(g *G) {
+	// Check with array value for attribute.
+	attrs := Attributes{
+		"id":                  "user-employee-123456789",
+		"loggedIn":            true,
+		"employee":            true,
+		"country":             "france",
+		"dietaryRestrictions": [1]string{"gluten_free"},
+	}
+
+	issue1Like(g, attrs)
 }

--- a/util.go
+++ b/util.go
@@ -156,7 +156,7 @@ func fixSliceTypes(vin interface{}) interface{} {
 	// Convert all type-specific slices to interface{} slices.
 	v := reflect.ValueOf(vin)
 	rv := vin
-	if v.Kind() == reflect.Slice {
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
 		srv := make([]interface{}, v.Len())
 		for i := 0; i < v.Len(); i++ {
 			elem := v.Index(i).Interface()


### PR DESCRIPTION
### Features and Changes

- Small change to allow arrays as values in attributes.
- This also prevents the generation of nil `GrowthBook` values, since it's no longer possible to introduce an invalid context.

- Closes #5

### Testing

Included tests that use both a slice and an array for attribute values to check that the internal conversion to `[]interface{}` works in both cases.
