### PR TITLE
allow version to have leading 0

### DIFF
--- a/internal/condition/version_cond.go
+++ b/internal/condition/version_cond.go
@@ -59,7 +59,8 @@ func paddedVersionString(input value.Value) string {
 	for i, p := range parts {
 		isNumber := versionNumRe.MatchString(p)
 		if isNumber && len(p) < 5 {
-			parts[i] = strings.Repeat(" ", 5-len(p)) + p
+			val := strings.TrimLeft(p, "0") // remove leading zeros
+			parts[i] = strings.Repeat(" ", 5-len(val)) + val
 		}
 	}
 	return strings.Join(parts, "-")

--- a/internal/condition/version_cond_test.go
+++ b/internal/condition/version_cond_test.go
@@ -18,6 +18,8 @@ func TestVersionCond(t *testing.T) {
 		{vneOp, "1.2", "1.2.0", true},
 		{vgtOp, "1.2.3", "1.2.3-rc", true},
 		{vgteOp, "1.2.3", "1.2.4", false},
+		{vgteOp, "1.02.3", "1.2.4", false},
+		{veqOp, "1.02.3", "1.2.3", true},
 		{vltOp, "1.2.3-rc", "1.2.3", true},
 		{vlteOp, "1", 1, true},
 	}


### PR DESCRIPTION
### Features and Changes
According to spec
> A normal version number MUST take the form X.Y.Z, where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes

However, in case when semver has a leading zero, it is reasonable that `1.2.3` is the same as `01.02.03`
Adjust code to handle this incorrect version

// If you think it's not worth merging it's ok. Not sure what is the reasuld in  SKDs for other languages

### Testing
Run tests
