### PR TITLE
perf(condition): O(1) map lookup for $in/$ini on string lists

### DIFF
--- a/internal/condition/in_cond.go
+++ b/internal/condition/in_cond.go
@@ -1,14 +1,19 @@
 package condition
 
-import "github.com/growthbook/growthbook-golang/internal/value"
+import (
+	"strings"
+
+	"github.com/growthbook/growthbook-golang/internal/value"
+)
 
 // InOp checks if value is in array
 type InCond struct {
 	expected value.ArrValue
+	strSet   map[string]struct{}
 }
 
 func NewInCond(arg value.ArrValue) InCond {
-	return InCond{arg}
+	return InCond{expected: arg, strSet: buildStrSet(arg, false)}
 }
 
 func NewNotInCond(arg value.ArrValue) Condition {
@@ -19,22 +24,33 @@ func NewNotInCond(arg value.ArrValue) Condition {
 func (c InCond) Eval(actual value.Value, _ SavedGroups) bool {
 	if arr, ok := actual.(value.ArrValue); ok {
 		for _, v := range arr {
-			if isIn(v, c.expected) {
+			if c.contains(v) {
 				return true
 			}
 		}
 		return false
 	}
-	return isIn(actual, c.expected)
+	return c.contains(actual)
+}
+
+func (c InCond) contains(v value.Value) bool {
+	if c.strSet != nil {
+		if s, ok := v.(value.StrValue); ok {
+			_, hit := c.strSet[string(s)]
+			return hit
+		}
+	}
+	return isIn(v, c.expected)
 }
 
 // IniCond checks if value is in array (case-insensitive for strings)
 type IniCond struct {
 	expected value.ArrValue
+	strSet   map[string]struct{}
 }
 
 func NewIniCond(arg value.ArrValue) IniCond {
-	return IniCond{arg}
+	return IniCond{expected: arg, strSet: buildStrSet(arg, true)}
 }
 
 func NewNotIniCond(arg value.ArrValue) Condition {
@@ -45,11 +61,42 @@ func NewNotIniCond(arg value.ArrValue) Condition {
 func (c IniCond) Eval(actual value.Value, _ SavedGroups) bool {
 	if arr, ok := actual.(value.ArrValue); ok {
 		for _, v := range arr {
-			if isInCaseInsensitive(v, c.expected) {
+			if c.contains(v) {
 				return true
 			}
 		}
 		return false
 	}
-	return isInCaseInsensitive(actual, c.expected)
+	return c.contains(actual)
+}
+
+func (c IniCond) contains(v value.Value) bool {
+	if c.strSet != nil {
+		if s, ok := v.(value.StrValue); ok {
+			_, hit := c.strSet[strings.ToLower(string(s))]
+			return hit
+		}
+	}
+	return isInCaseInsensitive(v, c.expected)
+}
+
+// buildStrSet returns a string set when every element of arg is a StrValue,
+// otherwise nil so callers fall back to the linear scan.
+func buildStrSet(arg value.ArrValue, lower bool) map[string]struct{} {
+	if len(arg) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(arg))
+	for _, v := range arg {
+		s, ok := v.(value.StrValue)
+		if !ok {
+			return nil
+		}
+		k := string(s)
+		if lower {
+			k = strings.ToLower(k)
+		}
+		set[k] = struct{}{}
+	}
+	return set
 }

--- a/internal/condition/in_cond_bench_test.go
+++ b/internal/condition/in_cond_bench_test.go
@@ -1,0 +1,29 @@
+package condition
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/growthbook/growthbook-golang/internal/value"
+)
+
+func benchInCondEval(b *testing.B, n int) {
+	elems := make([]any, n)
+	for i := range elems {
+		elems[i] = "id-" + strconv.Itoa(i)
+	}
+	c := NewInCond(value.Arr(elems...))
+	hit := value.New("id-" + strconv.Itoa(n-1))
+	miss := value.New("missing")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.Eval(hit, nil)
+		_ = c.Eval(miss, nil)
+	}
+}
+
+func BenchmarkInCondEval10(b *testing.B)    { benchInCondEval(b, 10) }
+func BenchmarkInCondEval100(b *testing.B)   { benchInCondEval(b, 100) }
+func BenchmarkInCondEval1000(b *testing.B)  { benchInCondEval(b, 1000) }
+func BenchmarkInCondEval10000(b *testing.B) { benchInCondEval(b, 10000) }

--- a/internal/condition/in_cond_test.go
+++ b/internal/condition/in_cond_test.go
@@ -19,6 +19,23 @@ func TestInCond(t *testing.T) {
 		require.True(t, c.Eval(value.New(200), nil))
 		require.False(t, c.Eval(value.New(400), nil))
 	})
+	t.Run("all-string array uses set lookup", func(t *testing.T) {
+		c := NewInCond(value.Arr("a", "b", "c"))
+		require.NotNil(t, c.strSet)
+		require.True(t, c.Eval(value.New("a"), nil))
+		require.True(t, c.Eval(value.New("c"), nil))
+		require.False(t, c.Eval(value.New("d"), nil))
+		require.False(t, c.Eval(value.New(1), nil))
+		require.True(t, c.Eval(value.Arr("x", "b"), nil))
+		require.False(t, c.Eval(value.Arr("x", "y"), nil))
+	})
+	t.Run("mixed-type array falls back to linear scan", func(t *testing.T) {
+		c := NewInCond(value.Arr("a", 1, "c"))
+		require.Nil(t, c.strSet)
+		require.True(t, c.Eval(value.New("a"), nil))
+		require.True(t, c.Eval(value.New(1), nil))
+		require.False(t, c.Eval(value.New("b"), nil))
+	})
 }
 
 func TestNotInCond(t *testing.T) {
@@ -63,6 +80,22 @@ func TestIniCond(t *testing.T) {
 	t.Run("empty array returns false", func(t *testing.T) {
 		c := NewIniCond(value.Arr())
 		require.False(t, c.Eval(value.New("test"), nil))
+	})
+
+	t.Run("all-string array uses set lookup", func(t *testing.T) {
+		c := NewIniCond(value.Arr("Alpha", "BETA"))
+		require.NotNil(t, c.strSet)
+		require.True(t, c.Eval(value.New("alpha"), nil))
+		require.True(t, c.Eval(value.New("Beta"), nil))
+		require.False(t, c.Eval(value.New("gamma"), nil))
+		require.False(t, c.Eval(value.New(1), nil))
+	})
+
+	t.Run("mixed-type array falls back to linear scan", func(t *testing.T) {
+		c := NewIniCond(value.Arr("Alpha", 1))
+		require.Nil(t, c.strSet)
+		require.True(t, c.Eval(value.New("ALPHA"), nil))
+		require.True(t, c.Eval(value.New(1), nil))
 	})
 }
 


### PR DESCRIPTION
## Summary

`InCond.Eval` / `IniCond.Eval` (the `$in` / `$ini` / `$nin` / `$nini` operators) currently linear-scan the expected array on every evaluation, calling the interface-dispatched `value.Equal` for each element.

When every expected element is a string — the common case for saved groups, user-ID allowlists, country lists, etc. — this PR precomputes a `map[string]struct{}` once in the constructor and replaces the per-evaluation scan with a single map lookup. Arrays containing non-string values keep the existing linear-scan behaviour unchanged.

The constructors are invoked from the JSON unmarshal path (`condition/marshal.go`), so the set is rebuilt automatically whenever the feature payload is reloaded; no extra invalidation is needed.

## Behaviour

`isIn` compares with `value.Equal`, which already returns `false` on type mismatch, so a non-string attribute could never match an all-string list before this change either. The fast path therefore preserves existing semantics. The SDK spec test suite (`cases.json`) continues to pass.

## Benchmarks

`go test ./internal/condition/ -bench BenchmarkInCondEval -benchmem -count=6`, compared with `benchstat` (one hit + one miss lookup per iteration):

```
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) Platinum 8488C
                   │     old      │                 new                 │
                   │    sec/op    │    sec/op     vs base               │
InCondEval10-64        214.25n ± 2%   17.84n ±  5%  -91.68% (p=0.002 n=6)
InCondEval100-64      1852.00n ± 3%   19.38n ± 15%  -98.95% (p=0.002 n=6)
InCondEval1000-64    17344.00n ± 4%   18.26n ± 25%  -99.89% (p=0.002 n=6)
InCondEval10000-64  200472.00n ± 2%   18.78n ± 15%  -99.99% (p=0.002 n=6)
geomean                  6.095µ        18.56n        -99.70%
```

`Eval` stays constant ~18ns regardless of list size (vs O(n) before), with zero allocations on the hot path.

The added memory cost is one `map[string]struct{}` per `$in`/`$ini` condition, sized to the list length, allocated once at payload-parse time.