### PR TITLE
PoolDataSource - prevent from creating timer multiple times

### DIFF
--- a/datasource_poll.go
+++ b/datasource_poll.go
@@ -61,14 +61,15 @@ func (ds *PollDataSource) Close() error {
 }
 
 func (ds *PollDataSource) startPolling(ctx context.Context) {
+	timer := time.Tick(ds.interval)
+
 	for {
-		timer := time.NewTimer(ds.interval)
 		select {
 		case <-ctx.Done():
 			ds.ready = false
 			ds.logger.Info("Finished polling due to context")
 			return
-		case <-timer.C:
+		case <-timer:
 			err := ds.loadData(ctx)
 			if err != nil {
 				ds.logger.Error("Error loading features", "error", err)


### PR DESCRIPTION
### Features and Changes
Prevent from creating timer instance multiple times


Before the timer was created, every ds.interval caused unnecessary heap allocations.
This PR ensure that timer is created only once