### PR TITLE
fix sse without backoff, add WithSseMaxRetryInterval method

### DIFF
--- a/datasource_sse.go
+++ b/datasource_sse.go
@@ -12,28 +12,48 @@ import (
 )
 
 type SseDataSource struct {
-	client *Client
-	cancel context.CancelFunc
-	ready  bool
-	// retry  time.Duration
-	logger *slog.Logger
-	mu     sync.RWMutex
+	client           *Client
+	cancel           context.CancelFunc
+	ready            bool
+	maxRetryInterval time.Duration
+	logger           *slog.Logger
+	mu               sync.RWMutex
+}
+
+// SseOption configures an SseDataSource.
+type SseOption func(*SseDataSource)
+
+// WithSseMaxRetryInterval sets the maximum backoff interval between reconnection
+// attempts. By default the interval grows without bound; setting this caps it
+// (e.g. 30*time.Second).
+func WithSseMaxRetryInterval(d time.Duration) SseOption {
+	return func(ds *SseDataSource) {
+		ds.maxRetryInterval = d
+	}
 }
 
 const minbufsize = 64 * 1024
 const maxbufsize = 10 * 1024 * 1024
 
-func WithSseDataSource() ClientOption {
+// defaultMaxRetryInterval is the default cap for backoff delay between SSE reconnects.
+const defaultMaxRetryInterval = 30 * time.Second
+
+func WithSseDataSource(opts ...SseOption) ClientOption {
 	return func(c *Client) error {
-		c.data.dataSource = newSseDataSource(c)
+		ds := newSseDataSource(c)
+		for _, opt := range opts {
+			opt(ds)
+		}
+		c.data.dataSource = ds
 		return nil
 	}
 }
 
 func newSseDataSource(client *Client) *SseDataSource {
 	return &SseDataSource{
-		client: client,
-		logger: client.logger.With("source", "Growthbook SSE datasource"),
+		client:           client,
+		maxRetryInterval: defaultMaxRetryInterval,
+		logger:           client.logger.With("source", "Growthbook SSE datasource"),
 	}
 }
 
@@ -82,6 +102,9 @@ func (ds *SseDataSource) connect(ctx context.Context) error {
 	sseClient := &sse.Client{
 		HTTPClient: ds.client.data.httpClient,
 		OnRetry:    ds.onRetry(ctx),
+		Backoff: sse.Backoff{
+			MaxInterval: ds.maxRetryInterval,
+		},
 	}
 	sseConn := sseClient.NewConnection(req)
 	buf := make([]byte, minbufsize)


### PR DESCRIPTION
Issue

When creating sse.Client in datasource_sse.go, Backoff was not configured, resulting in a default MaxInterval = 0 (unbounded growth). The backoff sequence follows 500ms → 750ms → 1.1s → ... → several minutes → no limit. Consequently, the retry interval accumulates without an upper bound after a disconnection.

Solution

Added new types and functions:

SseOption func(*SseDataSource) — A functional option type for SSE configuration.
WithSseMaxRetryInterval(d time.Duration) SseOption — Sets the maximum backoff interval.
defaultMaxRetryInterval = 30s — A reasonable default upper limit.
WithSseDataSource signature update (backward compatible):

go

// Old usage remains valid
WithSseDataSource()

// New usage, customizing maximum backoff interval
WithSseDataSource(WithSseMaxRetryInterval(60 * time.Second))
The Backoff.MaxInterval of sse.Client is now correctly set:

go

Backoff: sse.Backoff{
    MaxInterval: ds.maxRetryInterval,  // Defaults to 30s; remaining fields are populated by go-sse mergeDefaults
},
The mergeDefaults in go-sse will fill in the default values for other fields (InitialInterval=500ms, Multiplier=1.5, Jitter=0.5), and MaxInterval will not be overwritten.