### PR TITLE
Fix variation id value out of bounds check causing first variation metadata to be not set on result

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -174,7 +174,7 @@ func (e *evaluator) getExperimentResult(
 	hashAttribute, hashValue := e.getHashAttribute(exp.HashAttribute, "")
 
 	var meta *VariationMeta
-	if variationId > 0 && variationId < len(exp.Meta) {
+	if variationId >= 0 && variationId < len(exp.Meta) {
 		meta = &exp.Meta[variationId]
 	}
 


### PR DESCRIPTION
### Features and Changes

Closes https://github.com/growthbook/growthbook-golang/issues/42

Fixes an issue where variation metadata is missing if variation id is `0`.
In other words, for every experiment evaluation resulting in first variation, the meta data is not set.

It breaks our use case where we report which variation was exposed to a customer using the variation key.

This is caused by erronous slice out of bounds check.

Credit goes to [@tomas](https://github.com/tomasbareikis-home24) for identifying the cause
