### PR TITLE
perf(condition): use map lookup for string $in/$ini lists

### DIFF
--- a/internal/condition/in_cond.go
+++ b/internal/condition/in_cond.go
@@ -13,7 +13,7 @@ type InCond struct {
 }
 
 func NewInCond(arg value.ArrValue) InCond {
-	return InCond{expected: arg, strSet: buildStrSet(arg, false)}
+	return InCond{expected: arg, strSet: buildStrSet(arg)}
 }
 
 func NewNotInCond(arg value.ArrValue) Condition {
@@ -50,7 +50,7 @@ type IniCond struct {
 }
 
 func NewIniCond(arg value.ArrValue) IniCond {
-	return IniCond{expected: arg, strSet: buildStrSet(arg, true)}
+	return IniCond{expected: arg, strSet: buildLowerASCIIStringSet(arg)}
 }
 
 func NewNotIniCond(arg value.ArrValue) Condition {
@@ -73,8 +73,11 @@ func (c IniCond) Eval(actual value.Value, _ SavedGroups) bool {
 func (c IniCond) contains(v value.Value) bool {
 	if c.strSet != nil {
 		if s, ok := v.(value.StrValue); ok {
-			_, hit := c.strSet[strings.ToLower(string(s))]
-			return hit
+			actual := string(s)
+			if isASCII(actual) {
+				_, hit := c.strSet[strings.ToLower(actual)]
+				return hit
+			}
 		}
 	}
 	return isInCaseInsensitive(v, c.expected)
@@ -82,7 +85,24 @@ func (c IniCond) contains(v value.Value) bool {
 
 // buildStrSet returns a string set when every element of arg is a StrValue,
 // otherwise nil so callers fall back to the linear scan.
-func buildStrSet(arg value.ArrValue, lower bool) map[string]struct{} {
+func buildStrSet(arg value.ArrValue) map[string]struct{} {
+	if len(arg) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(arg))
+	for _, v := range arg {
+		s, ok := v.(value.StrValue)
+		if !ok {
+			return nil
+		}
+		set[string(s)] = struct{}{}
+	}
+	return set
+}
+
+// buildLowerASCIIStringSet is the $ini fast path. It only indexes ASCII
+// strings so the slow path keeps the exact EqualFold behavior for Unicode.
+func buildLowerASCIIStringSet(arg value.ArrValue) map[string]struct{} {
 	if len(arg) == 0 {
 		return nil
 	}
@@ -93,10 +113,19 @@ func buildStrSet(arg value.ArrValue, lower bool) map[string]struct{} {
 			return nil
 		}
 		k := string(s)
-		if lower {
-			k = strings.ToLower(k)
+		if !isASCII(k) {
+			return nil
 		}
-		set[k] = struct{}{}
+		set[strings.ToLower(k)] = struct{}{}
 	}
 	return set
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 127 {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/condition/in_cond.go
+++ b/internal/condition/in_cond.go
@@ -1,14 +1,19 @@
 package condition
 
-import "github.com/growthbook/growthbook-golang/internal/value"
+import (
+	"strings"
+
+	"github.com/growthbook/growthbook-golang/internal/value"
+)
 
 // InOp checks if value is in array
 type InCond struct {
 	expected value.ArrValue
+	strSet   map[string]struct{}
 }
 
 func NewInCond(arg value.ArrValue) InCond {
-	return InCond{arg}
+	return InCond{expected: arg, strSet: buildStrSet(arg, false)}
 }
 
 func NewNotInCond(arg value.ArrValue) Condition {
@@ -19,22 +24,33 @@ func NewNotInCond(arg value.ArrValue) Condition {
 func (c InCond) Eval(actual value.Value, _ SavedGroups) bool {
 	if arr, ok := actual.(value.ArrValue); ok {
 		for _, v := range arr {
-			if isIn(v, c.expected) {
+			if c.contains(v) {
 				return true
 			}
 		}
 		return false
 	}
-	return isIn(actual, c.expected)
+	return c.contains(actual)
+}
+
+func (c InCond) contains(v value.Value) bool {
+	if c.strSet != nil {
+		if s, ok := v.(value.StrValue); ok {
+			_, hit := c.strSet[string(s)]
+			return hit
+		}
+	}
+	return isIn(v, c.expected)
 }
 
 // IniCond checks if value is in array (case-insensitive for strings)
 type IniCond struct {
 	expected value.ArrValue
+	strSet   map[string]struct{}
 }
 
 func NewIniCond(arg value.ArrValue) IniCond {
-	return IniCond{arg}
+	return IniCond{expected: arg, strSet: buildStrSet(arg, true)}
 }
 
 func NewNotIniCond(arg value.ArrValue) Condition {
@@ -45,11 +61,42 @@ func NewNotIniCond(arg value.ArrValue) Condition {
 func (c IniCond) Eval(actual value.Value, _ SavedGroups) bool {
 	if arr, ok := actual.(value.ArrValue); ok {
 		for _, v := range arr {
-			if isInCaseInsensitive(v, c.expected) {
+			if c.contains(v) {
 				return true
 			}
 		}
 		return false
 	}
-	return isInCaseInsensitive(actual, c.expected)
+	return c.contains(actual)
+}
+
+func (c IniCond) contains(v value.Value) bool {
+	if c.strSet != nil {
+		if s, ok := v.(value.StrValue); ok {
+			_, hit := c.strSet[strings.ToLower(string(s))]
+			return hit
+		}
+	}
+	return isInCaseInsensitive(v, c.expected)
+}
+
+// buildStrSet returns a string set when every element of arg is a StrValue,
+// otherwise nil so callers fall back to the linear scan.
+func buildStrSet(arg value.ArrValue, lower bool) map[string]struct{} {
+	if len(arg) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(arg))
+	for _, v := range arg {
+		s, ok := v.(value.StrValue)
+		if !ok {
+			return nil
+		}
+		k := string(s)
+		if lower {
+			k = strings.ToLower(k)
+		}
+		set[k] = struct{}{}
+	}
+	return set
 }

--- a/internal/condition/in_cond_bench_test.go
+++ b/internal/condition/in_cond_bench_test.go
@@ -23,7 +23,28 @@ func benchInCondEval(b *testing.B, n int) {
 	}
 }
 
+func benchIniCondEval(b *testing.B, n int) {
+	elems := make([]any, n)
+	for i := range elems {
+		elems[i] = "ID-" + strconv.Itoa(i)
+	}
+	c := NewIniCond(value.Arr(elems...))
+	hit := value.New("id-" + strconv.Itoa(n-1))
+	miss := value.New("missing")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.Eval(hit, nil)
+		_ = c.Eval(miss, nil)
+	}
+}
+
 func BenchmarkInCondEval10(b *testing.B)    { benchInCondEval(b, 10) }
 func BenchmarkInCondEval100(b *testing.B)   { benchInCondEval(b, 100) }
 func BenchmarkInCondEval1000(b *testing.B)  { benchInCondEval(b, 1000) }
 func BenchmarkInCondEval10000(b *testing.B) { benchInCondEval(b, 10000) }
+
+func BenchmarkIniCondEval10(b *testing.B)    { benchIniCondEval(b, 10) }
+func BenchmarkIniCondEval100(b *testing.B)   { benchIniCondEval(b, 100) }
+func BenchmarkIniCondEval1000(b *testing.B)  { benchIniCondEval(b, 1000) }
+func BenchmarkIniCondEval10000(b *testing.B) { benchIniCondEval(b, 10000) }

--- a/internal/condition/in_cond_bench_test.go
+++ b/internal/condition/in_cond_bench_test.go
@@ -1,0 +1,29 @@
+package condition
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/growthbook/growthbook-golang/internal/value"
+)
+
+func benchInCondEval(b *testing.B, n int) {
+	elems := make([]any, n)
+	for i := range elems {
+		elems[i] = "id-" + strconv.Itoa(i)
+	}
+	c := NewInCond(value.Arr(elems...))
+	hit := value.New("id-" + strconv.Itoa(n-1))
+	miss := value.New("missing")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.Eval(hit, nil)
+		_ = c.Eval(miss, nil)
+	}
+}
+
+func BenchmarkInCondEval10(b *testing.B)    { benchInCondEval(b, 10) }
+func BenchmarkInCondEval100(b *testing.B)   { benchInCondEval(b, 100) }
+func BenchmarkInCondEval1000(b *testing.B)  { benchInCondEval(b, 1000) }
+func BenchmarkInCondEval10000(b *testing.B) { benchInCondEval(b, 10000) }

--- a/internal/condition/in_cond_test.go
+++ b/internal/condition/in_cond_test.go
@@ -25,6 +25,7 @@ func TestInCond(t *testing.T) {
 		require.True(t, c.Eval(value.New("a"), nil))
 		require.True(t, c.Eval(value.New("c"), nil))
 		require.False(t, c.Eval(value.New("d"), nil))
+		require.False(t, c.Eval(value.New("1"), nil))
 		require.False(t, c.Eval(value.New(1), nil))
 		require.True(t, c.Eval(value.Arr("x", "b"), nil))
 		require.False(t, c.Eval(value.Arr("x", "y"), nil))
@@ -91,6 +92,20 @@ func TestIniCond(t *testing.T) {
 		require.False(t, c.Eval(value.New(1), nil))
 	})
 
+	t.Run("non-ascii strings fall back to EqualFold scan", func(t *testing.T) {
+		c := NewIniCond(value.Arr("CAFÉ"))
+		require.Nil(t, c.strSet)
+		require.True(t, c.Eval(value.New("café"), nil))
+		require.False(t, c.Eval(value.New("cafe"), nil))
+	})
+
+	t.Run("non-ascii actual values fall back to EqualFold scan", func(t *testing.T) {
+		c := NewIniCond(value.Arr("k"))
+		require.NotNil(t, c.strSet)
+		require.True(t, c.Eval(value.New("K"), nil))
+		require.True(t, c.Eval(value.New("K"), nil))
+	})
+
 	t.Run("mixed-type array falls back to linear scan", func(t *testing.T) {
 		c := NewIniCond(value.Arr("Alpha", 1))
 		require.Nil(t, c.strSet)
@@ -111,5 +126,11 @@ func TestNotIniCond(t *testing.T) {
 	t.Run("empty array returns true", func(t *testing.T) {
 		c := NewNotIniCond(value.Arr())
 		require.True(t, c.Eval(value.New("test"), nil))
+	})
+
+	t.Run("inverts ascii set lookup", func(t *testing.T) {
+		c := NewNotIniCond(value.Arr("Alpha", "BETA"))
+		require.False(t, c.Eval(value.New("alpha"), nil))
+		require.True(t, c.Eval(value.New("gamma"), nil))
 	})
 }

--- a/internal/condition/in_cond_test.go
+++ b/internal/condition/in_cond_test.go
@@ -19,6 +19,23 @@ func TestInCond(t *testing.T) {
 		require.True(t, c.Eval(value.New(200), nil))
 		require.False(t, c.Eval(value.New(400), nil))
 	})
+	t.Run("all-string array uses set lookup", func(t *testing.T) {
+		c := NewInCond(value.Arr("a", "b", "c"))
+		require.NotNil(t, c.strSet)
+		require.True(t, c.Eval(value.New("a"), nil))
+		require.True(t, c.Eval(value.New("c"), nil))
+		require.False(t, c.Eval(value.New("d"), nil))
+		require.False(t, c.Eval(value.New(1), nil))
+		require.True(t, c.Eval(value.Arr("x", "b"), nil))
+		require.False(t, c.Eval(value.Arr("x", "y"), nil))
+	})
+	t.Run("mixed-type array falls back to linear scan", func(t *testing.T) {
+		c := NewInCond(value.Arr("a", 1, "c"))
+		require.Nil(t, c.strSet)
+		require.True(t, c.Eval(value.New("a"), nil))
+		require.True(t, c.Eval(value.New(1), nil))
+		require.False(t, c.Eval(value.New("b"), nil))
+	})
 }
 
 func TestNotInCond(t *testing.T) {
@@ -63,6 +80,22 @@ func TestIniCond(t *testing.T) {
 	t.Run("empty array returns false", func(t *testing.T) {
 		c := NewIniCond(value.Arr())
 		require.False(t, c.Eval(value.New("test"), nil))
+	})
+
+	t.Run("all-string array uses set lookup", func(t *testing.T) {
+		c := NewIniCond(value.Arr("Alpha", "BETA"))
+		require.NotNil(t, c.strSet)
+		require.True(t, c.Eval(value.New("alpha"), nil))
+		require.True(t, c.Eval(value.New("Beta"), nil))
+		require.False(t, c.Eval(value.New("gamma"), nil))
+		require.False(t, c.Eval(value.New(1), nil))
+	})
+
+	t.Run("mixed-type array falls back to linear scan", func(t *testing.T) {
+		c := NewIniCond(value.Arr("Alpha", 1))
+		require.Nil(t, c.strSet)
+		require.True(t, c.Eval(value.New("ALPHA"), nil))
+		require.True(t, c.Eval(value.New(1), nil))
 	})
 }
 


### PR DESCRIPTION
## Summary

Optimizes `$in` / `$ini` condition evaluation for the common all-string list case by precomputing a string lookup map at condition construction time. Extension of the [PR#67](https://github.com/growthbook/growthbook-golang/pull/67)  

This keeps evaluation O(1) instead of scanning the expected array on every call. Mixed-type arrays still use the existing linear scan path.

## Details

- Adds map-backed lookup for all-string `$in` lists
- Adds map-backed lookup for ASCII all-string `$ini` lists
- Preserves strict `$in` behavior, so `"1"` does not match `1`
- Preserves existing `$ini` Unicode behavior by falling back to the previous `EqualFold` scan for non-ASCII strings
- Keeps `$nin` / `$nini` behavior unchanged through existing `NotCond` wrapping

The tradeoff is one `map[string]struct{}` allocation per optimized condition, created once when the condition is constructed / payload is parsed. The hot eval path remains zero-allocation.

## Benchmarks

```sh
go test ./internal/condition -bench 'Benchmark(InCond|IniCond)Eval' -benchmem -count=6

On Apple M1 Max, both $in and $ini stay flat across list sizes with 0 B/op and 0 allocs/op.

Approximate ranges:

$in: ~20-35 ns/op across 10 to 10,000 entries
$ini: ~45-65 ns/op across 10 to 10,000 entries - because it still checks ASCII/lowercases actual strings.
```
