### PR TITLE
ci: replace macOS runner with Linux in build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         go-version: [ '1.21', '1.23' ]
     
     steps:


### PR DESCRIPTION
Switch the cross-platform CI workflow from macOS to Linux: the build matrix now runs on ubuntu-latest instead of macos-latest