### PR TITLE
Add support for integer types in compare function to resolve Force Value attributes issue

### DIFF
--- a/conditions.go
+++ b/conditions.go
@@ -378,6 +378,44 @@ func compare(comp string, x interface{}, y interface{}) bool {
 		case "$gte":
 			return xs >= ys
 		}
+
+	case int, int32, int64:
+		ys, ok := y.(int64)
+		if !ok {
+			switch y := y.(type) {
+			case int:
+				ys = int64(y)
+			case int32:
+				ys = int64(y)
+			default:
+				logWarn("y is not a comparable numeric type")
+				return false
+			}
+		}
+
+		xs, ok := x.(int64)
+		if !ok {
+			switch x := x.(type) {
+			case int:
+				xs = int64(x)
+			case int32:
+				xs = int64(x)
+			default:
+				logWarn("x is not a comparable numeric type")
+				return false
+			}
+		}
+
+		switch comp {
+		case "$lt":
+			return xs < ys
+		case "$lte":
+			return xs <= ys
+		case "$gt":
+			return xs > ys
+		case "$gte":
+			return xs >= ys
+		}
 	}
 	return false
 }

--- a/conditions_test.go
+++ b/conditions_test.go
@@ -35,3 +35,57 @@ func TestConditionValueIsPresentButFalsy(t *testing.T) {
 		t.Error("2: expected condition evaluation to be false")
 	}
 }
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		comp     string
+		x        interface{}
+		y        interface{}
+		expected bool
+	}{
+		{"$lt", float64(10), float64(20), true},
+		{"$lte", float64(10), float64(10), true},
+		{"$gt", float64(20), float64(10), true},
+		{"$gte", float64(10), float64(10), true},
+		{"$lt", "apple", "banana", true},
+		{"$lte", "apple", "apple", true},
+		{"$gt", "banana", "apple", true},
+		{"$gte", "apple", "apple", true},
+		{"$lt", int(10), int(20), true},
+		{"$lte", int(10), int(10), true},
+		{"$gt", int(20), int(10), true},
+		{"$gte", int(10), int(10), true},
+		{"$lt", int32(10), int32(20), true},
+		{"$lt", int64(10), int64(20), true},
+		{"$lt", float64(20), float64(10), false},
+		{"$lte", float64(20), float64(10), false},
+		{"$gt", float64(10), float64(20), false},
+		{"$gte", float64(10), float64(20), false},
+		{"$lt", int(10), "banana", false},
+		{"$lt", "apple", int64(10), false},
+		{"$lt", float64(10), "banana", false},
+		{"$lt", "banana", "apple", false},
+		{"$lte", "banana", "apple", false},
+		{"$gt", "apple", "banana", false},
+		{"$gte", "apple", "banana", false},
+		{"$lt", int(20), int(10), false},
+		{"$lte", int(20), int(10), false},
+		{"$gt", int(10), int(20), false},
+		{"$gte", int(10), int(20), false},
+		{"$lt", "apple", float64(10), false},
+		{"$lte", "apple", float64(10), false},
+		{"$gt", "apple", float64(10), false},
+		{"$gte", "apple", float64(10), false},
+		{"$lt", "apple", int(10), false},
+		{"$lte", "apple", int(10), false},
+		{"$gt", "apple", int(10), false},
+		{"$gte", "apple", int(10), false},
+	}
+
+	for _, test := range tests {
+		result := compare(test.comp, test.x, test.y)
+		if result != test.expected {
+			t.Errorf("compare(%s, %v, %v) = %v, expected %v", test.comp, test.x, test.y, result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
### Features and Changes

This PR addresses the 'Force Value attributes issue' where the compare function only accepted float64 type data, limiting compatibility with integer attributes in GrowthBook. The function has been enhanced to accept int, int32, and int64 types, aligning with GrowthBook's number attribute specifications (which can be float or integer).

Changes
* Extended compare function to support int, int32, and int64 types
* Added type checking and conversion to ensure safe comparisons across these numeric types
* Enhanced error logging for type mismatches
These updates improve flexibility and ensure the compare function fully supports all numeric attributes in GrowthBook.

### Testing
```
Running tool: /usr/bin/go test -timeout 60s -coverprofile=/tmp/vscode-gomFKWAE/go-code-cover -run ^TestCompare$ github.com/growthbook/growthbook-golang -v

=== RUN   TestCompare
--- PASS: TestCompare (0.00s)
PASS
coverage: 2.1% of statements
ok  	github.com/growthbook/growthbook-golang	0.011s	coverage: 2.1% of statements
```
<!--
  Please describe how to test these changes.
 -->

### Screenshots
![image](https://github.com/user-attachments/assets/7d641c12-31fb-4727-8c10-6bec36e56d88)
![image](https://github.com/user-attachments/assets/221b54a9-4b34-4310-b735-e73aa6cbdf1e)

