### PR TITLE
Follow-up: SSE Backoff Cap

### DIFF
--- a/datasource_sse.go
+++ b/datasource_sse.go
@@ -24,11 +24,12 @@ type SseDataSource struct {
 type SseOption func(*SseDataSource)
 
 // WithSseMaxRetryInterval sets the maximum backoff interval between reconnection
-// attempts. By default the interval grows without bound; setting this caps it
-// (e.g. 30*time.Second).
+// attempts. Non-positive values keep the default cap.
 func WithSseMaxRetryInterval(d time.Duration) SseOption {
 	return func(ds *SseDataSource) {
-		ds.maxRetryInterval = d
+		if d > 0 {
+			ds.maxRetryInterval = d
+		}
 	}
 }
 
@@ -42,7 +43,9 @@ func WithSseDataSource(opts ...SseOption) ClientOption {
 	return func(c *Client) error {
 		ds := newSseDataSource(c)
 		for _, opt := range opts {
-			opt(ds)
+			if opt != nil {
+				opt(ds)
+			}
 		}
 		c.data.dataSource = ds
 		return nil

--- a/datasource_sse.go
+++ b/datasource_sse.go
@@ -12,28 +12,48 @@ import (
 )
 
 type SseDataSource struct {
-	client *Client
-	cancel context.CancelFunc
-	ready  bool
-	// retry  time.Duration
-	logger *slog.Logger
-	mu     sync.RWMutex
+	client           *Client
+	cancel           context.CancelFunc
+	ready            bool
+	maxRetryInterval time.Duration
+	logger           *slog.Logger
+	mu               sync.RWMutex
+}
+
+// SseOption configures an SseDataSource.
+type SseOption func(*SseDataSource)
+
+// WithSseMaxRetryInterval sets the maximum backoff interval between reconnection
+// attempts. By default the interval grows without bound; setting this caps it
+// (e.g. 30*time.Second).
+func WithSseMaxRetryInterval(d time.Duration) SseOption {
+	return func(ds *SseDataSource) {
+		ds.maxRetryInterval = d
+	}
 }
 
 const minbufsize = 64 * 1024
 const maxbufsize = 10 * 1024 * 1024
 
-func WithSseDataSource() ClientOption {
+// defaultMaxRetryInterval is the default cap for backoff delay between SSE reconnects.
+const defaultMaxRetryInterval = 30 * time.Second
+
+func WithSseDataSource(opts ...SseOption) ClientOption {
 	return func(c *Client) error {
-		c.data.dataSource = newSseDataSource(c)
+		ds := newSseDataSource(c)
+		for _, opt := range opts {
+			opt(ds)
+		}
+		c.data.dataSource = ds
 		return nil
 	}
 }
 
 func newSseDataSource(client *Client) *SseDataSource {
 	return &SseDataSource{
-		client: client,
-		logger: client.logger.With("source", "Growthbook SSE datasource"),
+		client:           client,
+		maxRetryInterval: defaultMaxRetryInterval,
+		logger:           client.logger.With("source", "Growthbook SSE datasource"),
 	}
 }
 
@@ -82,6 +102,9 @@ func (ds *SseDataSource) connect(ctx context.Context) error {
 	sseClient := &sse.Client{
 		HTTPClient: ds.client.data.httpClient,
 		OnRetry:    ds.onRetry(ctx),
+		Backoff: sse.Backoff{
+			MaxInterval: ds.maxRetryInterval,
+		},
 	}
 	sseConn := sseClient.NewConnection(req)
 	buf := make([]byte, minbufsize)

--- a/datasource_sse_test.go
+++ b/datasource_sse_test.go
@@ -170,6 +170,42 @@ func TestSseDataSource(t *testing.T) {
 	})
 }
 
+func TestSseDataSourceRetryInterval(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("default max retry interval", func(t *testing.T) {
+		client, err := NewClient(ctx, WithSseDataSource())
+		require.Nil(t, err)
+		ds, ok := client.data.dataSource.(*SseDataSource)
+		require.True(t, ok)
+		require.Equal(t, defaultMaxRetryInterval, ds.maxRetryInterval)
+	})
+
+	t.Run("custom max retry interval", func(t *testing.T) {
+		client, err := NewClient(ctx, WithSseDataSource(WithSseMaxRetryInterval(time.Minute)))
+		require.Nil(t, err)
+		ds, ok := client.data.dataSource.(*SseDataSource)
+		require.True(t, ok)
+		require.Equal(t, time.Minute, ds.maxRetryInterval)
+	})
+
+	t.Run("non-positive max retry interval keeps default", func(t *testing.T) {
+		client, err := NewClient(ctx, WithSseDataSource(WithSseMaxRetryInterval(0)))
+		require.Nil(t, err)
+		ds, ok := client.data.dataSource.(*SseDataSource)
+		require.True(t, ok)
+		require.Equal(t, defaultMaxRetryInterval, ds.maxRetryInterval)
+	})
+
+	t.Run("nil option is ignored", func(t *testing.T) {
+		client, err := NewClient(ctx, WithSseDataSource(nil))
+		require.Nil(t, err)
+		ds, ok := client.data.dataSource.(*SseDataSource)
+		require.True(t, ok)
+		require.Equal(t, defaultMaxRetryInterval, ds.maxRetryInterval)
+	})
+}
+
 type sseTestServer struct {
 	http     *httptest.Server
 	ssecount atomic.Int32


### PR DESCRIPTION
### Features and Changes

This follow-up adds on top of [PR #64](https://github.com/growthbook/growthbook-golang/pull/64):

* WithSseMaxRetryInterval(0) or negative values keep the safe default instead of reintroducing unbounded backoff.
* WithSseDataSource(nil) is ignored safely.
* Added tests for default/custom/non-positive/nil option behavior.
* Kept WithSseDataSource() source-compatible and non-breaking.