### PR TITLE
Enable access to last feature update time

### DIFF
--- a/feature_api_response_test.go
+++ b/feature_api_response_test.go
@@ -1,0 +1,115 @@
+package growthbook
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+const jsonData = `{
+  "status": 200,
+  "features": {
+    "banner_text": {
+      "defaultValue": "Welcome to Acme Donuts!",
+      "rules": [
+        {
+          "condition": {
+            "country": "france"
+          },
+          "force": "Bienvenue au Beignets Acme !"
+        },
+        {
+          "condition": {
+            "country": "spain"
+          },
+          "force": "¡Bienvenidos y bienvenidas a Donas Acme!"
+        }
+      ]
+    },
+    "dark_mode": {
+      "defaultValue": false,
+      "rules": [
+        {
+          "condition": {
+            "loggedIn": true
+          },
+          "force": true,
+          "coverage": 0.5,
+          "hashAttribute": "id"
+        }
+      ]
+    },
+    "donut_price": {
+      "defaultValue": 2.5,
+      "rules": [
+        {
+          "condition": {
+            "employee": true
+          },
+          "force": 0
+        }
+      ]
+    },
+    "meal_overrides_gluten_free": {
+      "defaultValue": {
+        "meal_type": "standard",
+        "dessert": "Strawberry Cheesecake"
+      },
+      "rules": [
+        {
+          "condition": {
+            "dietaryRestrictions": {
+              "$elemMatch": {
+                "$eq": "gluten_free"
+              }
+            }
+          },
+          "force": {
+            "meal_type": "gf",
+            "dessert": "French Vanilla Ice Cream"
+          }
+        }
+      ]
+    },
+    "app_name": {
+      "defaultValue": "(unknown)",
+      "rules": [
+        {
+          "condition": {
+            "version": {
+              "$vgte": "1.0.0",
+              "$vlt": "2.0.0"
+            }
+          },
+          "force": "Albatross"
+        },
+        {
+          "condition": {
+            "version": {
+              "$vgte": "2.0.0",
+              "$vlt": "3.0.0"
+            }
+          },
+          "force": "Badger"
+        },
+        {
+          "condition": {
+            "version": {
+              "$vgte": "3.0.0",
+              "$vlt": "4.0.0"
+            }
+          },
+          "force": "Capybara"
+        }
+      ]
+    }
+  },
+  "dateUpdated": "2023-06-27T18:10:13.378Z"
+}`
+
+func TestAPIResponseParsing(t *testing.T) {
+	apiResponse := FeatureAPIResponse{}
+	err := json.Unmarshal([]byte(jsonData), &apiResponse)
+	if err != nil {
+		t.Errorf("failed to parse API response data")
+	}
+}

--- a/feature_repository_test.go
+++ b/feature_repository_test.go
@@ -80,6 +80,7 @@ func setupWithDelay(provideSSE bool, delay time.Duration, encryptedFeatures stri
 			}
 			response := &FeatureAPIResponse{
 				Features:          features,
+				DateUpdated:       time.Now(),
 				EncryptedFeatures: encryptedFeatures,
 			}
 
@@ -530,7 +531,9 @@ func TestRepoComplexSSEScenario(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		ok := rand.Intn(100) < 90
 		if ok && bad == 0 {
-			featuresJson := fmt.Sprintf(`{"features": {"foo": {"defaultValue": "val%d"}}}`, i+1)
+			featuresJson := fmt.Sprintf(
+				`{"features": {"foo": {"defaultValue": "val%d"}}, "dateUpdated": "%s"}`,
+				i+1, time.Now().Format(dateLayout))
 			commands[i] = command{i + 1, time.Now()}
 			env.sseServer.Publish("features", &sse.Event{Data: []byte(featuresJson)})
 		} else {
@@ -594,7 +597,7 @@ func TestRepoComplexSSEScenario(t *testing.T) {
 			if v.result != expected && v.result != before && v.result != after {
 				errors++
 				t.Error("unexpected feature value")
-				fmt.Println(v.result, v.t, cmdidx, cmdidx, beforeidx, afteridx)
+				fmt.Println(v.result, expected, v.t, cmdidx, beforeidx, afteridx)
 			}
 		}
 	}


### PR DESCRIPTION
### Features and Changes

I noticed that the Go example code made use of the last update timestamp returned from the GB API. I wasn't exposing that in the SDK, and it seems like it would be useful. This PR adds a `LatestFeatureUpdate` method to the `GrowthBook` type to retrieve this information. (There were some changes needed to the JSON encoding and decoding of API responses to make this work reliably.)

### Testing

There's a test in `feature_api_response_test.go` to check the encoding/decoding for API responses works correctly.