### PR TITLE
fix: Let SSE client reconnect after EOF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require github.com/ian-ross/sse/v2 v2.0.0-20230916152657-420261c3546b
 
 require (
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
-	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
+	gopkg.in/cenkalti/backoff.v1 v1.1.0
 )


### PR DESCRIPTION
### Features and Changes

Fixes leaking go routine - `github.com/ian-ross/sse/v2.(*Client).readLoop`
```
119 @ 0x446d76 0x40f00e 0x40ebbd 0x168247e 0x47b3c1
#	0x168247d	github.com/ian-ross/sse/v2.(*Client).readLoop+0x25d

```

Calling `Unsubscribe` in the `OnDisconnect` callback causes the [errorChan](https://github.com/ian-ross/sse/blob/master/client.go#L166) in the patched sse package to never be consumed. Causing [readLoop](https://github.com/ian-ross/sse/blob/master/client.go#L220) go routine to never end.

This allows the sse client to reconnect. A custom `ReconnectStrategy` is used to ensure it reconnects indefinitely.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
