### PR TITLE
Fix all JSON tests from v0.2.3 test spec

### DIFF
--- a/json.go
+++ b/json.go
@@ -15,13 +15,8 @@ func BuildExperimentResult(dict map[string]interface{}) *ExperimentResult {
 	res := ExperimentResult{}
 	for k, v := range dict {
 		switch k {
-		case "inExperiment":
-			tmp, ok := v.(bool)
-			if !ok {
-				logError(ErrJSONInvalidType, "ExperimentResult", "inExperiment")
-				continue
-			}
-			res.InExperiment = tmp
+		case "value":
+			res.Value = v
 		case "variationId":
 			tmp, ok := v.(float64)
 			if !ok {
@@ -29,8 +24,20 @@ func BuildExperimentResult(dict map[string]interface{}) *ExperimentResult {
 				continue
 			}
 			res.VariationID = int(tmp)
-		case "value":
-			res.Value = v
+		case "inExperiment":
+			tmp, ok := v.(bool)
+			if !ok {
+				logError(ErrJSONInvalidType, "ExperimentResult", "inExperiment")
+				continue
+			}
+			res.InExperiment = tmp
+		case "hashUsed":
+			tmp, ok := v.(bool)
+			if !ok {
+				logError(ErrJSONInvalidType, "ExperimentResult", "hashUsed")
+				continue
+			}
+			res.HashUsed = tmp
 		case "hashAttribute":
 			tmp, ok := v.(string)
 			if !ok {
@@ -45,6 +52,13 @@ func BuildExperimentResult(dict map[string]interface{}) *ExperimentResult {
 				continue
 			}
 			res.HashValue = tmp
+		case "featureId":
+			tmp, ok := v.(string)
+			if !ok {
+				logError(ErrJSONInvalidType, "ExperimentResult", "featureId")
+				continue
+			}
+			res.FeatureID = &tmp
 		default:
 			logWarn(WarnJSONUnknownKey, "ExperimentResult", k)
 		}

--- a/types.go
+++ b/types.go
@@ -60,11 +60,13 @@ type FeatureResult struct {
 // ExperimentResult records the result of running an Experiment given
 // a specific Context.
 type ExperimentResult struct {
-	InExperiment  bool
-	VariationID   int
 	Value         FeatureValue
+	VariationID   int
+	InExperiment  bool
+	HashUsed      bool
 	HashAttribute string
 	HashValue     string
+	FeatureID     *string
 }
 
 // FeatureRule overrides the default value of a Feature.


### PR DESCRIPTION
### Features and Changes

- The first batch of changes are about including the `UsedHash` and `FeatureID` fields in the `ExperimentResult` type — these were both new things in version 0.2.3 compared to before.

*More to come here*

- Closes #7

### Testing

All of these changes are to accompany tests driven by the JSON test spec.
