### PR TITLE
feat: normalize all types before equality check

### DIFF
--- a/conditions.go
+++ b/conditions.go
@@ -543,20 +543,33 @@ func jsEqual(a interface{}, b interface{}) bool {
 		return true
 
 	default:
-		return reflect.DeepEqual(normalizeNumber(a), normalizeNumber(b))
+		return reflect.DeepEqual(normalizeType(a), normalizeType(b))
 	}
 }
 
-func normalizeNumber(a interface{}) interface{} {
+func normalizeType(a interface{}) interface{} {
 	v := reflect.ValueOf(a)
-	if v.CanFloat() {
-		return v.Float()
+
+	for {
+		if kind := v.Kind(); kind == reflect.Pointer || kind == reflect.Interface {
+			v = v.Elem()
+		} else {
+			break
+		}
 	}
-	if v.CanInt() {
+
+	switch v.Kind() {
+	case reflect.Float32, reflect.Float64:
+		return float64(v.Float())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return float64(v.Int())
-	}
-	if v.CanUint() {
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return float64(v.Uint())
+	case reflect.String:
+		return v.String()
+	case reflect.Bool:
+		return v.Bool()
+	default:
+		return a
 	}
-	return a
 }

--- a/conditions_test.go
+++ b/conditions_test.go
@@ -35,3 +35,32 @@ func TestConditionValueIsPresentButFalsy(t *testing.T) {
 		t.Error("2: expected condition evaluation to be false")
 	}
 }
+
+func TestConditionWithCustomTypeValue(t *testing.T) {
+	type CustomString string
+	var value CustomString = "123"
+	condition := ParseCondition([]byte(`{"userId": "123"}`))
+	result := condition.Eval(Attributes{"userId": value})
+	if result != true {
+		t.Error("2: expected condition evaluation to be true")
+	}
+}
+
+func TestConditionWithCustomTypeValuePointer(t *testing.T) {
+	type CustomString string
+	var value CustomString = "123"
+	condition := ParseCondition([]byte(`{"userId": "123"}`))
+	result := condition.Eval(Attributes{"userId": &value})
+	if result != true {
+		t.Error("2: expected condition evaluation to be true")
+	}
+}
+
+func TestConditionWithInterfaceValue(t *testing.T) {
+	var value interface{} = "123"
+	condition := ParseCondition([]byte(`{"userId": "123"}`))
+	result := condition.Eval(Attributes{"userId": &value})
+	if result != true {
+		t.Error("2: expected condition evaluation to be true")
+	}
+}


### PR DESCRIPTION
### Features and Changes

This is my attempt to convert all non-basic types, pointers and interfaces to basic ones. I change normalizeNumber function to normalizeType that firstly gets value under pointer or interface and then tries to convert value to basic type.

- Closes [Issue](https://github.com/growthbook/growthbook-golang/issues/21)

### Testing

Add Attributes with custom types, pointers or interface values. Check if condition passes.
