### PR TITLE
Fix implicit boolean condition matching null/absent attributes

### DIFF
--- a/cases.json
+++ b/cases.json
@@ -1674,6 +1674,32 @@
       false
     ],
     [
+      "null condition - false attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": false
+      },
+      false
+    ],
+    [
+      "false condition - missing attribute",
+      {
+        "userId": false
+      },
+      {},
+      false
+    ],
+    [
+      "false strict condition - missing attribute",
+      {
+        "userId": { "$eq": false }
+      },
+      {},
+      false
+    ],
+    [
       "$vgt/$vlt - pass - major",
       {
         "version": {

--- a/internal/condition/utils.go
+++ b/internal/condition/utils.go
@@ -8,7 +8,13 @@ import (
 
 func valueCompare(actual, expected value.Value) bool {
 	switch expected.Type() {
-	case value.StrType, value.NumType, value.BoolType:
+	case value.BoolType:
+		if value.IsNull(actual) {
+			return false
+		}
+		casted := actual.Cast(expected.Type())
+		return value.Equal(expected, casted)
+	case value.StrType, value.NumType:
 		casted := actual.Cast(expected.Type())
 		return value.Equal(expected, casted)
 	case value.NullType:

--- a/internal/condition/value_cond_test.go
+++ b/internal/condition/value_cond_test.go
@@ -21,6 +21,10 @@ func TestValueCond(t *testing.T) {
 		{0, 0, true},
 		{0, "", true},
 		{0, false, true},
+		{false, nil, false},
+		{true, nil, false},
+		{0, nil, true},
+		{nil, nil, true},
 	}
 	for _, tt := range tests {
 		var c Condition = NewValueCond(tt.e)


### PR DESCRIPTION
## Summary

A condition like `{"isPro": false}` evaluates to `true` when the `isPro` attribute is not set. The JS reference SDK and spec test suite v0.7.1 say this should be `false`.

## Root cause

`valueCompare` casts the actual value to the expected value's type before comparing. For an absent attribute, `ObjValue.Path` returns `Null()`, and `NullValue.Cast(BoolType)` returns `False()`, so `false == false` matches.

## Fix

Add an `IsNull(actual)` early-return in the `BoolType` arm of `valueCompare`, mirroring the JS SDK guard added in growthbook/growthbook#3665 (`value !== null && !!value === condition`). That PR also bumped the spec test suite to v0.7.1 with three new `evalCondition` cases covering this; those cases are added here.

The `NumType` arm is left unchanged so `{"count": 0}` vs absent still returns `true`, matching the JS reference (`null * 1 === 0`).

## Notes

- Explicit `{"isPro": {"$eq": false}}` was already correct (routes through `CompCond` → type-checked `value.Equal`).
- `specVersion` is left at `0.7.0` since the full 0.7.1 sync also adds `ruleId` to feature-result fixtures, which is out of scope here.
- `TestInCond/search_in_array_casts_to_value_type` and `TestNotInCond/...` fail on `main` independently of this change (since ff97a3a switched `isIn` from `valueCompare` to `value.Equal` without updating the test). Not touched here.