### PR TITLE
feat: add FeaturesRefreshHandler for refresh lifecycle observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,45 @@ To stop background updates, call `client.Close()` on the main client instance wh
 
 ---
 
+### Feature Refresh Handler
+
+To observe the feature refresh lifecycle, set a handler with `WithFeaturesRefreshHandler`. It is invoked after every refresh attempt — from the polling and SSE datasources, from a manual `RefreshFeatures` call, and on the initial load. This is useful for emitting metrics on failures, tracking data freshness, or invalidating derived state when features change.
+
+```go
+client, err := gb.NewClient(
+    context.Background(),
+    gb.WithClientKey("sdk-XXXX"),
+    gb.WithPollDataSource(60*time.Second),
+    gb.WithFeaturesRefreshHandler(func(ctx context.Context, r gb.RefreshResult) {
+        switch {
+        case r.Error != nil:
+            // Refresh failed — emit a metric / alert / fall back.
+            metrics.Inc("growthbook.refresh.error")
+        case r.NotModified:
+            // Server confirmed features are still current (HTTP 304).
+            metrics.SetLastValidated(r.DateUpdated)
+        case r.Updated:
+            // New feature definitions were applied — invalidate derived caches.
+            myCache.Invalidate()
+        }
+    }),
+)
+```
+
+Exactly one of the following describes each event:
+
+| Field | Meaning |
+|-------|---------|
+| `Updated` | New feature definitions were fetched and applied (`false` if refused as older than current data) |
+| `NotModified` | Server returned HTTP 304 — cached features confirmed current, no payload sent |
+| `Error` | The refresh attempt failed (network error, non-2xx/304 status, or decode/decrypt failure) |
+| `Source` | Which mechanism produced the event: `RefreshSourcePoll`, `RefreshSourceSSE`, or `RefreshSourceManual` |
+| `DateUpdated` | `dateUpdated` of the applied payload, or the currently stored value on a 304 |
+
+The handler is shared with child clients — register it once on the root client. Implementations should return quickly and must not block the datasource; any panics are recovered and logged.
+
+---
+
 ### Tracking
 
 #### Built-in GrowthBook Tracking Plugin

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ client, err := gb.NewClient(
             // Refresh failed — emit a metric / alert / fall back.
             metrics.Inc("growthbook.refresh.error")
         case r.NotModified:
-            // Server confirmed features are still current (HTTP 304).
+            // Cached features confirmed still current (HTTP 304, or a fetched
+            // response older than current data was refused).
             metrics.SetLastValidated(r.DateUpdated)
         case r.Updated:
             // New feature definitions were applied — invalidate derived caches.
@@ -126,15 +127,15 @@ client, err := gb.NewClient(
 )
 ```
 
-Exactly one of the following describes each event:
+Exactly one of `Updated`, `NotModified`, or `Error` is set on each event; `Source` and `DateUpdated` always accompany it:
 
 | Field | Meaning |
 |-------|---------|
-| `Updated` | New feature definitions were fetched and applied (`false` if refused as older than current data) |
-| `NotModified` | Server returned HTTP 304 — cached features confirmed current, no payload sent |
+| `Updated` | New feature definitions were fetched and applied |
+| `NotModified` | Cached features confirmed still current — either HTTP 304, or a fetched response older than current data was refused |
 | `Error` | The refresh attempt failed (network error, non-2xx/304 status, or decode/decrypt failure) |
 | `Source` | Which mechanism produced the event: `RefreshSourcePoll`, `RefreshSourceSSE`, or `RefreshSourceManual` |
-| `DateUpdated` | `dateUpdated` of the applied payload, or the currently stored value on a 304 |
+| `DateUpdated` | `dateUpdated` of the applied payload, or the currently stored value when nothing was applied |
 
 The handler is shared with child clients — register it once on the root client. Implementations should return quickly and must not block the datasource; any panics are recovered and logged.
 

--- a/client.go
+++ b/client.go
@@ -146,21 +146,20 @@ func (client *Client) SetEncryptedJSONFeatures(encryptedJSON string) error {
 	return client.SetJSONFeatures(featuresJSON)
 }
 
-// UpdateFromApiResponse updates shared data from Growthbook API response
-func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
+func (client *Client) applyApiResponse(resp *FeatureApiResponse) (bool, error) {
 	dataUpdated := client.data.getDateUpdated()
 	apiUpdated := resp.DateUpdated
 	if apiUpdated.Before(dataUpdated) {
 		client.logger.Warn("Api response is older then current data, refuse to update",
 			"dataUpdated", dataUpdated, "apiUdpated", apiUpdated)
-		return nil
+		return false, nil
 	}
 	var features FeatureMap
 	var err error
 	if resp.EncryptedFeatures != "" {
 		features, err = client.DecryptFeatures(resp.EncryptedFeatures)
 		if err != nil {
-			return err
+			return false, err
 		}
 	} else {
 		features = resp.Features
@@ -171,7 +170,21 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
-	return nil
+	return true, nil
+}
+
+func (client *Client) applyApiResponseJSON(respJSON string) (bool, error) {
+	var resp FeatureApiResponse
+	if err := json.Unmarshal([]byte(respJSON), &resp); err != nil {
+		return false, err
+	}
+	return client.applyApiResponse(&resp)
+}
+
+// UpdateFromApiResponse updates shared data from Growthbook API response
+func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
+	_, err := client.applyApiResponse(resp)
+	return err
 }
 
 func (client *Client) DecryptFeatures(encrypted string) (FeatureMap, error) {
@@ -188,12 +201,8 @@ func (client *Client) DecryptFeatures(encrypted string) (FeatureMap, error) {
 }
 
 func (client *Client) UpdateFromApiResponseJSON(respJSON string) error {
-	var resp FeatureApiResponse
-	err := json.Unmarshal([]byte(respJSON), &resp)
-	if err != nil {
-		return err
-	}
-	return client.UpdateFromApiResponse(&resp)
+	_, err := client.applyApiResponseJSON(respJSON)
+	return err
 }
 
 // RefreshFeatures immediately fetches the latest features from the GrowthBook API
@@ -202,12 +211,19 @@ func (client *Client) UpdateFromApiResponseJSON(respJSON string) error {
 func (client *Client) RefreshFeatures(ctx context.Context) error {
 	resp, err := client.CallFeatureApi(ctx, "")
 	if err != nil {
+		client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceManual, Error: err})
 		return err
 	}
 	if resp.Features == nil && resp.EncryptedFeatures == "" {
 		return nil
 	}
-	return client.UpdateFromApiResponse(resp)
+	updated, err := client.applyApiResponse(resp)
+	if err != nil {
+		client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceManual, Error: err})
+		return err
+	}
+	client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceManual, Updated: updated, DateUpdated: resp.DateUpdated})
+	return nil
 }
 
 // EvalFeature evaluates feature based on attributes and features map

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
@@ -173,12 +174,13 @@ func (client *Client) applyApiResponse(resp *FeatureApiResponse) (bool, error) {
 	return true, nil
 }
 
-func (client *Client) applyApiResponseJSON(respJSON string) (bool, error) {
+func (client *Client) applyApiResponseJSON(respJSON string) (bool, time.Time, error) {
 	var resp FeatureApiResponse
 	if err := json.Unmarshal([]byte(respJSON), &resp); err != nil {
-		return false, err
+		return false, time.Time{}, err
 	}
-	return client.applyApiResponse(&resp)
+	updated, err := client.applyApiResponse(&resp)
+	return updated, resp.DateUpdated, err
 }
 
 // UpdateFromApiResponse updates shared data from Growthbook API response
@@ -201,7 +203,7 @@ func (client *Client) DecryptFeatures(encrypted string) (FeatureMap, error) {
 }
 
 func (client *Client) UpdateFromApiResponseJSON(respJSON string) error {
-	_, err := client.applyApiResponseJSON(respJSON)
+	_, _, err := client.applyApiResponseJSON(respJSON)
 	return err
 }
 
@@ -222,7 +224,11 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 		client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceManual, Error: err})
 		return err
 	}
-	client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceManual, Updated: updated, DateUpdated: resp.DateUpdated})
+	if updated {
+		client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceManual, Updated: true, DateUpdated: resp.DateUpdated})
+	} else {
+		client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceManual, NotModified: true, DateUpdated: resp.DateUpdated})
+	}
 	return nil
 }
 

--- a/client_data.go
+++ b/client_data.go
@@ -9,20 +9,21 @@ import (
 )
 
 type data struct {
-	mu            sync.RWMutex
-	features      FeatureMap
-	savedGroups   condition.SavedGroups
-	dateUpdated   time.Time
-	apiHost       string
-	clientKey     string
-	decryptionKey string
-	httpClient    *http.Client
-	dataSource    DataSource
-	dsStarted     bool
-	dsStartWait   chan struct{}
-	dsStartErr    error
-	plugins       []Plugin
-	subscribers   subscriberRegistry
+	mu             sync.RWMutex
+	features       FeatureMap
+	savedGroups    condition.SavedGroups
+	dateUpdated    time.Time
+	apiHost        string
+	clientKey      string
+	decryptionKey  string
+	httpClient     *http.Client
+	dataSource     DataSource
+	dsStarted      bool
+	dsStartWait    chan struct{}
+	dsStartErr     error
+	plugins        []Plugin
+	subscribers    subscriberRegistry
+	refreshHandler FeaturesRefreshHandler
 }
 
 func newData() *data {
@@ -97,4 +98,10 @@ func (d *data) decrypt(encrypted string) (string, error) {
 		return "", ErrNoDecryptionKey
 	}
 	return decrypt(encrypted, key)
+}
+
+func (d *data) getRefreshHandler() FeaturesRefreshHandler {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.refreshHandler
 }

--- a/client_option.go
+++ b/client_option.go
@@ -273,3 +273,12 @@ func (c *Client) cloneWith(opts ...ClientOption) (*Client, error) {
 	}
 	return clone, nil
 }
+
+// WithFeaturesRefreshHandler sets a handler invoked after each feature refresh
+// attempt by a background datasource. Shared across child clients.
+func WithFeaturesRefreshHandler(h FeaturesRefreshHandler) ClientOption {
+	return func(c *Client) error {
+		c.data.refreshHandler = h
+		return nil
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -257,6 +257,32 @@ func TestRefreshFeatures(t *testing.T) {
 			return r.Error != nil && r.Source == RefreshSourceManual
 		}), "expected a manual Error event")
 	})
+
+	t.Run("Refusing a stale response fires NotModified", func(t *testing.T) {
+		fresh := []byte(`{"features":{"foo":{"defaultValue":"fresh"}},"experiments":[],"dateUpdated":"2030-01-01T00:00:00Z"}`)
+		stale := []byte(`{"features":{"foo":{"defaultValue":"stale"}},"experiments":[],"dateUpdated":"2000-01-01T00:00:00Z"}`)
+		ts := startVersionedServer(fresh, stale)
+		defer ts.http.Close()
+		var c refreshCollector
+		client, err := NewClient(ctx,
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(c.handler()),
+		)
+		require.Nil(t, err)
+
+		// First refresh applies the fresh payload (dateUpdated 2030).
+		require.Nil(t, client.RefreshFeatures(ctx))
+		// Second refresh returns an older payload (2000) -> refused, reported
+		// as NotModified rather than Updated, and the stale value is ignored.
+		require.Nil(t, client.RefreshFeatures(ctx))
+
+		require.True(t, c.has(func(r RefreshResult) bool {
+			return r.NotModified && r.Source == RefreshSourceManual
+		}), "expected a manual NotModified event for the stale response")
+		require.Equal(t, FeatureMap{"foo": &Feature{DefaultValue: "fresh"}}, client.Features())
+	})
 }
 
 func TestClientExperimentTracking(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -221,6 +221,42 @@ func TestRefreshFeatures(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, client.Features())
 	})
+
+	t.Run("Fires Updated event on manual refresh", func(t *testing.T) {
+		ts := startServer(http.StatusOK, featuresJSON)
+		defer ts.http.Close()
+		var c refreshCollector
+		client, err := NewClient(ctx,
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(c.handler()),
+		)
+		require.Nil(t, err)
+		require.Nil(t, client.RefreshFeatures(ctx))
+
+		require.True(t, c.has(func(r RefreshResult) bool {
+			return r.Updated && r.Source == RefreshSourceManual
+		}), "expected a manual Updated event")
+	})
+
+	t.Run("Fires Error event on failed manual refresh", func(t *testing.T) {
+		ts := startServer(http.StatusNotFound, []byte(""))
+		defer ts.http.Close()
+		var c refreshCollector
+		client, err := NewClient(ctx,
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(c.handler()),
+		)
+		require.Nil(t, err)
+		require.Error(t, client.RefreshFeatures(ctx))
+
+		require.True(t, c.has(func(r RefreshResult) bool {
+			return r.Error != nil && r.Source == RefreshSourceManual
+		}), "expected a manual Error event")
+	})
 }
 
 func TestClientExperimentTracking(t *testing.T) {

--- a/datasource_poll.go
+++ b/datasource_poll.go
@@ -100,6 +100,11 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 
 	resp, err := ds.client.CallFeatureApi(ctx, etag)
 	if err != nil {
+		ds.client.notifyRefresh(
+			ctx,
+			RefreshResult{
+				Source: RefreshSourcePoll,
+				Error:  err})
 		return err
 	}
 
@@ -109,14 +114,36 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 		ds.mu.Unlock()
 	}
 
+	if resp.Status == 304 {
+		ds.client.notifyRefresh(
+			ctx,
+			RefreshResult{
+				Source:      RefreshSourcePoll,
+				NotModified: true,
+				DateUpdated: ds.client.data.getDateUpdated()})
+		return nil
+	}
+
 	if resp.Features == nil {
 		return nil
 	}
 
-	err = ds.client.UpdateFromApiResponse(resp)
+	updated, err := ds.client.applyApiResponse(resp)
 	if err != nil {
+		ds.client.notifyRefresh(
+			ctx,
+			RefreshResult{
+				Source: RefreshSourcePoll,
+				Error:  err})
+
 		return err
 	}
 
+	ds.client.notifyRefresh(
+		ctx,
+		RefreshResult{
+			Source:      RefreshSourcePoll,
+			Updated:     updated,
+			DateUpdated: resp.DateUpdated})
 	return nil
 }

--- a/datasource_poll.go
+++ b/datasource_poll.go
@@ -124,7 +124,7 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 		return nil
 	}
 
-	if resp.Features == nil {
+	if resp.Features == nil && resp.EncryptedFeatures == "" {
 		return nil
 	}
 
@@ -139,11 +139,21 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 		return err
 	}
 
-	ds.client.notifyRefresh(
-		ctx,
-		RefreshResult{
-			Source:      RefreshSourcePoll,
-			Updated:     updated,
-			DateUpdated: resp.DateUpdated})
+	if updated {
+		ds.client.notifyRefresh(
+			ctx,
+			RefreshResult{
+				Source:      RefreshSourcePoll,
+				Updated:     updated,
+				DateUpdated: resp.DateUpdated})
+	} else {
+		ds.client.notifyRefresh(
+			ctx,
+			RefreshResult{
+				Source:      RefreshSourcePoll,
+				NotModified: true,
+				DateUpdated: resp.DateUpdated})
+	}
+
 	return nil
 }

--- a/datasource_poll_test.go
+++ b/datasource_poll_test.go
@@ -190,6 +190,143 @@ func TestPollingDataSource(t *testing.T) {
 		err = client.Close()
 		require.Nil(t, err)
 	})
+
+	t.Run("304 fires NotModified", func(t *testing.T) {
+		ts := startEtagServer(featuresJSON)
+		defer ts.http.Close()
+		logger, _ := testLogger(slog.LevelError, t)
+		var c refreshCollector
+		client, err := NewClient(ctx,
+			WithLogger(logger),
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(c.handler()),
+			WithPollDataSource(10*time.Millisecond),
+		)
+
+		require.Nil(t, err)
+		require.Nil(t, client.EnsureLoaded(ctx))
+		time.Sleep(100 * time.Millisecond)
+		require.Nil(t, client.Close())
+		var got bool
+		for _, r := range c.all() {
+			if r.NotModified {
+				got = true
+			}
+		}
+		require.True(t, got, "expected at least one NotModified event")
+	})
+
+	t.Run("200 fires Updated", func(t *testing.T) {
+		ts := startServer(http.StatusOK, featuresJSON)
+		defer ts.http.Close()
+		logger, _ := testLogger(slog.LevelError, t)
+		var c refreshCollector
+		client, err := NewClient(ctx,
+			WithLogger(logger),
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(c.handler()),
+			WithPollDataSource(10*time.Millisecond),
+		)
+
+		require.Nil(t, err)
+		require.Nil(t, client.EnsureLoaded(ctx))
+		time.Sleep(100 * time.Millisecond)
+		require.Nil(t, client.Close())
+		var got bool
+		for _, r := range c.all() {
+			if r.Updated {
+				got = true
+			}
+		}
+		require.True(t, got, "expected at least one Updated event")
+	})
+
+	t.Run("error fires Error", func(t *testing.T) {
+		ts := startServer(http.StatusNotFound, []byte(""))
+		defer ts.http.Close()
+		logger, _ := testLogger(slog.LevelError, t)
+		var c refreshCollector
+		client, err := NewClient(ctx,
+			WithLogger(logger),
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(c.handler()),
+			WithPollDataSource(10*time.Millisecond),
+		)
+
+		require.Nil(t, err)
+		require.NotNil(t, client.EnsureLoaded(ctx))
+		time.Sleep(100 * time.Millisecond)
+		require.Nil(t, client.Close())
+		var got bool
+		for _, r := range c.all() {
+			if r.Error != nil {
+				got = true
+			}
+		}
+		require.True(t, got, "expected at least one Error event")
+	})
+
+	t.Run("panicking handler does not break polling", func(t *testing.T) {
+		ts := startServer(http.StatusOK, featuresJSON)
+		defer ts.http.Close()
+		panicHandler := func(ctx context.Context, r RefreshResult) { panic("boom") }
+		logger, _ := testLogger(slog.LevelError, t)
+		client, _ := NewClient(ctx,
+			WithLogger(logger),
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(panicHandler),
+			WithPollDataSource(10*time.Millisecond),
+		)
+
+		require.Nil(t, client.EnsureLoaded(ctx))
+		time.Sleep(50 * time.Millisecond)
+		n := ts.count.Load()
+		time.Sleep(50 * time.Millisecond)
+		require.Greater(t, ts.count.Load(), n)
+		require.Nil(t, client.Close())
+	})
+}
+
+// refreshCollector safely gathers RefreshResult events produced by the
+// datasource goroutine so the test goroutine can inspect them without a race.
+type refreshCollector struct {
+	mu      sync.Mutex
+	results []RefreshResult
+}
+
+// handler returns a FeaturesRefreshHandler that appends every event under lock.
+func (c *refreshCollector) handler() FeaturesRefreshHandler {
+	return func(ctx context.Context, r RefreshResult) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.results = append(c.results, r)
+	}
+}
+
+// all returns a copy of the collected events, so the caller can iterate
+// without holding the lock (and without racing the datasource goroutine).
+func (c *refreshCollector) all() []RefreshResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]RefreshResult(nil), c.results...)
+}
+
+// has reports whether any collected event matches pred.
+func (c *refreshCollector) has(pred func(RefreshResult) bool) bool {
+	for _, r := range c.all() {
+		if pred(r) {
+			return true
+		}
+	}
+	return false
 }
 
 type testServer struct {

--- a/datasource_poll_test.go
+++ b/datasource_poll_test.go
@@ -361,3 +361,19 @@ func startEtagServer(response []byte) *testServer {
 	}))
 	return &ts
 }
+
+// startVersionedServer returns each response in order on successive requests;
+// once the list is exhausted it keeps returning the last one. Useful for
+// exercising ordered payloads (e.g. a fresh response followed by a stale one).
+func startVersionedServer(responses ...[]byte) *testServer {
+	var ts testServer
+	ts.http = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		i := int(ts.count.Add(1)) - 1
+		if i >= len(responses) {
+			i = len(responses) - 1
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(responses[i])
+	}))
+	return &ts
+}

--- a/datasource_sse.go
+++ b/datasource_sse.go
@@ -107,13 +107,18 @@ func (ds *SseDataSource) processEvent(ctx context.Context, event sse.Event) {
 		return
 	}
 	ds.logger.Info("Updating features")
-	updated, err := ds.client.applyApiResponseJSON(event.Data)
+	updated, dateUpdated, err := ds.client.applyApiResponseJSON(event.Data)
 	if err != nil {
 		ds.logger.Error("Error updating features", "error", err)
 		ds.client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceSSE, Error: err})
 		return
 	}
-	ds.client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceSSE, Updated: updated})
+
+	if updated {
+		ds.client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceSSE, Updated: true, DateUpdated: dateUpdated})
+	} else {
+		ds.client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceSSE, NotModified: true, DateUpdated: dateUpdated})
+	}
 }
 
 func (ds *SseDataSource) loadData(ctx context.Context) error {
@@ -139,7 +144,7 @@ func (ds *SseDataSource) loadData(ctx context.Context) error {
 		return err
 	}
 
-	if resp.Features == nil {
+	if resp.Features == nil && resp.EncryptedFeatures == "" {
 		return nil
 	}
 
@@ -154,12 +159,11 @@ func (ds *SseDataSource) loadData(ctx context.Context) error {
 		return err
 	}
 
-	ds.client.notifyRefresh(
-		ctx,
-		RefreshResult{
-			Source:      RefreshSourceSSE,
-			Updated:     updated,
-			DateUpdated: resp.DateUpdated})
+	if updated {
+		ds.client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceSSE, Updated: true, DateUpdated: resp.DateUpdated})
+	} else {
+		ds.client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceSSE, NotModified: true, DateUpdated: resp.DateUpdated})
+	}
 	return nil
 }
 

--- a/datasource_sse.go
+++ b/datasource_sse.go
@@ -87,7 +87,7 @@ func (ds *SseDataSource) connect(ctx context.Context) error {
 	buf := make([]byte, minbufsize)
 	sseConn.Buffer(buf, maxbufsize)
 	sseConn.SubscribeEvent("features", func(event sse.Event) {
-		ds.processEvent(event)
+		ds.processEvent(ctx, event)
 	})
 	sseConn.Connect()
 	return nil
@@ -102,36 +102,64 @@ func (ds *SseDataSource) onRetry(ctx context.Context) func(err error, delay time
 	}
 }
 
-func (ds *SseDataSource) processEvent(event sse.Event) {
+func (ds *SseDataSource) processEvent(ctx context.Context, event sse.Event) {
 	if event.Data == "" {
 		return
 	}
 	ds.logger.Info("Updating features")
-	err := ds.client.UpdateFromApiResponseJSON(event.Data)
+	updated, err := ds.client.applyApiResponseJSON(event.Data)
 	if err != nil {
 		ds.logger.Error("Error updating features", "error", err)
+		ds.client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceSSE, Error: err})
+		return
 	}
+	ds.client.notifyRefresh(ctx, RefreshResult{Source: RefreshSourceSSE, Updated: updated})
 }
 
 func (ds *SseDataSource) loadData(ctx context.Context) error {
 	resp, err := ds.client.CallFeatureApi(ctx, "")
 	if err != nil {
+		ds.client.notifyRefresh(
+			ctx,
+			RefreshResult{
+				Source: RefreshSourceSSE,
+				Error:  err,
+			})
 		return err
 	}
 
 	if !resp.SseSupport {
-		return fmt.Errorf("sse is not supported")
+		err := fmt.Errorf("sse is not supported")
+		ds.client.notifyRefresh(
+			ctx,
+			RefreshResult{
+				Source: RefreshSourceSSE,
+				Error:  err,
+			})
+		return err
 	}
 
 	if resp.Features == nil {
 		return nil
 	}
 
-	err = ds.client.UpdateFromApiResponse(resp)
+	updated, err := ds.client.applyApiResponse(resp)
 	if err != nil {
+		ds.client.notifyRefresh(
+			ctx,
+			RefreshResult{
+				Source: RefreshSourceSSE,
+				Error:  err,
+			})
 		return err
 	}
 
+	ds.client.notifyRefresh(
+		ctx,
+		RefreshResult{
+			Source:      RefreshSourceSSE,
+			Updated:     updated,
+			DateUpdated: resp.DateUpdated})
 	return nil
 }
 

--- a/datasource_sse_test.go
+++ b/datasource_sse_test.go
@@ -168,6 +168,58 @@ func TestSseDataSource(t *testing.T) {
 			ts.http.Close()
 		}
 	})
+
+	t.Run("Fires Updated events for initial load and streamed update", func(t *testing.T) {
+		ts := startSseServer(featuresJSON, sseResponse(features2JSON, 10*time.Millisecond, 0))
+		defer ts.http.Close()
+		logger, _ := testLogger(slog.LevelWarn, t)
+		var c refreshCollector
+		client, err := NewClient(ctx,
+			WithLogger(logger),
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(c.handler()),
+			WithSseDataSource(),
+		)
+		require.Nil(t, err)
+		require.Nil(t, client.EnsureLoaded(ctx))
+		time.Sleep(100 * time.Millisecond) // let the stream deliver the features event
+		require.Nil(t, client.Close())
+
+		// One Updated event from the initial load (loadData), one from the
+		// streamed features event (processEvent).
+		var updated int
+		for _, r := range c.all() {
+			if r.Updated && r.Source == RefreshSourceSSE {
+				updated++
+			}
+		}
+		require.GreaterOrEqual(t, updated, 2, "expected Updated events from both initial load and stream")
+	})
+
+	t.Run("Fires Error event when initial load fails", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+		logger, _ := testLogger(slog.LevelError, t)
+		var c refreshCollector
+		client, err := NewClient(ctx,
+			WithLogger(logger),
+			WithHttpClient(ts.Client()),
+			WithApiHost(ts.URL),
+			WithClientKey("somekey"),
+			WithFeaturesRefreshHandler(c.handler()),
+			WithSseDataSource(),
+		)
+		require.Nil(t, err)
+		require.Error(t, client.EnsureLoaded(ctx))
+
+		require.True(t, c.has(func(r RefreshResult) bool {
+			return r.Error != nil && r.Source == RefreshSourceSSE
+		}), "expected an SSE Error event")
+	})
 }
 
 type sseTestServer struct {

--- a/refresh.go
+++ b/refresh.go
@@ -24,10 +24,12 @@ type RefreshResult struct {
 	// or a manual RefreshFeatures call.
 	Source RefreshSource
 	// Updated is true when new feature definitions were fetched and applied.
-	// It is false when the response was refused as older than current data.
+	// A fetched response that was refused as older than current data is
+	// reported as NotModified, not Updated.
 	Updated bool
-	// NotModified is true when the server returned HTTP 304, confirming the
-	// cached features are still valid without sending a new payload.
+	// NotModified is true when the cached features were confirmed still current
+	// without being replaced - either the server returned HTTP 304, or a
+	// fetched response older than current data was refused.
 	NotModified bool
 	// Error is non-nil when the refresh attempt failed (network error,
 	// non-2xx/304 status, or decode/decrypt failure).

--- a/refresh.go
+++ b/refresh.go
@@ -1,0 +1,63 @@
+package growthbook
+
+import (
+	"context"
+	"time"
+)
+
+// RefreshSource identifies which mechanism produced a refresh event.
+type RefreshSource string
+
+const (
+	RefreshSourcePoll   RefreshSource = "poll"
+	RefreshSourceSSE    RefreshSource = "sse"
+	RefreshSourceManual RefreshSource = "manual"
+)
+
+// RefreshResult describes the outcome of a single feature refresh attempt.
+// Exactly one of Updated, NotModified, or Error describes the outcome:
+// Updated when new definitions were applied, NotModified when the server
+// confirmed the cached features are still current (HTTP 304), and Error
+// when the attempt failed.
+type RefreshResult struct {
+	// Source identifies which mechanism produced the event: polling, SSE,
+	// or a manual RefreshFeatures call.
+	Source RefreshSource
+	// Updated is true when new feature definitions were fetched and applied.
+	// It is false when the response was refused as older than current data.
+	Updated bool
+	// NotModified is true when the server returned HTTP 304, confirming the
+	// cached features are still valid without sending a new payload.
+	NotModified bool
+	// Error is non-nil when the refresh attempt failed (network error,
+	// non-2xx/304 status, or decode/decrypt failure).
+	Error error
+	// DateUpdated is the dateUpdated of the applied payload, or the currently
+	// stored value on a 304. It is the zero time when Error is set.
+	DateUpdated time.Time
+}
+
+// FeaturesRefreshHandler is invoked after every feature refresh attempt made
+// by a background datasource (polling or SSE) or a manual RefreshFeatures
+// call. It also fires on the initial load. Implementations should return
+// quickly and must not block the datasource; panics are recovered and logged.
+// The handler is shared across child clients created via With* methods -
+// register it once on the root client.
+type FeaturesRefreshHandler func(ctx context.Context, result RefreshResult)
+
+// notifyRefresh safely invokes the configured handler. It reads the handler
+// under the lock, then invokes it WITHOUT holding the lock (user code may call
+// back into the client), recovering from panics so a handler never breaks the
+// datasource loop.
+func (client *Client) notifyRefresh(ctx context.Context, r RefreshResult) {
+	h := client.data.getRefreshHandler()
+	if h == nil {
+		return
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			client.logger.ErrorContext(ctx, "Refresh handler panicked", "error", rec)
+		}
+	}()
+	h(ctx, r)
+}


### PR DESCRIPTION
## What

Adds `WithFeaturesRefreshHandler` — a callback fired after every feature refresh attempt: polling, SSE, manual `RefreshFeatures`, and the initial load.

## Why

Refresh failures were only logged to slog — no way to alert on errors, track freshness, or invalidate derived state on change. Parity with Kotlin/Flutter `refreshHandler`, as a server-side observability hook (readiness stays with `EnsureLoaded`).

## API

```go
gb.WithFeaturesRefreshHandler(func(ctx context.Context, r gb.RefreshResult) {
    switch {
    case r.Error != nil:   // refresh failed
    case r.NotModified:    // unchanged: HTTP 304, or a stale response refused
    case r.Updated:        // new features applied
    }
})
```

Exactly one of `Updated` / `NotModified` / `Error` is set per event; `Source` identifies `poll`/`SSE`/`manual`.

## Notes

- Handler lives on the shared `data` struct, invoked outside the lock with panic recovery. Shared across child clients, not per-child.
- Split `applyApiResponse`/`applyApiResponseJSON` out of the `UpdateFromApiResponse*` wrappers to report the outcome + `dateUpdated`. Public API unchanged.

## Fixes

- Poll/SSE now apply encrypted-only responses (`features: null` + `encryptedFeatures`) — the `Features == nil` guard previously skipped decryption.
- SSE streamed updates now populate `DateUpdated` (was zero).

## Tests

Poll (304 / updated / error / panicking handler), SSE (initial + streamed / error), manual (updated / error / stale→NotModified) — all under `-race`.