### PR TITLE
Use SSE client reconnect strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/growthbook/growthbook-golang
 
 go 1.18
 
-require github.com/ian-ross/sse/v2 v2.0.0-20230916152657-420261c3546b
-
 require (
-	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
-	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
+	github.com/ian-ross/sse/v2 v2.0.0-20230916152657-420261c3546b
+	gopkg.in/cenkalti/backoff.v1 v1.1.0
 )
+
+require golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect


### PR DESCRIPTION
### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

This is a fix for reconnections when the remote end disconnects causing goroutine leaks. We discovered it on our production environment because our connections close after 1 min by default.

The problem lies in the call to `c.Unsubscribe(ch)` from inside the `OnDisconnect` handler. This handler is called [just before sending the error that caused the disconnect to the error channel](https://github.com/ian-ross/sse/blob/master/client.go#L213-L222) (erChan). By the time the error is sent to the channel, there is no code waiting to read from it and it gets stuck there. This is because the call to `c.Unsubscribe(ch)` caused [this branch](https://github.com/ian-ross/sse/blob/master/client.go#L165) from the `select` to be taken, and the `<-errorChan` branch never has the chance to read the error that the other goroutine is trying to send to the channel.

The reconnect logic from this lib creates a new SSE Client each time, so this problem repeats indefinitely as long as disconnects keep happening.

I opted for using the `ReconnectStrategy` exposed by the SSE client to fix this.

### Testing

<!--
  Please describe how to test these changes.
 -->
I deployed a version of our app with this patch applied. Before and after metrics:
![image](https://github.com/growthbook/growthbook-golang/assets/11269035/d4b27502-7461-4241-9679-8f6179af2a10)

