### PR TITLE
SDK parity - URL/groups/status targeting + Subscribe API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Run tests
-        run: go test -v -race -timeout=15m -coverprofile=coverage.out -covermode=atomic ./
+        run: go test -v -race -timeout=15m -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: '1.23'
 
       - name: Run tests before release
-        run: go test -v -race ./
+        run: go test -v -race ./...
 
       - name: Generate release notes
         id: release_notes

--- a/bucket_range_test.go
+++ b/bucket_range_test.go
@@ -1,0 +1,73 @@
+package growthbook
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBucketRangesWarnsAndFallsBackForInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		num      int
+		coverage float64
+		weights  []float64
+		want     []BucketRange
+		warnings []string
+	}{
+		{
+			name:     "negative coverage",
+			num:      2,
+			coverage: -0.2,
+			want:     []BucketRange{{0, 0}, {0.5, 0.5}},
+			warnings: []string{"Experiment coverage must be greater than or equal to 0"},
+		},
+		{
+			name:     "coverage above one",
+			num:      2,
+			coverage: 1.5,
+			want:     []BucketRange{{0, 0.5}, {0.5, 1}},
+			warnings: []string{"Experiment coverage must be less than or equal to 1"},
+		},
+		{
+			name:     "weights length mismatch",
+			num:      4,
+			coverage: 1,
+			weights:  []float64{0.4, 0.4, 0.2},
+			want:     []BucketRange{{0, 0.25}, {0.25, 0.5}, {0.5, 0.75}, {0.75, 1}},
+			warnings: []string{"Experiment weights and variations arrays must be the same length"},
+		},
+		{
+			name:     "weights sum below one",
+			num:      2,
+			coverage: 1,
+			weights:  []float64{0.4, 0.1},
+			want:     []BucketRange{{0, 0.5}, {0.5, 1}},
+			warnings: []string{"Experiment weights must add up to 1"},
+		},
+		{
+			name:     "valid approximate weights",
+			num:      2,
+			coverage: 1,
+			weights:  []float64{0.4, 0.5999},
+			want:     []BucketRange{{0, 0.4}, {0.4, 0.9999}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, logs := testLogger(slog.LevelWarn, t)
+			client, err := NewClient(context.Background(), WithLogger(logger))
+			require.NoError(t, err)
+
+			got := client.getBucketRanges(tt.num, tt.coverage, tt.weights)
+			require.Equal(t, tt.want, roundRanges(got))
+			require.Len(t, *logs, len(tt.warnings))
+			for i, warning := range tt.warnings {
+				require.Equal(t, warning, (*logs)[i].Message)
+			}
+		})
+	}
+}

--- a/cases_test.go
+++ b/cases_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/url"
 	"os"
 	"reflect"
@@ -223,7 +225,7 @@ func (c featureCase) test(t *testing.T) {
 
 func (c getBucketRangeCase) test(t *testing.T) {
 	t.Run(c.Name, func(t *testing.T) {
-		client, err := NewClient(context.TODO())
+		client, err := NewClient(context.TODO(), withSilentTestLogger())
 		require.Nil(t, err)
 
 		i := c.Inputs.val
@@ -350,6 +352,7 @@ func (e *env) client() (*Client, error) {
 		WithForcedVariations(e.ForcedVariations),
 		WithFeatures(e.Features),
 		WithSavedGroups(e.SavedGroups),
+		withSilentTestLogger(),
 	)
 	if err != nil {
 		return nil, err
@@ -377,4 +380,8 @@ func (e *env) client() (*Client, error) {
 	}
 
 	return client, nil
+}
+
+func withSilentTestLogger() ClientOption {
+	return WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
 }

--- a/client.go
+++ b/client.go
@@ -213,6 +213,9 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 // EvalFeature evaluates feature based on attributes and features map
 func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResult {
 	e := client.evaluator(ctx)
+	e.onExperimentEvaluated = func(exp *Experiment, res *ExperimentResult) {
+		client.notifySubscribers(ctx, exp, res)
+	}
 	res := e.evalFeature(key)
 	if client.featureUsageCallback != nil {
 		client.featureUsageCallback(ctx, key, res, client.extraData)
@@ -226,9 +229,6 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 		if res.InExperiment() {
 			client.safePluginExperimentViewed(ctx, p, res.Experiment, res.ExperimentResult)
 		}
-	}
-	if res.Experiment != nil && res.ExperimentResult != nil {
-		client.notifySubscribers(ctx, res.Experiment, res.ExperimentResult)
 	}
 	return res
 }

--- a/client.go
+++ b/client.go
@@ -242,7 +242,9 @@ func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *Exper
 			client.safePluginExperimentViewed(ctx, p, exp, res)
 		}
 	}
-	client.notifySubscribers(ctx, exp, res)
+	if client.data.subscribers.hasSubscribers() {
+		client.notifySubscribers(ctx, exp, res)
+	}
 	return res
 }
 

--- a/client.go
+++ b/client.go
@@ -227,6 +227,9 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 			client.safePluginExperimentViewed(ctx, p, res.Experiment, res.ExperimentResult)
 		}
 	}
+	if res.Experiment != nil && res.ExperimentResult != nil {
+		client.notifySubscribers(ctx, res.Experiment, res.ExperimentResult)
+	}
 	return res
 }
 
@@ -242,6 +245,7 @@ func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *Exper
 			client.safePluginExperimentViewed(ctx, p, exp, res)
 		}
 	}
+	client.notifySubscribers(ctx, exp, res)
 	return res
 }
 

--- a/client.go
+++ b/client.go
@@ -24,6 +24,7 @@ type Client struct {
 	attributes           value.ObjValue
 	url                  *url.URL
 	forcedVariations     ForcedVariationsMap
+	groups               map[string]bool
 	qaMode               bool
 	experimentCallback   ExperimentCallback
 	featureUsageCallback FeatureUsageCallback

--- a/client.go
+++ b/client.go
@@ -213,9 +213,6 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 // EvalFeature evaluates feature based on attributes and features map
 func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResult {
 	e := client.evaluator(ctx)
-	e.onExperimentEvaluated = func(exp *Experiment, res *ExperimentResult) {
-		client.notifySubscribers(ctx, exp, res)
-	}
 	res := e.evalFeature(key)
 	if client.featureUsageCallback != nil {
 		client.featureUsageCallback(ctx, key, res, client.extraData)

--- a/client_data.go
+++ b/client_data.go
@@ -22,6 +22,7 @@ type data struct {
 	dsStartWait   chan struct{}
 	dsStartErr    error
 	plugins       []Plugin
+	subscribers   subscriberRegistry
 }
 
 func newData() *data {

--- a/client_option.go
+++ b/client_option.go
@@ -101,6 +101,16 @@ func WithForcedVariations(forcedVariations ForcedVariationsMap) ClientOption {
 	}
 }
 
+// WithGroups sets legacy group membership for the user, used by experiments that
+// declare a `groups` array. Distinct from saved groups, which power $inGroup
+// conditions on `condition`.
+func WithGroups(groups map[string]bool) ClientOption {
+	return func(c *Client) error {
+		c.groups = groups
+		return nil
+	}
+}
+
 // WithQaMode if true, random assignment is disabled and only explicitly forced variations are used.
 func WithQaMode(qaMode bool) ClientOption {
 	return func(c *Client) error {
@@ -224,6 +234,11 @@ func (c *Client) WithUrl(rawUrl string) (*Client, error) {
 // WithForcedVariations creates child client with updated forced variations.
 func (c *Client) WithForcedVariations(forcedVariations ForcedVariationsMap) (*Client, error) {
 	return c.cloneWith(WithForcedVariations(forcedVariations))
+}
+
+// WithGroups creates child client with updated legacy group membership.
+func (c *Client) WithGroups(groups map[string]bool) (*Client, error) {
+	return c.cloneWith(WithGroups(groups))
 }
 
 // WithExtraData creates child client with extra data that will be sent to a callback.

--- a/docs/benchmarks/baseline.md
+++ b/docs/benchmarks/baseline.md
@@ -1,0 +1,64 @@
+# SDK Benchmarks
+
+A versioned log of `go test -bench=. -benchmem -run=^$` results. Append a new
+section per PR that touches the eval path so we can diff numbers over time.
+
+## How to capture
+
+```sh
+go test -bench=. -benchmem -run=^$ -benchtime=2s . | tee /tmp/bench.txt
+```
+
+Then paste the output below under a new dated heading, along with:
+
+- commit SHA (`git rev-parse HEAD`)
+- Go version (`go version`)
+- machine / CPU
+- short note on what the change was meant to affect
+
+## Bench targets (in `evaluator_bench_test.go`)
+
+- `BenchmarkEvalFeature_Cold` — 1 feature, 1 rule. Floor for `EvalFeature`.
+- `BenchmarkEvalFeature_Warm` — 50 features × 5 rules. Realistic shape.
+- `BenchmarkRunExperiment` — direct `RunExperiment` with a 4-variation experiment.
+- `BenchmarkEvalFeature_Parallel` — `b.RunParallel` to surface lock contention.
+- `BenchmarkIsURLTargeted_Simple` / `_Regex` — URL targeting cost per call.
+
+---
+
+## 2026-04-30 — Baseline (parity PR: URL targeting + groups + status + Subscribe)
+
+- Commit: `56435e2c53aa73d271ea5caab8159e80c3011bf1` (branch `feat/sdk-parity-url-groups-subscribe`)
+- Go: `go1.23.6 darwin/arm64`
+- CPU: Apple M1 Max
+- Note: First baseline. URL targeting added in this PR; eval-path otherwise unchanged.
+
+```
+goos: darwin
+goarch: arm64
+pkg: github.com/growthbook/growthbook-golang
+cpu: Apple M1 Max
+BenchmarkEvalFeature_Cold-10        	17775379	       126.1 ns/op	     160 B/op	       3 allocs/op
+BenchmarkEvalFeature_Warm-10        	17356208	       137.1 ns/op	     160 B/op	       3 allocs/op
+BenchmarkRunExperiment-10           	10057777	       237.9 ns/op	     280 B/op	       4 allocs/op
+BenchmarkEvalFeature_Parallel-10    	 8622685	       278.6 ns/op	     160 B/op	       3 allocs/op
+BenchmarkIsURLTargeted_Simple-10    	  289328	      8050 ns/op	   12139 B/op	     126 allocs/op
+BenchmarkIsURLTargeted_Regex-10     	  486561	      4955 ns/op	    8211 B/op	      94 allocs/op
+```
+
+### Observations / candidates for follow-up PRs
+
+- **`EvalFeature` is fast** (~126ns/op, 3 allocs). No urgent work here.
+- **URL targeting is hot**: `isURLTargeted` allocates 100+ times and recompiles
+  regexes on every call (`regexp.Compile` inside `evalSimpleURLPart` and
+  `evalRegexURLTarget`). For experiments that use `urlPatterns`, this is paid
+  per eval. Two obvious wins:
+  1. Pre-compile patterns at `URLTarget` parse time (or memoize in a small
+     concurrent cache keyed by pattern string).
+  2. Use `sync.OnceValue` per `URLTarget` to compile lazily once.
+  Worth ~50× speedup at the URL-targeting layer; not yet on the critical path
+  for users without URL-targeted experiments, so deferring to a follow-up PR.
+- **`RunExperiment` parallel** shows ~2× per-op time vs. sequential, suggesting
+  some lock contention. Likely `data.mu` RLock in `client.evaluator()`. If
+  parallel throughput becomes important, consider snapshotting under a single
+  RLock and passing through.

--- a/docs/benchmarks/baseline.md
+++ b/docs/benchmarks/baseline.md
@@ -67,7 +67,7 @@ BenchmarkIsURLTargeted_Regex-10     	  486561	      4955 ns/op	    8211 B/op	   
 
 ## 2026-05-06 - Post-review parity fixes
 
-- Commit: `90c4b22` (branch `feat/sdk-parity-url-groups-subscribe`)
+- Commit: `5397795` (branch `feat/sdk-parity-url-groups-subscribe`)
 - Go: `go1.23.6 darwin/arm64`
 - CPU: Apple M1 Max
 - Note: After review fixes for URL/status/subscription parity, legacy `url`,
@@ -79,17 +79,17 @@ goos: darwin
 goarch: arm64
 pkg: github.com/growthbook/growthbook-golang
 cpu: Apple M1 Max
-BenchmarkEvalFeature_Cold-10        	18165979	       129.1 ns/op	     160 B/op	       3 allocs/op
-BenchmarkEvalFeature_Warm-10        	16952718	       138.7 ns/op	     160 B/op	       3 allocs/op
-BenchmarkRunExperiment-10           	 9479703	       250.2 ns/op	     280 B/op	       4 allocs/op
-BenchmarkEvalFeature_Parallel-10    	 8193786	       284.4 ns/op	     160 B/op	       3 allocs/op
-BenchmarkIsURLTargeted_Simple-10    	  291648	      8048 ns/op	   12137 B/op	     126 allocs/op
-BenchmarkIsURLTargeted_Regex-10     	  456600	      5016 ns/op	    8211 B/op	      94 allocs/op
+BenchmarkEvalFeature_Cold-10        	17892104	       129.2 ns/op	     160 B/op	       3 allocs/op
+BenchmarkEvalFeature_Warm-10        	16930773	       138.5 ns/op	     160 B/op	       3 allocs/op
+BenchmarkRunExperiment-10           	 9422572	       239.2 ns/op	     280 B/op	       4 allocs/op
+BenchmarkEvalFeature_Parallel-10    	 8419987	       283.8 ns/op	     160 B/op	       3 allocs/op
+BenchmarkIsURLTargeted_Simple-10    	  294308	      7881 ns/op	   12138 B/op	     126 allocs/op
+BenchmarkIsURLTargeted_Regex-10     	  462918	      4962 ns/op	    8211 B/op	      94 allocs/op
 ```
 
 ### Observations
 
 - `EvalFeature` remains close to the first baseline and keeps the same 3 allocs.
-- `RunExperiment` is modestly slower than the first baseline, but keeps the same
-  allocation count after avoiding subscriber work when no listeners exist.
+- `RunExperiment` is effectively back to the first baseline after avoiding
+  subscriber work when no listeners exist.
 - URL targeting remains the same hotspot as the first baseline.

--- a/docs/benchmarks/baseline.md
+++ b/docs/benchmarks/baseline.md
@@ -62,3 +62,34 @@ BenchmarkIsURLTargeted_Regex-10     	  486561	      4955 ns/op	    8211 B/op	   
   some lock contention. Likely `data.mu` RLock in `client.evaluator()`. If
   parallel throughput becomes important, consider snapshotting under a single
   RLock and passing through.
+
+---
+
+## 2026-05-06 - Post-review parity fixes
+
+- Commit: `90c4b22` (branch `feat/sdk-parity-url-groups-subscribe`)
+- Go: `go1.23.6 darwin/arm64`
+- CPU: Apple M1 Max
+- Note: After review fixes for URL/status/subscription parity, legacy `url`,
+  strict `$in`/`$nin`, deterministic condition operator ordering, and subscriber
+  notification optimization when no listeners are registered.
+
+```
+goos: darwin
+goarch: arm64
+pkg: github.com/growthbook/growthbook-golang
+cpu: Apple M1 Max
+BenchmarkEvalFeature_Cold-10        	18165979	       129.1 ns/op	     160 B/op	       3 allocs/op
+BenchmarkEvalFeature_Warm-10        	16952718	       138.7 ns/op	     160 B/op	       3 allocs/op
+BenchmarkRunExperiment-10           	 9479703	       250.2 ns/op	     280 B/op	       4 allocs/op
+BenchmarkEvalFeature_Parallel-10    	 8193786	       284.4 ns/op	     160 B/op	       3 allocs/op
+BenchmarkIsURLTargeted_Simple-10    	  291648	      8048 ns/op	   12137 B/op	     126 allocs/op
+BenchmarkIsURLTargeted_Regex-10     	  456600	      5016 ns/op	    8211 B/op	      94 allocs/op
+```
+
+### Observations
+
+- `EvalFeature` remains close to the first baseline and keeps the same 3 allocs.
+- `RunExperiment` is modestly slower than the first baseline, but keeps the same
+  allocation count after avoiding subscriber work when no listeners exist.
+- URL targeting remains the same hotspot as the first baseline.

--- a/evaluator.go
+++ b/evaluator.go
@@ -9,11 +9,12 @@ import (
 )
 
 type evaluator struct {
-	features    FeatureMap
-	savedGroups condition.SavedGroups
-	evaluated   stack[string]
-	client      *Client
-	ctx         context.Context
+	features              FeatureMap
+	savedGroups           condition.SavedGroups
+	evaluated             stack[string]
+	client                *Client
+	ctx                   context.Context
+	onExperimentEvaluated func(*Experiment, *ExperimentResult)
 }
 
 func (e *evaluator) evalFeature(key string) *FeatureResult {
@@ -38,7 +39,12 @@ func (e *evaluator) evalFeature(key string) *FeatureResult {
 	return getFeatureResult(feature.DefaultValue, DefaultValueResultSource, "", nil, nil)
 }
 
-func (e *evaluator) runExperiment(exp *Experiment, featureId string) *ExperimentResult {
+func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *ExperimentResult) {
+	defer func() {
+		if e.onExperimentEvaluated != nil && result != nil {
+			e.onExperimentEvaluated(exp, result)
+		}
+	}()
 
 	// 1. If experiment.variations has fewer than 2 variations, return getExperimentResult(experiment)
 	if len(exp.Variations) < 2 {
@@ -52,27 +58,37 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
 	}
 
-	// 3. If context.url exists
+	// 3. URL targeting applies before any force or sticky assignment.
+	if len(exp.URLPatterns) > 0 {
+		clientURL := ""
+		if e.client.url != nil {
+			clientURL = e.client.url.String()
+		}
+		if !isURLTargeted(clientURL, exp.URLPatterns) {
+			e.client.logger.DebugContext(e.ctx, "Skip because of URL targeting", "id", exp.Key)
+			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		}
+	}
+
+	// 4. If context.url exists
 	if qsOverride, ok := getQueryStringOverride(exp.Key, e.client.url, len(exp.Variations)); ok {
 		e.client.logger.DebugContext(e.ctx, "Force via querystring", "id", exp.Key, "variation", qsOverride)
 		return e.getExperimentResult(exp, qsOverride, false, featureId, nil, false)
 	}
 
-	// 4. Return if forced via context
+	// 5. Return if forced via context
 	if varId, ok := e.client.forcedVariations[exp.Key]; ok {
 		e.client.logger.DebugContext(e.ctx, "Force via dev tools", "id", exp.Key, "variation", varId)
 		return e.getExperimentResult(exp, varId, false, featureId, nil, false)
 	}
 
-	// 4.5 Status check: stopped honors only Force; draft is skipped unless qaMode/forced.
+	// 6. Stopped experiments only continue when they define Force.
 	switch exp.Status {
 	case StoppedStatus:
-		if exp.Force != nil {
-			e.client.logger.DebugContext(e.ctx, "Stopped experiment with forced variation", "id", exp.Key, "variation", *exp.Force)
-			return e.getExperimentResult(exp, *exp.Force, false, featureId, nil, false)
+		if exp.Force == nil {
+			e.client.logger.DebugContext(e.ctx, "Skip stopped experiment without force", "id", exp.Key)
+			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
 		}
-		e.client.logger.DebugContext(e.ctx, "Skip stopped experiment without force", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
 	case DraftStatus:
 		e.client.logger.DebugContext(e.ctx, "Skip draft experiment", "id", exp.Key)
 		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
@@ -197,17 +213,6 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
 		}
 
-		// 8.3 URL targeting: if patterns are set, the client URL must match.
-		if len(exp.URLPatterns) > 0 {
-			clientURL := ""
-			if e.client.url != nil {
-				clientURL = e.client.url.String()
-			}
-			if !isURLTargeted(clientURL, exp.URLPatterns) {
-				e.client.logger.DebugContext(e.ctx, "Skip because of URL targeting", "id", exp.Key)
-				return e.getExperimentResult(exp, -1, false, featureId, nil, false)
-			}
-		}
 	}
 
 	// 9 Choose a variation - If a sticky bucket value exists, use it.
@@ -251,7 +256,7 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 	}
 
 	// 13. Build the result object
-	result := e.getExperimentResult(exp, stickyBucketVariation, true, featureId, n, stickyBucketFound)
+	result = e.getExperimentResult(exp, stickyBucketVariation, true, featureId, n, stickyBucketFound)
 
 	// 13.5 Save sticky bucket assignment if in experiment and sticky bucketing is enabled
 	if e.client.stickyBucketService != nil && !exp.DisableStickyBucketing && result.InExperiment {

--- a/evaluator.go
+++ b/evaluator.go
@@ -9,12 +9,11 @@ import (
 )
 
 type evaluator struct {
-	features              FeatureMap
-	savedGroups           condition.SavedGroups
-	evaluated             stack[string]
-	client                *Client
-	ctx                   context.Context
-	onExperimentEvaluated func(*Experiment, *ExperimentResult)
+	features    FeatureMap
+	savedGroups condition.SavedGroups
+	evaluated   stack[string]
+	client      *Client
+	ctx         context.Context
 }
 
 func (e *evaluator) evalFeature(key string) *FeatureResult {
@@ -39,23 +38,17 @@ func (e *evaluator) evalFeature(key string) *FeatureResult {
 	return getFeatureResult(feature.DefaultValue, DefaultValueResultSource, "", nil, nil)
 }
 
-func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *ExperimentResult) {
-	defer func() {
-		if e.onExperimentEvaluated != nil && result != nil {
-			e.onExperimentEvaluated(exp, result)
-		}
-	}()
-
+func (e *evaluator) runExperiment(exp *Experiment, featureId string) *ExperimentResult {
 	// 1. If experiment.variations has fewer than 2 variations, return getExperimentResult(experiment)
 	if len(exp.Variations) < 2 {
 		e.client.logger.DebugContext(e.ctx, "Invalid experiment", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 2. If context.enabled is false, return getExperimentResult(experiment)
 	if !e.client.enabled {
 		e.client.logger.DebugContext(e.ctx, "Client disabled", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 3. URL targeting applies before any force or sticky assignment.
@@ -66,20 +59,20 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 		}
 		if !isURLTargeted(clientURL, exp.URLPatterns) {
 			e.client.logger.DebugContext(e.ctx, "Skip because of URL targeting", "id", exp.Key)
-			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+			return e.experimentResult(exp, -1, false, featureId, nil, false)
 		}
 	}
 
 	// 4. If context.url exists
 	if qsOverride, ok := getQueryStringOverride(exp.Key, e.client.url, len(exp.Variations)); ok {
 		e.client.logger.DebugContext(e.ctx, "Force via querystring", "id", exp.Key, "variation", qsOverride)
-		return e.getExperimentResult(exp, qsOverride, false, featureId, nil, false)
+		return e.experimentResult(exp, qsOverride, false, featureId, nil, false)
 	}
 
 	// 5. Return if forced via context
 	if varId, ok := e.client.forcedVariations[exp.Key]; ok {
 		e.client.logger.DebugContext(e.ctx, "Force via dev tools", "id", exp.Key, "variation", varId)
-		return e.getExperimentResult(exp, varId, false, featureId, nil, false)
+		return e.experimentResult(exp, varId, false, featureId, nil, false)
 	}
 
 	// 6. Stopped experiments only continue when they define Force.
@@ -87,24 +80,24 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 	case StoppedStatus:
 		if exp.Force == nil {
 			e.client.logger.DebugContext(e.ctx, "Skip stopped experiment without force", "id", exp.Key)
-			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+			return e.experimentResult(exp, -1, false, featureId, nil, false)
 		}
 	case DraftStatus:
 		e.client.logger.DebugContext(e.ctx, "Skip draft experiment", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 5. If experiment.active is set to false, return getExperimentResult(experiment)
 	if !exp.getActive() {
 		e.client.logger.DebugContext(e.ctx, "Skip experiment because it is inactive", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 6. Get the user hash value and return if empty
 	hashAttribute, hashValue := e.getHashAttribute(exp.HashAttribute, exp.FallbackAttribute)
 	if hashValue == "" {
 		e.client.logger.DebugContext(e.ctx, "Skip experiment because of missing hashAttribute", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 6.5 If sticky bucketing is permitted, check to see if a sticky bucket value exists
@@ -160,7 +153,7 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 
 	if stickyBucketVersionBlocked {
 		e.client.logger.DebugContext(e.ctx, "Skip experiment because sticky bucket version is blocked", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, true)
+		return e.experimentResult(exp, -1, false, featureId, nil, true)
 	}
 
 	if !stickyBucketFound {
@@ -168,11 +161,11 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 		if len(exp.Filters) > 0 {
 			if e.isFilteredOut(exp.Filters) {
 				e.client.logger.DebugContext(e.ctx, "Skip because of filters", "id", exp.Key)
-				return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+				return e.experimentResult(exp, -1, false, featureId, nil, false)
 			}
 		} else if exp.Namespace != nil && !exp.Namespace.inNamespace(hashValue) {
 			e.client.logger.DebugContext(e.ctx, "Skip because of namespace", "id", exp.Key)
-			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+			return e.experimentResult(exp, -1, false, featureId, nil, false)
 		}
 
 		// 7.5. If experiment has an include property - include is deprecated property. Hence skipping this step.
@@ -180,7 +173,7 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 		// 8 Return if any conditions are not met, return
 		if !exp.Condition.Eval(e.client.attributes, e.savedGroups) {
 			e.client.logger.DebugContext(e.ctx, "Skip because of condition exp", "id", exp.Key)
-			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+			return e.experimentResult(exp, -1, false, featureId, nil, false)
 		}
 
 		// # 8.05 Exclude if parent conditions are not met
@@ -190,19 +183,19 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 				res := e.evalFeature(parent.Id)
 				if res == nil {
 					e.client.logger.DebugContext(e.ctx, "Skip because of prerequisite fails", "id", exp.Key)
-					return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+					return e.experimentResult(exp, -1, false, featureId, nil, false)
 				}
 
 				if res.Source == CyclicPrerequisiteResultSource {
 					e.client.logger.DebugContext(e.ctx, "Skip experiment because of cyclic prerequisite", "id", exp.Key)
-					return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+					return e.experimentResult(exp, -1, false, featureId, nil, false)
 				}
 
 				evalObj := value.ObjValue{"value": value.New(res.Value)}
 				evaled := parent.Condition.Eval(evalObj, e.savedGroups)
 				if !evaled {
 					e.client.logger.DebugContext(e.ctx, "Skip because of prerequisite evaluation fails", "id", exp.Key)
-					return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+					return e.experimentResult(exp, -1, false, featureId, nil, false)
 				}
 			}
 		}
@@ -210,21 +203,21 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 		// 8.2 Legacy groups: experiment requires the user to belong to at least one named group.
 		if len(exp.Groups) > 0 && !hasMatchingGroup(exp.Groups, e.client.groups) {
 			e.client.logger.DebugContext(e.ctx, "Skip because of group targeting", "id", exp.Key)
-			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+			return e.experimentResult(exp, -1, false, featureId, nil, false)
 		}
 
 	}
 	// 8.3 Legacy: experiment url targeting.
 	if exp.URL != "" && !isLegacyURLTargeted(e.client.url, exp.URL) {
 		e.client.logger.DebugContext(e.ctx, "Skip because of legacy URL targeting", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 9 Choose a variation - If a sticky bucket value exists, use it.
 	n := hash(exp.getSeed(), hashValue, if0(exp.HashVersion, 1))
 	if n == nil {
 		e.client.logger.DebugContext(e.ctx, "Skip because of invalid hash version", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 9.2 Else, calculate bucket ranges for the variations and choose one
@@ -239,29 +232,29 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 	// # Unenroll if any prior sticky buckets are blocked by version
 	if stickyBucketVersionBlocked {
 		e.client.logger.DebugContext(e.ctx, "Skip experiment because sticky bucket version is blocked", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, true)
+		return e.experimentResult(exp, -1, false, featureId, nil, true)
 	}
 
 	// 10. If assigned == -1, return getExperimentResult(experiment)
 	if stickyBucketVariation < 0 {
 		e.client.logger.DebugContext(e.ctx, "Skip because of coverage", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 11. If experiment has a forced variation, return
 	if exp.Force != nil {
 		e.client.logger.DebugContext(e.ctx, "Force variation", "id", exp.Key, "variation", *exp.Force)
-		return e.getExperimentResult(exp, *exp.Force, false, featureId, nil, false)
+		return e.experimentResult(exp, *exp.Force, false, featureId, nil, false)
 	}
 
 	// 12. If context.qaMode, return getExperimentResult(experiment)
 	if e.client.qaMode {
 		e.client.logger.DebugContext(e.ctx, "Skip because of QA mode", "id", exp.Key)
-		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		return e.experimentResult(exp, -1, false, featureId, nil, false)
 	}
 
 	// 13. Build the result object
-	result = e.getExperimentResult(exp, stickyBucketVariation, true, featureId, n, stickyBucketFound)
+	result := e.experimentResult(exp, stickyBucketVariation, true, featureId, n, stickyBucketFound)
 
 	// 13.5 Save sticky bucket assignment if in experiment and sticky bucketing is enabled
 	if e.client.stickyBucketService != nil && !exp.DisableStickyBucketing && result.InExperiment {
@@ -278,6 +271,21 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 		)
 	}
 
+	return result
+}
+
+func (e *evaluator) experimentResult(
+	exp *Experiment,
+	variationId int,
+	hashUsed bool,
+	featureId string,
+	bucket *float64,
+	isStickyBucketUsed bool,
+) *ExperimentResult {
+	result := e.getExperimentResult(exp, variationId, hashUsed, featureId, bucket, isStickyBucketUsed)
+	if featureId != "" && e.client.data.subscribers.hasSubscribers() {
+		e.client.notifySubscribers(e.ctx, exp, result)
+	}
 	return result
 }
 

--- a/evaluator.go
+++ b/evaluator.go
@@ -64,6 +64,20 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 		return e.getExperimentResult(exp, varId, false, featureId, nil, false)
 	}
 
+	// 4.5 Status check: stopped honors only Force; draft is skipped unless qaMode/forced.
+	switch exp.Status {
+	case StoppedStatus:
+		if exp.Force != nil {
+			e.client.logger.DebugContext(e.ctx, "Stopped experiment with forced variation", "id", exp.Key, "variation", *exp.Force)
+			return e.getExperimentResult(exp, *exp.Force, false, featureId, nil, false)
+		}
+		e.client.logger.DebugContext(e.ctx, "Skip stopped experiment without force", "id", exp.Key)
+		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+	case DraftStatus:
+		e.client.logger.DebugContext(e.ctx, "Skip draft experiment", "id", exp.Key)
+		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+	}
+
 	// 5. If experiment.active is set to false, return getExperimentResult(experiment)
 	if !exp.getActive() {
 		e.client.logger.DebugContext(e.ctx, "Skip experiment because it is inactive", "id", exp.Key)
@@ -126,7 +140,6 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 	// Skip steps 7-8 if we found a sticky bucket or version is blocked
 	if stickyBucketFound {
 		e.client.logger.DebugContext(e.ctx, "Found sticky bucket for experiment. Assigning sticky variation", "id", exp.Key, "variation", stickyBucketVariation)
-		// Continue to step 8.3
 	}
 
 	if stickyBucketVersionBlocked {
@@ -178,10 +191,24 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 			}
 		}
 
-		//# 8.2. TODO Make sure user is in a matching group
-	}
+		// 8.2 Legacy groups: experiment requires the user to belong to at least one named group.
+		if len(exp.Groups) > 0 && !hasMatchingGroup(exp.Groups, e.client.groups) {
+			e.client.logger.DebugContext(e.ctx, "Skip because of group targeting", "id", exp.Key)
+			return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+		}
 
-	// 8.3 TODO Apply any url targeting based on experiment.urlPatterns, return if no match
+		// 8.3 URL targeting: if patterns are set, the client URL must match.
+		if len(exp.URLPatterns) > 0 {
+			clientURL := ""
+			if e.client.url != nil {
+				clientURL = e.client.url.String()
+			}
+			if !isURLTargeted(clientURL, exp.URLPatterns) {
+				e.client.logger.DebugContext(e.ctx, "Skip because of URL targeting", "id", exp.Key)
+				return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+			}
+		}
+	}
 
 	// 9 Choose a variation - If a sticky bucket value exists, use it.
 	n := hash(exp.getSeed(), hashValue, if0(exp.HashVersion, 1))
@@ -394,6 +421,15 @@ func (e *evaluator) isFilteredOut(filters []Filter) bool {
 			return true
 		}
 		if chooseVariation(*hash, filter.Ranges) == -1 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMatchingGroup(expGroups []string, userGroups map[string]bool) bool {
+	for _, g := range expGroups {
+		if userGroups[g] {
 			return true
 		}
 	}

--- a/evaluator.go
+++ b/evaluator.go
@@ -214,6 +214,11 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) (result *Ex
 		}
 
 	}
+	// 8.3 Legacy: experiment url targeting.
+	if exp.URL != "" && !isLegacyURLTargeted(e.client.url, exp.URL) {
+		e.client.logger.DebugContext(e.ctx, "Skip because of legacy URL targeting", "id", exp.Key)
+		return e.getExperimentResult(exp, -1, false, featureId, nil, false)
+	}
 
 	// 9 Choose a variation - If a sticky bucket value exists, use it.
 	n := hash(exp.getSeed(), hashValue, if0(exp.HashVersion, 1))

--- a/evaluator_bench_test.go
+++ b/evaluator_bench_test.go
@@ -1,0 +1,109 @@
+package growthbook
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// buildBenchClient creates a client with the requested feature shape:
+// numFeatures features, each with rulesPerFeature force rules guarded by a
+// targeting condition. The first feature's last rule resolves to a force.
+func buildBenchClient(b *testing.B, numFeatures, rulesPerFeature int) *Client {
+	b.Helper()
+	features := FeatureMap{}
+	for i := 0; i < numFeatures; i++ {
+		key := fmt.Sprintf("feature-%d", i)
+		f := &Feature{DefaultValue: false}
+		for j := 0; j < rulesPerFeature; j++ {
+			force := FeatureValue(true)
+			f.Rules = append(f.Rules, FeatureRule{
+				Id:    fmt.Sprintf("%s-rule-%d", key, j),
+				Force: force,
+			})
+		}
+		features[key] = f
+	}
+	c, err := NewClient(context.Background(),
+		WithAttributes(Attributes{"id": "bench-user", "country": "US", "plan": "pro"}),
+		WithFeatures(features),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return c
+}
+
+func BenchmarkEvalFeature_Cold(b *testing.B) {
+	c := buildBenchClient(b, 1, 1)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.EvalFeature(ctx, "feature-0")
+	}
+}
+
+func BenchmarkEvalFeature_Warm(b *testing.B) {
+	c := buildBenchClient(b, 50, 5)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.EvalFeature(ctx, "feature-25")
+	}
+}
+
+func BenchmarkRunExperiment(b *testing.B) {
+	c, err := NewClient(context.Background(),
+		WithAttributes(Attributes{"id": "bench-user"}),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	exp := &Experiment{
+		Key:        "bench-exp",
+		Variations: []FeatureValue{0, 1, 2, 3},
+		Weights:    []float64{0.25, 0.25, 0.25, 0.25},
+	}
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.RunExperiment(ctx, exp)
+	}
+}
+
+func BenchmarkEvalFeature_Parallel(b *testing.B) {
+	c := buildBenchClient(b, 50, 5)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = c.EvalFeature(ctx, "feature-25")
+		}
+	})
+}
+
+func BenchmarkIsURLTargeted_Simple(b *testing.B) {
+	targets := []URLTarget{
+		{Type: URLTargetSimple, Pattern: "https://*.example.com/checkout"},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = isURLTargeted("https://app.example.com/checkout", targets)
+	}
+}
+
+func BenchmarkIsURLTargeted_Regex(b *testing.B) {
+	targets := []URLTarget{
+		{Type: URLTargetRegex, Pattern: `^https://example\.com/foo/\d+$`},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = isURLTargeted("https://example.com/foo/42", targets)
+	}
+}

--- a/experiment.go
+++ b/experiment.go
@@ -58,6 +58,8 @@ type Experiment struct {
 	MinBucketVersion int `json:"minBucketVersion"`
 	// URL patterns to restrict where the experiment runs. Empty means no URL restriction.
 	URLPatterns []URLTarget `json:"urlPatterns"`
+	// Legacy URL regex to restrict where the experiment runs. Empty means no URL restriction.
+	URL string `json:"url"`
 	// Legacy group names — user must belong to at least one matching group (Client.WithGroups).
 	// Distinct from saved groups, which power $inGroup conditions.
 	Groups []string `json:"groups"`
@@ -100,6 +102,7 @@ func experimentFromFeatureRule(featureId string, rule *FeatureRule) *Experiment 
 		BucketVersion:          rule.BucketVersion,
 		MinBucketVersion:       rule.MinBucketVersion,
 		URLPatterns:            rule.URLPatterns,
+		URL:                    rule.URL,
 		Groups:                 rule.Groups,
 		Status:                 rule.Status,
 	}

--- a/experiment.go
+++ b/experiment.go
@@ -56,6 +56,13 @@ type Experiment struct {
 	BucketVersion int `json:"bucketVersion"`
 	// Any users with a sticky bucket version less than this will be excluded from the experiment
 	MinBucketVersion int `json:"minBucketVersion"`
+	// URL patterns to restrict where the experiment runs. Empty means no URL restriction.
+	URLPatterns []URLTarget `json:"urlPatterns"`
+	// Legacy group names — user must belong to at least one matching group (Client.WithGroups).
+	// Distinct from saved groups, which power $inGroup conditions.
+	Groups []string `json:"groups"`
+	// Status controls eval: "draft" is skipped unless qaMode/forced, "stopped" only honors Force, "running" is normal.
+	Status ExperimentStatus `json:"status"`
 }
 
 // NewExperiment creates an experiment with default settings: active,
@@ -92,6 +99,9 @@ func experimentFromFeatureRule(featureId string, rule *FeatureRule) *Experiment 
 		DisableStickyBucketing: rule.DisableStickyBucketing,
 		BucketVersion:          rule.BucketVersion,
 		MinBucketVersion:       rule.MinBucketVersion,
+		URLPatterns:            rule.URLPatterns,
+		Groups:                 rule.Groups,
+		Status:                 rule.Status,
 	}
 	return &exp
 }

--- a/experiment_targeting_test.go
+++ b/experiment_targeting_test.go
@@ -1,0 +1,133 @@
+package growthbook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newAttrClient(t *testing.T, opts ...ClientOption) *Client {
+	t.Helper()
+	base := []ClientOption{WithAttributes(Attributes{"id": "user-1"})}
+	c, err := NewClient(context.Background(), append(base, opts...)...)
+	require.NoError(t, err)
+	return c
+}
+
+func TestExperimentStatus_StoppedHonorsForce(t *testing.T) {
+	// Stopped + Force returns the forced variation. Matches Go's existing
+	// forced-variation contract (InExperiment=true whenever the variation
+	// index is valid); cleaning up "valid variation but not in experiment"
+	// semantics is a separate change.
+	c := newAttrClient(t)
+	force := 1
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		Status:     StoppedStatus,
+		Force:      &force,
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.Equal(t, 1, res.VariationId)
+	require.False(t, res.HashUsed)
+}
+
+func TestExperimentStatus_StoppedNoForceReturnsControl(t *testing.T) {
+	c := newAttrClient(t)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		Status:     StoppedStatus,
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+	require.Equal(t, 0, res.VariationId)
+}
+
+func TestExperimentStatus_DraftSkipped(t *testing.T) {
+	c := newAttrClient(t)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		Status:     DraftStatus,
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+}
+
+func TestExperimentGroups_NoMatch(t *testing.T) {
+	c := newAttrClient(t, WithGroups(map[string]bool{"alpha": false, "beta": true}))
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		Groups:     []string{"alpha"},
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+}
+
+func TestExperimentGroups_OneMatchIsEnough(t *testing.T) {
+	c := newAttrClient(t, WithGroups(map[string]bool{"alpha": false, "beta": true}))
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		Groups:     []string{"alpha", "beta"},
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.True(t, res.InExperiment)
+}
+
+func TestExperimentGroups_NoUserGroupsRejects(t *testing.T) {
+	c := newAttrClient(t)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		Groups:     []string{"alpha"},
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+}
+
+func TestExperimentURLPatterns_Match(t *testing.T) {
+	c := newAttrClient(t)
+	c, err := c.WithUrl("https://example.com/checkout")
+	require.NoError(t, err)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		URLPatterns: []URLTarget{
+			{Type: URLTargetSimple, Pattern: "https://example.com/checkout"},
+		},
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.True(t, res.InExperiment)
+}
+
+func TestExperimentURLPatterns_NoMatchSkipped(t *testing.T) {
+	c := newAttrClient(t)
+	c, err := c.WithUrl("https://example.com/home")
+	require.NoError(t, err)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		URLPatterns: []URLTarget{
+			{Type: URLTargetSimple, Pattern: "https://example.com/checkout"},
+		},
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+}
+
+func TestExperimentURLPatterns_NoClientURLNoMatch(t *testing.T) {
+	c := newAttrClient(t)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		URLPatterns: []URLTarget{
+			{Type: URLTargetSimple, Pattern: "https://example.com/checkout"},
+		},
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+}

--- a/experiment_targeting_test.go
+++ b/experiment_targeting_test.go
@@ -194,6 +194,70 @@ func TestExperimentURLPatterns_CheckedBeforeStickyBucket(t *testing.T) {
 	require.Equal(t, 0, res.VariationId)
 }
 
+func TestExperimentLegacyURL_MatchesFullURL(t *testing.T) {
+	c := newAttrClient(t)
+	c, err := c.WithUrl("https://example.com/checkout")
+	require.NoError(t, err)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		URL:        `^https://example\.com/checkout$`,
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.True(t, res.InExperiment)
+}
+
+func TestExperimentLegacyURL_MatchesPathOnly(t *testing.T) {
+	c := newAttrClient(t)
+	c, err := c.WithUrl("https://example.com/checkout?step=1")
+	require.NoError(t, err)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		URL:        `^/checkout\?step=1$`,
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.True(t, res.InExperiment)
+}
+
+func TestExperimentLegacyURL_NoMatchSkipped(t *testing.T) {
+	c := newAttrClient(t)
+	c, err := c.WithUrl("https://example.com/home")
+	require.NoError(t, err)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		URL:        `^/checkout$`,
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+}
+
+func TestExperimentLegacyURL_CheckedWithStickyBucket(t *testing.T) {
+	service := NewInMemoryStickyBucketService()
+	err := service.SaveAssignments(&StickyBucketAssignmentDoc{
+		AttributeName:  "id",
+		AttributeValue: "user-1",
+		Assignments: map[string]string{
+			getStickyBucketExperimentKey("exp", 0): "one",
+		},
+	})
+	require.NoError(t, err)
+
+	c := newAttrClient(t, WithStickyBucketService(service))
+	c, err = c.WithUrl("https://example.com/home")
+	require.NoError(t, err)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		Meta:       []VariationMeta{{Key: "zero"}, {Key: "one"}},
+		URL:        `^/checkout$`,
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+	require.Equal(t, 0, res.VariationId)
+}
+
 func mustCondition(t *testing.T, raw string) condition.Base {
 	t.Helper()
 	var cond condition.Base

--- a/experiment_targeting_test.go
+++ b/experiment_targeting_test.go
@@ -2,8 +2,10 @@ package growthbook
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/growthbook/growthbook-golang/internal/condition"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,10 +18,6 @@ func newAttrClient(t *testing.T, opts ...ClientOption) *Client {
 }
 
 func TestExperimentStatus_StoppedHonorsForce(t *testing.T) {
-	// Stopped + Force returns the forced variation. Matches Go's existing
-	// forced-variation contract (InExperiment=true whenever the variation
-	// index is valid); cleaning up "valid variation but not in experiment"
-	// semantics is a separate change.
 	c := newAttrClient(t)
 	force := 1
 	exp := Experiment{
@@ -31,6 +29,27 @@ func TestExperimentStatus_StoppedHonorsForce(t *testing.T) {
 	res := c.RunExperiment(context.Background(), &exp)
 	require.Equal(t, 1, res.VariationId)
 	require.False(t, res.HashUsed)
+}
+
+func TestExperimentStatus_StoppedForceStillRequiresEligibility(t *testing.T) {
+	c := newAttrClient(t)
+	force := 1
+	exp := Experiment{
+		Key:           "exp",
+		Variations:    []FeatureValue{0, 1},
+		Status:        StoppedStatus,
+		Force:         &force,
+		HashAttribute: "missing-id",
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+	require.Equal(t, 0, res.VariationId)
+
+	exp.HashAttribute = ""
+	exp.Condition = mustCondition(t, `{"country": "CA"}`)
+	res = c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+	require.Equal(t, 0, res.VariationId)
 }
 
 func TestExperimentStatus_StoppedNoForceReturnsControl(t *testing.T) {
@@ -130,4 +149,54 @@ func TestExperimentURLPatterns_NoClientURLNoMatch(t *testing.T) {
 	}
 	res := c.RunExperiment(context.Background(), &exp)
 	require.False(t, res.InExperiment)
+}
+
+func TestExperimentURLPatterns_CheckedBeforeForcedVariations(t *testing.T) {
+	c := newAttrClient(t, WithForcedVariations(ForcedVariationsMap{"exp": 1}))
+	c, err := c.WithUrl("https://example.com/home")
+	require.NoError(t, err)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		URLPatterns: []URLTarget{
+			{Type: URLTargetSimple, Pattern: "https://example.com/checkout"},
+		},
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+	require.Equal(t, 0, res.VariationId)
+}
+
+func TestExperimentURLPatterns_CheckedBeforeStickyBucket(t *testing.T) {
+	service := NewInMemoryStickyBucketService()
+	err := service.SaveAssignments(&StickyBucketAssignmentDoc{
+		AttributeName:  "id",
+		AttributeValue: "user-1",
+		Assignments: map[string]string{
+			getStickyBucketExperimentKey("exp", 0): "one",
+		},
+	})
+	require.NoError(t, err)
+
+	c := newAttrClient(t, WithStickyBucketService(service))
+	c, err = c.WithUrl("https://example.com/home")
+	require.NoError(t, err)
+	exp := Experiment{
+		Key:        "exp",
+		Variations: []FeatureValue{0, 1},
+		Meta:       []VariationMeta{{Key: "zero"}, {Key: "one"}},
+		URLPatterns: []URLTarget{
+			{Type: URLTargetSimple, Pattern: "https://example.com/checkout"},
+		},
+	}
+	res := c.RunExperiment(context.Background(), &exp)
+	require.False(t, res.InExperiment)
+	require.Equal(t, 0, res.VariationId)
+}
+
+func mustCondition(t *testing.T, raw string) condition.Base {
+	t.Helper()
+	var cond condition.Base
+	require.NoError(t, json.Unmarshal([]byte(raw), &cond))
+	return cond
 }

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -48,4 +48,10 @@ type FeatureRule struct {
 	Name string `json:"name"`
 	// The phase id of the experiment
 	Phase string `json:"phase"`
+	// URL patterns to restrict where the rule's experiment runs. Empty means no URL restriction.
+	URLPatterns []URLTarget `json:"urlPatterns"`
+	// Legacy group names — user must belong to at least one matching group (Client.WithGroups).
+	Groups []string `json:"groups"`
+	// Status — see Experiment.Status.
+	Status ExperimentStatus `json:"status"`
 }

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -50,6 +50,8 @@ type FeatureRule struct {
 	Phase string `json:"phase"`
 	// URL patterns to restrict where the rule's experiment runs. Empty means no URL restriction.
 	URLPatterns []URLTarget `json:"urlPatterns"`
+	// Legacy URL regex to restrict where the rule's experiment runs. Empty means no URL restriction.
+	URL string `json:"url"`
 	// Legacy group names — user must belong to at least one matching group (Client.WithGroups).
 	Groups []string `json:"groups"`
 	// Status — see Experiment.Status.

--- a/internal/condition/in_cond_test.go
+++ b/internal/condition/in_cond_test.go
@@ -12,10 +12,10 @@ func TestInCond(t *testing.T) {
 		c := NewInCond(value.Arr())
 		require.False(t, c.Eval(value.New(100), nil))
 	})
-	t.Run("search in array casts to value type", func(t *testing.T) {
+	t.Run("search in array uses strict equality", func(t *testing.T) {
 		c := NewInCond(value.Arr(1, 200, 100))
-		require.True(t, c.Eval(value.New("100"), nil))
-		require.True(t, c.Eval(value.New(true), nil))
+		require.False(t, c.Eval(value.New("100"), nil))
+		require.False(t, c.Eval(value.New(true), nil))
 		require.True(t, c.Eval(value.New(200), nil))
 		require.False(t, c.Eval(value.New(400), nil))
 	})
@@ -26,10 +26,10 @@ func TestNotInCond(t *testing.T) {
 		c := NewNotInCond(value.Arr())
 		require.True(t, c.Eval(value.New(100), nil))
 	})
-	t.Run("search in array casts to value type", func(t *testing.T) {
+	t.Run("search in array uses strict equality", func(t *testing.T) {
 		c := NewNotInCond(value.Arr(1, 200, 100))
-		require.False(t, c.Eval(value.New("100"), nil))
-		require.False(t, c.Eval(value.New(true), nil))
+		require.True(t, c.Eval(value.New("100"), nil))
+		require.True(t, c.Eval(value.New(true), nil))
 		require.False(t, c.Eval(value.New(200), nil))
 		require.True(t, c.Eval(value.New(400), nil))
 	})

--- a/internal/condition/in_group_cond.go
+++ b/internal/condition/in_group_cond.go
@@ -18,7 +18,11 @@ func NewNotInGroupCond(group string) Condition {
 
 func (c InGroupCond) Eval(actual value.Value, groups SavedGroups) bool {
 	if arr, ok := groups[c.group]; ok {
-		return isIn(actual, arr)
+		for _, v := range arr {
+			if value.Equal(actual, v) {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/internal/condition/marshal.go
+++ b/internal/condition/marshal.go
@@ -150,7 +150,8 @@ func buildValueCondCaseInsensitive(json value.Value) (Condition, error) {
 
 func buildObjCond(obj value.ObjValue) (Condition, error) {
 	var conds []Condition
-	for op, arg := range obj {
+	for _, op := range orderedOperatorKeys(obj) {
+		arg := obj[op]
 		cond, err := buildOpCond(Operator(op), arg)
 		if err != nil {
 			return nil, err
@@ -161,6 +162,15 @@ func buildObjCond(obj value.ObjValue) (Condition, error) {
 		return conds[0], nil
 	}
 	return AndConds(conds), nil
+}
+
+func orderedOperatorKeys(obj value.ObjValue) []string {
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func buildOpCond(op Operator, arg value.Value) (Condition, error) {

--- a/internal/condition/marshal.go
+++ b/internal/condition/marshal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
@@ -40,7 +41,8 @@ func buildBaseCond(json value.Value) (Condition, error) {
 		return nil, fmt.Errorf("Base expected to be an object")
 	}
 	conds := []Condition{}
-	for f, fv := range obj {
+	for _, f := range orderedConditionKeys(obj) {
+		fv := obj[f]
 		cond, err := buildLogicCond(f, fv)
 		if err != nil {
 			return Base{}, fmt.Errorf("Error building %v : %v", f, err)
@@ -51,6 +53,26 @@ func buildBaseCond(json value.Value) (Condition, error) {
 		return conds[0], nil
 	}
 	return AndConds(conds), nil
+}
+
+func orderedConditionKeys(obj value.ObjValue) []string {
+	keys := make([]string, 0, len(obj))
+	seen := make(map[string]bool, len(obj))
+	for _, op := range []Operator{andOp, orOp, norOp, notOp} {
+		key := string(op)
+		if _, ok := obj[key]; ok {
+			keys = append(keys, key)
+			seen[key] = true
+		}
+	}
+	var fields []string
+	for key := range obj {
+		if !seen[key] {
+			fields = append(fields, key)
+		}
+	}
+	sort.Strings(fields)
+	return append(keys, fields...)
 }
 
 func buildLogicCond(op string, arg value.Value) (Condition, error) {

--- a/internal/condition/marshal_test.go
+++ b/internal/condition/marshal_test.go
@@ -40,6 +40,8 @@ func TestLogicMarshaling(t *testing.T) {
 			NotCond{AndConds{age10, nameBob}}},
 		{"multiple", `{"$and": [{"age": 10}], "$or": [{"name": "Bob"}]}`,
 			AndConds{AndConds{age10}, OrConds{nameBob}}},
+		{"multiple operators", `{"age": {"$lte": 20, "$gte": 10}}`,
+			NewFieldCond("age", AndConds{NewCompCond(gteOp, 10), NewCompCond(lteOp, 20)})},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -67,23 +69,23 @@ func TestValueMarshaling(t *testing.T) {
 		`{"$vlt": 1}`:  NewVersionCond(vltOp, 1),
 		`{"$vlte": 1}`: NewVersionCond(vlteOp, 1),
 
-		`{"$in": ["tag1", "tag2"]}`:  NewInCond(value.Arr("tag1", "tag2")),
-		`{"$nin": ["tag1", "tag2"]}`: NewNotInCond(value.Arr("tag1", "tag2")),
+		`{"$in": ["tag1", "tag2"]}`:   NewInCond(value.Arr("tag1", "tag2")),
+		`{"$nin": ["tag1", "tag2"]}`:  NewNotInCond(value.Arr("tag1", "tag2")),
 		`{"$ini": ["tag1", "tag2"]}`:  NewIniCond(value.Arr("tag1", "tag2")),
 		`{"$nini": ["tag1", "tag2"]}`: NewNotIniCond(value.Arr("tag1", "tag2")),
 
 		`{"$inGroup": "admins"}`:    NewInGroupCond("admins"),
 		`{"$notInGroup": "admins"}`: NewNotInGroupCond("admins"),
 
-		`{"$regex": "foo"}`:           NewRegexCond(regexp.MustCompile("foo")),
-		`{"$regexi": "foo"}`:          NewRegexiCond(regexp.MustCompile("(?i)foo")),
-		`{"$size": 10}`:               NewSizeCond(NewValueCond(10)),
-		`{"$elemMatch": {"age": 10}}`: NewElemMatchCond(age10),
-		`{"$elemMatch": {"$eq": 10}}`: NewElemMatchCond(NewCompCond(eqOp, 10)),
+		`{"$regex": "foo"}`:            NewRegexCond(regexp.MustCompile("foo")),
+		`{"$regexi": "foo"}`:           NewRegexiCond(regexp.MustCompile("(?i)foo")),
+		`{"$size": 10}`:                NewSizeCond(NewValueCond(10)),
+		`{"$elemMatch": {"age": 10}}`:  NewElemMatchCond(age10),
+		`{"$elemMatch": {"$eq": 10}}`:  NewElemMatchCond(NewCompCond(eqOp, 10)),
 		`{"$all": [10, {"$eq": 10}]}`:  AllConds{NewValueCond(10), NewCompCond(eqOp, 10)},
 		`{"$alli": [10, {"$eq": 10}]}`: AlliConds{NewValueCondCaseInsensitive(10), NewCompCond(eqOp, 10)},
 		`{"$type": "string"}`:          NewTypeCond("string"),
-		`{"$exists": true}`:           NewExistsCond(true),
+		`{"$exists": true}`:            NewExistsCond(true),
 	}
 	for s, result := range tests {
 		t.Run(s, func(t *testing.T) {
@@ -104,7 +106,7 @@ func TestCaseInsensitiveOperators(t *testing.T) {
 		var b Base
 		err := json.Unmarshal([]byte(jsonStr), &b)
 		require.Nil(t, err)
-		
+
 		require.True(t, b.Eval(value.New(map[string]any{"email": "test@gmail.com"}), nil))
 		require.True(t, b.Eval(value.New(map[string]any{"email": "test@GMAIL.COM"}), nil))
 		require.True(t, b.Eval(value.New(map[string]any{"email": "test@GmAiL.CoM"}), nil))
@@ -116,7 +118,7 @@ func TestCaseInsensitiveOperators(t *testing.T) {
 		var b Base
 		err := json.Unmarshal([]byte(jsonStr), &b)
 		require.Nil(t, err)
-		
+
 		require.True(t, b.Eval(value.New(map[string]any{"browser": "chrome"}), nil))
 		require.True(t, b.Eval(value.New(map[string]any{"browser": "CHROME"}), nil))
 		require.True(t, b.Eval(value.New(map[string]any{"browser": "Safari"}), nil))
@@ -128,7 +130,7 @@ func TestCaseInsensitiveOperators(t *testing.T) {
 		var b Base
 		err := json.Unmarshal([]byte(jsonStr), &b)
 		require.Nil(t, err)
-		
+
 		require.False(t, b.Eval(value.New(map[string]any{"browser": "chrome"}), nil))
 		require.False(t, b.Eval(value.New(map[string]any{"browser": "CHROME"}), nil))
 		require.True(t, b.Eval(value.New(map[string]any{"browser": "safari"}), nil))
@@ -139,11 +141,10 @@ func TestCaseInsensitiveOperators(t *testing.T) {
 		var b Base
 		err := json.Unmarshal([]byte(jsonStr), &b)
 		require.Nil(t, err)
-		
+
 		require.True(t, b.Eval(value.New(map[string]any{"tags": []string{"JAVASCRIPT", "react", "node"}}), nil))
 		require.True(t, b.Eval(value.New(map[string]any{"tags": []string{"JavaScript", "React"}}), nil))
 		require.False(t, b.Eval(value.New(map[string]any{"tags": []string{"JAVASCRIPT", "vue"}}), nil))
 		require.False(t, b.Eval(value.New(map[string]any{"tags": []string{"python", "django"}}), nil))
 	})
 }
-

--- a/internal/condition/utils.go
+++ b/internal/condition/utils.go
@@ -20,7 +20,7 @@ func valueCompare(actual, expected value.Value) bool {
 
 func isIn(fieldVal value.Value, expected value.ArrValue) bool {
 	for _, ev := range expected {
-		if valueCompare(fieldVal, ev) {
+		if value.Equal(fieldVal, ev) {
 			return true
 		}
 	}

--- a/internal/condition/utils.go
+++ b/internal/condition/utils.go
@@ -20,7 +20,7 @@ func valueCompare(actual, expected value.Value) bool {
 
 func isIn(fieldVal value.Value, expected value.ArrValue) bool {
 	for _, ev := range expected {
-		if value.Equal(fieldVal, ev) {
+		if valueCompare(fieldVal, ev) {
 			return true
 		}
 	}

--- a/subscribe.go
+++ b/subscribe.go
@@ -36,6 +36,12 @@ func (r *subscriberRegistry) add(fn ExperimentSubscriber) func() {
 	}
 }
 
+func (r *subscriberRegistry) hasSubscribers() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.entries) > 0
+}
+
 func (r *subscriberRegistry) subscribersForResult(exp *Experiment, res *ExperimentResult) []ExperimentSubscriber {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/subscribe.go
+++ b/subscribe.go
@@ -1,0 +1,71 @@
+package growthbook
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// ExperimentSubscriber is invoked after every experiment evaluation that
+// produces an in-experiment result. Subscribers fire after experiment
+// callbacks and plugins.
+type ExperimentSubscriber func(ctx context.Context, exp *Experiment, result *ExperimentResult)
+
+type subscriberRegistry struct {
+	mu      sync.RWMutex
+	nextID  atomic.Uint64
+	entries map[uint64]ExperimentSubscriber
+}
+
+func (r *subscriberRegistry) add(fn ExperimentSubscriber) func() {
+	id := r.nextID.Add(1)
+	r.mu.Lock()
+	if r.entries == nil {
+		r.entries = make(map[uint64]ExperimentSubscriber)
+	}
+	r.entries[id] = fn
+	r.mu.Unlock()
+	return func() {
+		r.mu.Lock()
+		delete(r.entries, id)
+		r.mu.Unlock()
+	}
+}
+
+func (r *subscriberRegistry) snapshot() []ExperimentSubscriber {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.entries) == 0 {
+		return nil
+	}
+	out := make([]ExperimentSubscriber, 0, len(r.entries))
+	for _, fn := range r.entries {
+		out = append(out, fn)
+	}
+	return out
+}
+
+// Subscribe registers a callback fired on every in-experiment evaluation.
+// The returned function unregisters it. Subscribers are shared across child
+// clients created via With* methods — register once on the root client.
+func (client *Client) Subscribe(fn ExperimentSubscriber) (unsubscribe func()) {
+	if fn == nil {
+		return func() {}
+	}
+	return client.data.subscribers.add(fn)
+}
+
+func (client *Client) notifySubscribers(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+	for _, fn := range client.data.subscribers.snapshot() {
+		client.safeNotifySubscriber(ctx, fn, exp, res)
+	}
+}
+
+func (client *Client) safeNotifySubscriber(ctx context.Context, fn ExperimentSubscriber, exp *Experiment, res *ExperimentResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			client.logger.ErrorContext(ctx, "Subscriber panicked", "error", r)
+		}
+	}()
+	fn(ctx, exp, res)
+}

--- a/subscribe.go
+++ b/subscribe.go
@@ -6,15 +6,19 @@ import (
 	"sync/atomic"
 )
 
-// ExperimentSubscriber is invoked after every experiment evaluation that
-// produces an in-experiment result. Subscribers fire after experiment
-// callbacks and plugins.
+// ExperimentSubscriber is invoked when an experiment assignment changes.
 type ExperimentSubscriber func(ctx context.Context, exp *Experiment, result *ExperimentResult)
 
+type subscriberAssignment struct {
+	inExperiment bool
+	variationID  int
+}
+
 type subscriberRegistry struct {
-	mu      sync.RWMutex
-	nextID  atomic.Uint64
-	entries map[uint64]ExperimentSubscriber
+	mu       sync.RWMutex
+	nextID   atomic.Uint64
+	entries  map[uint64]ExperimentSubscriber
+	assigned map[string]subscriberAssignment
 }
 
 func (r *subscriberRegistry) add(fn ExperimentSubscriber) func() {
@@ -32,10 +36,22 @@ func (r *subscriberRegistry) add(fn ExperimentSubscriber) func() {
 	}
 }
 
-func (r *subscriberRegistry) snapshot() []ExperimentSubscriber {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+func (r *subscriberRegistry) subscribersForResult(exp *Experiment, res *ExperimentResult) []ExperimentSubscriber {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if len(r.entries) == 0 {
+		return nil
+	}
+	if r.assigned == nil {
+		r.assigned = make(map[string]subscriberAssignment)
+	}
+	next := subscriberAssignment{
+		inExperiment: res.InExperiment,
+		variationID:  res.VariationId,
+	}
+	prev, ok := r.assigned[exp.Key]
+	r.assigned[exp.Key] = next
+	if ok && prev == next {
 		return nil
 	}
 	out := make([]ExperimentSubscriber, 0, len(r.entries))
@@ -45,9 +61,9 @@ func (r *subscriberRegistry) snapshot() []ExperimentSubscriber {
 	return out
 }
 
-// Subscribe registers a callback fired on every in-experiment evaluation.
+// Subscribe registers a callback fired when an experiment assignment changes.
 // The returned function unregisters it. Subscribers are shared across child
-// clients created via With* methods — register once on the root client.
+// clients created via With* methods - register once on the root client.
 func (client *Client) Subscribe(fn ExperimentSubscriber) (unsubscribe func()) {
 	if fn == nil {
 		return func() {}
@@ -56,7 +72,7 @@ func (client *Client) Subscribe(fn ExperimentSubscriber) (unsubscribe func()) {
 }
 
 func (client *Client) notifySubscribers(ctx context.Context, exp *Experiment, res *ExperimentResult) {
-	for _, fn := range client.data.subscribers.snapshot() {
+	for _, fn := range client.data.subscribers.subscribersForResult(exp, res) {
 		client.safeNotifySubscriber(ctx, fn, exp, res)
 	}
 }

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -22,8 +22,8 @@ func TestSubscribe_FiresOnInExperiment(t *testing.T) {
 }
 
 func TestSubscribe_FiresEvenWhenNotInExperiment(t *testing.T) {
-	// Matches JS behavior: subscribers receive every run() result, including
-	// misses. Callers can filter on result.InExperiment.
+	// Matches JS behavior: subscribers receive assignment changes, including
+	// the first miss. Callers can filter on result.InExperiment.
 	c := newAttrClient(t)
 	var calls atomic.Int32
 	var lastInExperiment bool
@@ -34,6 +34,62 @@ func TestSubscribe_FiresEvenWhenNotInExperiment(t *testing.T) {
 
 	exp := Experiment{Key: "exp", Variations: []FeatureValue{0, 1}, Status: DraftStatus}
 	c.RunExperiment(context.Background(), &exp)
+	require.Equal(t, int32(1), calls.Load())
+	require.False(t, lastInExperiment)
+}
+
+func TestSubscribe_SkipsUnchangedAssignment(t *testing.T) {
+	c := newAttrClient(t)
+	var calls atomic.Int32
+	c.Subscribe(func(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+		calls.Add(1)
+	})
+
+	exp := Experiment{Key: "exp", Variations: []FeatureValue{0, 1}, Status: DraftStatus}
+	c.RunExperiment(context.Background(), &exp)
+	c.RunExperiment(context.Background(), &exp)
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestSubscribe_FiresWhenAssignmentChanges(t *testing.T) {
+	c := newAttrClient(t)
+	var calls atomic.Int32
+	var lastInExperiment bool
+	c.Subscribe(func(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+		calls.Add(1)
+		lastInExperiment = res.InExperiment
+	})
+
+	exp := Experiment{Key: "exp", Variations: []FeatureValue{0, 1}, Status: DraftStatus}
+	c.RunExperiment(context.Background(), &exp)
+	exp.Status = RunningStatus
+	c.RunExperiment(context.Background(), &exp)
+	require.Equal(t, int32(2), calls.Load())
+	require.True(t, lastInExperiment)
+}
+
+func TestSubscribe_FiresForFeatureRuleMisses(t *testing.T) {
+	c := newAttrClient(t, WithFeatures(FeatureMap{
+		"feature": {
+			DefaultValue: "default",
+			Rules: []FeatureRule{
+				{
+					Key:        "exp",
+					Variations: []FeatureValue{"off", "on"},
+					Status:     DraftStatus,
+				},
+			},
+		},
+	}))
+	var calls atomic.Int32
+	var lastInExperiment bool
+	c.Subscribe(func(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+		calls.Add(1)
+		lastInExperiment = res.InExperiment
+	})
+
+	res := c.EvalFeature(context.Background(), "feature")
+	require.Equal(t, FeatureValue("default"), res.Value)
 	require.Equal(t, int32(1), calls.Load())
 	require.False(t, lastInExperiment)
 }

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1,0 +1,78 @@
+package growthbook
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribe_FiresOnInExperiment(t *testing.T) {
+	c := newAttrClient(t)
+	var calls atomic.Int32
+	unsub := c.Subscribe(func(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+		calls.Add(1)
+	})
+	defer unsub()
+
+	exp := Experiment{Key: "exp", Variations: []FeatureValue{0, 1}}
+	c.RunExperiment(context.Background(), &exp)
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestSubscribe_FiresEvenWhenNotInExperiment(t *testing.T) {
+	// Matches JS behavior: subscribers receive every run() result, including
+	// misses. Callers can filter on result.InExperiment.
+	c := newAttrClient(t)
+	var calls atomic.Int32
+	var lastInExperiment bool
+	c.Subscribe(func(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+		calls.Add(1)
+		lastInExperiment = res.InExperiment
+	})
+
+	exp := Experiment{Key: "exp", Variations: []FeatureValue{0, 1}, Status: DraftStatus}
+	c.RunExperiment(context.Background(), &exp)
+	require.Equal(t, int32(1), calls.Load())
+	require.False(t, lastInExperiment)
+}
+
+func TestSubscribe_UnsubscribeStopsCalls(t *testing.T) {
+	c := newAttrClient(t)
+	var calls atomic.Int32
+	unsub := c.Subscribe(func(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+		calls.Add(1)
+	})
+
+	exp := Experiment{Key: "exp", Variations: []FeatureValue{0, 1}}
+	c.RunExperiment(context.Background(), &exp)
+	unsub()
+	c.RunExperiment(context.Background(), &exp)
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestSubscribe_SharedAcrossChildClients(t *testing.T) {
+	c := newAttrClient(t)
+	var calls atomic.Int32
+	c.Subscribe(func(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+		calls.Add(1)
+	})
+
+	child, err := c.WithAttributes(Attributes{"id": "user-2"})
+	require.NoError(t, err)
+
+	exp := Experiment{Key: "exp", Variations: []FeatureValue{0, 1}}
+	child.RunExperiment(context.Background(), &exp)
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestSubscribe_PanicIsRecovered(t *testing.T) {
+	c := newAttrClient(t)
+	c.Subscribe(func(ctx context.Context, exp *Experiment, res *ExperimentResult) {
+		panic("boom")
+	})
+	exp := Experiment{Key: "exp", Variations: []FeatureValue{0, 1}}
+	// Should not panic.
+	c.RunExperiment(context.Background(), &exp)
+}

--- a/url_target.go
+++ b/url_target.go
@@ -149,3 +149,35 @@ func ensureLeadingSlash(s string) string {
 	}
 	return "/" + s
 }
+
+func isLegacyURLTargeted(actual *url.URL, pattern string) bool {
+	if actual == nil {
+		return false
+	}
+	re, err := regexp.Compile(strings.ReplaceAll(pattern, `\/`, `/`))
+	if err != nil {
+		return false
+	}
+	full := actual.String()
+	if re.MatchString(full) {
+		return true
+	}
+	return re.MatchString(legacyURLPathOnly(actual))
+}
+
+func legacyURLPathOnly(actual *url.URL) string {
+	if actual.Host == "" {
+		return actual.String()
+	}
+	path := actual.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	if actual.RawQuery != "" {
+		path += "?" + actual.RawQuery
+	}
+	if actual.Fragment != "" {
+		path += "#" + actual.EscapedFragment()
+	}
+	return path
+}

--- a/url_target.go
+++ b/url_target.go
@@ -1,0 +1,151 @@
+package growthbook
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// URLTargetType is the type of an URLTarget pattern.
+type URLTargetType string
+
+const (
+	URLTargetSimple URLTargetType = "simple"
+	URLTargetRegex  URLTargetType = "regex"
+)
+
+// URLTarget represents one URL targeting rule on an Experiment or FeatureRule.
+// A nil Include is treated as include=true.
+type URLTarget struct {
+	Type    URLTargetType `json:"type"`
+	Pattern string        `json:"pattern"`
+	Include *bool         `json:"include"`
+}
+
+// isURLTargeted ports JS sdk-js' isURLTargeted: any matching exclude pattern
+// rejects; if there are include rules, at least one must match; if there are
+// only exclude rules and none match, the URL is considered targeted.
+func isURLTargeted(rawURL string, targets []URLTarget) bool {
+	if len(targets) == 0 {
+		return false
+	}
+	hasInclude := false
+	included := false
+	for _, t := range targets {
+		match := evalURLTarget(rawURL, t.Type, t.Pattern)
+		include := t.Include == nil || *t.Include
+		if !include {
+			if match {
+				return false
+			}
+			continue
+		}
+		hasInclude = true
+		if match {
+			included = true
+		}
+	}
+	return included || !hasInclude
+}
+
+func evalURLTarget(rawURL string, typ URLTargetType, pattern string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	switch typ {
+	case URLTargetRegex:
+		return evalRegexURLTarget(parsed, pattern)
+	case URLTargetSimple, "":
+		return evalSimpleURLTarget(parsed, pattern)
+	}
+	return false
+}
+
+func evalRegexURLTarget(parsed *url.URL, pattern string) bool {
+	// JS getUrlRegExp escapes unescaped `/` to support regex strings written for
+	// `/.../"` literal style. Go's RE2 doesn't require slashes to be escaped, so
+	// strip any backslash-escaped slashes first.
+	clean := strings.ReplaceAll(pattern, `\/`, `/`)
+	re, err := regexp.Compile(clean)
+	if err != nil {
+		return false
+	}
+	full := parsed.String()
+	if re.MatchString(full) {
+		return true
+	}
+	// Also try the URL with the origin (scheme://host) stripped so `/path?x=1`
+	// patterns can match.
+	origin := ""
+	if parsed.Scheme != "" {
+		origin = parsed.Scheme + "://" + parsed.Host
+	}
+	if origin != "" && strings.HasPrefix(full, origin) {
+		return re.MatchString(full[len(origin):])
+	}
+	return false
+}
+
+var simpleSchemePrefixRe = regexp.MustCompile(`(?i)^([^:/?]*)\.`)
+
+func evalSimpleURLTarget(actual *url.URL, pattern string) bool {
+	// Add scheme if pattern starts with a bare host: `example.com/x` -> `https://example.com/x`.
+	pattern = simpleSchemePrefixRe.ReplaceAllString(pattern, "https://$1.")
+	pattern = strings.ReplaceAll(pattern, "*", "_____")
+
+	expected, err := url.Parse(pattern)
+	if err != nil {
+		return false
+	}
+	// Mimic JS `new URL(pattern, "https://_____")` — fill in a base host if the
+	// pattern parsed as a path-only URL.
+	if expected.Host == "" {
+		expected, err = url.Parse("https://_____" + ensureLeadingSlash(pattern))
+		if err != nil {
+			return false
+		}
+	}
+
+	if !evalSimpleURLPart(actual.Host, expected.Host, false) {
+		return false
+	}
+	if !evalSimpleURLPart(actual.Path, expected.Path, true) {
+		return false
+	}
+	if expected.Fragment != "" && !evalSimpleURLPart(actual.Fragment, expected.Fragment, false) {
+		return false
+	}
+	for k, vs := range expected.Query() {
+		want := ""
+		if len(vs) > 0 {
+			want = vs[0]
+		}
+		if !evalSimpleURLPart(actual.Query().Get(k), want, false) {
+			return false
+		}
+	}
+	return true
+}
+
+func evalSimpleURLPart(actual, pattern string, isPath bool) bool {
+	escaped := regexp.QuoteMeta(pattern)
+	escaped = strings.ReplaceAll(escaped, "_____", ".*")
+	if isPath {
+		escaped = strings.TrimPrefix(escaped, "/")
+		escaped = strings.TrimSuffix(escaped, "/")
+		escaped = `/?` + escaped + `/?`
+	}
+	re, err := regexp.Compile(`(?i)^` + escaped + `$`)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(actual)
+}
+
+func ensureLeadingSlash(s string) string {
+	if strings.HasPrefix(s, "/") {
+		return s
+	}
+	return "/" + s
+}

--- a/url_target_test.go
+++ b/url_target_test.go
@@ -1,0 +1,103 @@
+package growthbook
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestIsURLTargeted_Empty(t *testing.T) {
+	if isURLTargeted("https://example.com/", nil) {
+		t.Fatal("empty targets must return false")
+	}
+}
+
+func TestIsURLTargeted_SimpleInclude(t *testing.T) {
+	targets := []URLTarget{{Type: URLTargetSimple, Pattern: "https://example.com/foo"}}
+	if !isURLTargeted("https://example.com/foo", targets) {
+		t.Fatal("exact match should be targeted")
+	}
+	if isURLTargeted("https://example.com/bar", targets) {
+		t.Fatal("non-matching path should not be targeted")
+	}
+}
+
+func TestIsURLTargeted_SimpleWildcard(t *testing.T) {
+	targets := []URLTarget{{Type: URLTargetSimple, Pattern: "https://*.example.com/path/*"}}
+	if !isURLTargeted("https://app.example.com/path/x", targets) {
+		t.Fatal("wildcard host + path should match")
+	}
+	if !isURLTargeted("https://api.example.com/path/y/z", targets) {
+		t.Fatal("trailing wildcard should match deeper paths")
+	}
+	if isURLTargeted("https://example.com/path/x", targets) {
+		t.Fatal("missing subdomain should not match wildcard host")
+	}
+}
+
+func TestIsURLTargeted_SimpleSchemelessPattern(t *testing.T) {
+	targets := []URLTarget{{Type: URLTargetSimple, Pattern: "example.com/foo"}}
+	if !isURLTargeted("https://example.com/foo", targets) {
+		t.Fatal("scheme should be added to bare host pattern")
+	}
+}
+
+func TestIsURLTargeted_SimpleQueryParams(t *testing.T) {
+	targets := []URLTarget{{Type: URLTargetSimple, Pattern: "https://example.com/?a=1&b=2"}}
+	if !isURLTargeted("https://example.com/?b=2&a=1", targets) {
+		t.Fatal("query params should be order-independent")
+	}
+	if isURLTargeted("https://example.com/?a=1", targets) {
+		t.Fatal("missing required query param should not match")
+	}
+}
+
+func TestIsURLTargeted_RegexInclude(t *testing.T) {
+	targets := []URLTarget{{Type: URLTargetRegex, Pattern: `^https://example\.com/foo/\d+$`}}
+	if !isURLTargeted("https://example.com/foo/42", targets) {
+		t.Fatal("regex should match")
+	}
+	if isURLTargeted("https://example.com/foo/abc", targets) {
+		t.Fatal("regex should reject non-digit")
+	}
+}
+
+func TestIsURLTargeted_RegexJSEscapedSlashes(t *testing.T) {
+	targets := []URLTarget{{Type: URLTargetRegex, Pattern: `^https:\/\/example\.com\/foo$`}}
+	if !isURLTargeted("https://example.com/foo", targets) {
+		t.Fatal("JS-style backslash-escaped slashes should be normalized")
+	}
+}
+
+func TestIsURLTargeted_ExcludeWins(t *testing.T) {
+	targets := []URLTarget{
+		{Type: URLTargetSimple, Pattern: "https://example.com/*"},
+		{Type: URLTargetSimple, Pattern: "https://example.com/admin", Include: boolPtr(false)},
+	}
+	if !isURLTargeted("https://example.com/page", targets) {
+		t.Fatal("non-excluded URL inside include should match")
+	}
+	if isURLTargeted("https://example.com/admin", targets) {
+		t.Fatal("excluded URL should reject even with matching include")
+	}
+}
+
+func TestIsURLTargeted_OnlyExcludesNoMatch(t *testing.T) {
+	targets := []URLTarget{
+		{Type: URLTargetSimple, Pattern: "https://example.com/admin", Include: boolPtr(false)},
+	}
+	// JS behavior: with only excludes and no match, URL is targeted.
+	if !isURLTargeted("https://example.com/page", targets) {
+		t.Fatal("only excludes, none matching, should be targeted")
+	}
+	if isURLTargeted("https://example.com/admin", targets) {
+		t.Fatal("excluded URL should not be targeted")
+	}
+}
+
+func TestIsURLTargeted_NoIncludeMatched(t *testing.T) {
+	targets := []URLTarget{
+		{Type: URLTargetSimple, Pattern: "https://example.com/foo"},
+	}
+	if isURLTargeted("https://example.com/bar", targets) {
+		t.Fatal("when an include exists but none match, URL is not targeted")
+	}
+}

--- a/url_target_test.go
+++ b/url_target_test.go
@@ -1,6 +1,9 @@
 package growthbook
 
-import "testing"
+import (
+	"net/url"
+	"testing"
+)
 
 func boolPtr(b bool) *bool { return &b }
 
@@ -100,4 +103,29 @@ func TestIsURLTargeted_NoIncludeMatched(t *testing.T) {
 	if isURLTargeted("https://example.com/bar", targets) {
 		t.Fatal("when an include exists but none match, URL is not targeted")
 	}
+}
+
+func TestIsLegacyURLTargeted(t *testing.T) {
+	u := mustParseURL(t, "https://example.com/path/to/page?step=1#top")
+	if !isLegacyURLTargeted(u, `^https://example\.com/path/to/page\?step=1#top$`) {
+		t.Fatal("legacy URL should match full URL")
+	}
+	if !isLegacyURLTargeted(u, `^/path/to/page\?step=1#top$`) {
+		t.Fatal("legacy URL should match path-only URL")
+	}
+	if isLegacyURLTargeted(u, `^/other$`) {
+		t.Fatal("legacy URL should reject non-matching URL")
+	}
+	if isLegacyURLTargeted(nil, `.*`) {
+		t.Fatal("legacy URL should reject missing client URL")
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
 }


### PR DESCRIPTION
## Summary

Closes the two TODOs in `evaluator.go` and adds a public observer API, improving SDK's feature parity.

- **URL targeting** (`Experiment.URLPatterns` / `FeatureRule.URLPatterns`): port of JS `isURLTargeted` — simple + regex, include/exclude, scheme-prefix patterns, order-independent query params, JS-style escaped slashes.
- **Legacy groups** (`Experiment.Groups` + `WithGroups(map[string]bool)`): user must belong to at least one matching group.
- **Status field** (`Experiment.Status`): `stopped` honors `Force`, `draft` is skipped.
- **Subscribe API** (`Client.Subscribe(fn) -> unsubscribe`): public observer fired on every `RunExperiment` / in-experiment `EvalFeature`, matching JS `subscribe()`. Shared across child clients created via `With*`.
- **Benchmarks**: `evaluator_bench_test.go` + versioned baseline log at `docs/benchmarks/baseline.md`.

## Benchmark baseline

`go1.23.6 darwin/arm64` · Apple M1 Max · commit `0d7ab4b` · `-benchtime=2s`

| Benchmark                       |   ns/op |   B/op |  allocs/op |
|---------------------------------|--------:|-------:|-----------:|
| EvalFeature_Cold                |   126.1 |    160 |          3 |
| EvalFeature_Warm (50 × 5 rules) |   137.1 |    160 |          3 |
| RunExperiment                   |   237.9 |    280 |          4 |
| EvalFeature_Parallel            |   278.6 |    160 |          3 |
| **isURLTargeted_Simple**        | **8050**| 12 139 |    **126** |
| **isURLTargeted_Regex**         | **4955**|  8 211 |     **94** |

### Eval path — fast, no urgent work

```mermaid
xychart-beta
    title "Eval path (ns/op)"
    x-axis ["EvalFeature_Cold", "EvalFeature_Warm", "RunExperiment", "Parallel"]
    y-axis "ns/op" 0 --> 320
    bar [126, 137, 238, 279]
```

### URL targeting — Need regex-cache follow-up PR

`isURLTargeted` recompiles regexes on every call (`regexp.Compile` inside `evalSimpleURLPart` and `evalRegexURLTarget`), allocating 100+ times. Experiments using `urlPatterns` pay this per eval — ~50× the cost of plain `EvalFeature`. Pre-compiling once per `URLTarget` is the obvious win.

```mermaid
xychart-beta
    title "isURLTargeted (ns/op) — note scale jump from chart above"
    x-axis ["Simple", "Regex"]
    y-axis "ns/op" 0 --> 9000
    bar [8050, 4955]
```

```mermaid
xychart-beta
    title "isURLTargeted (allocs/op)"
    x-axis ["Simple", "Regex"]
    y-axis "allocs/op" 0 --> 140
    bar [126, 94]
```