### PR TITLE
feat: add WithForcedFeatures for local feature value overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Add `WithForcedFeatures` to force feature values locally (source `override`),
+  available on the root client and merged over the parent on child clients.
+
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
 - **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`

--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ To stop background updates, call `client.Close()` on the main client instance wh
 
 ---
 
+### Forced Feature Values
+
+`WithForcedFeatures` forces specific features to evaluate to a given value,
+bypassing rules and experiments. The result reports the `override` source and
+is excluded from feature-usage reporting. Useful for QA and testing.
+
+```go
+client, _ := gb.NewClient(ctx,
+    gb.WithForcedFeatures(gb.ForcedFeaturesMap{"my-feature": true}),
+)
+```
+
+On a child client the forced features are **merged** over the parent's, with the
+child's keys taking precedence:
+
+```go
+child, _ := client.WithForcedFeatures(gb.ForcedFeaturesMap{"other-feature": 42})
+```
+
+A supplied `ForcedFeaturesMap` must not be mutated concurrently while the client
+is in use.
+
+---
+
 ### Tracking
 
 #### Built-in GrowthBook Tracking Plugin

--- a/client.go
+++ b/client.go
@@ -24,6 +24,7 @@ type Client struct {
 	attributes           value.ObjValue
 	url                  *url.URL
 	forcedVariations     ForcedVariationsMap
+	forcedFeatures       ForcedFeaturesMap
 	groups               map[string]bool
 	qaMode               bool
 	experimentCallback   ExperimentCallback
@@ -48,6 +49,11 @@ type Client struct {
 
 // ForcedVariationsMap is a map that forces an Experiment to always assign a specific variation. Useful for QA.
 type ForcedVariationsMap map[string]int
+
+// ForcedFeaturesMap is a map from feature key to a forced value. When a feature
+// key is present, EvalFeature short-circuits and returns the forced value with
+// source "override", skipping rules and experiments. Useful for QA and testing.
+type ForcedFeaturesMap map[string]FeatureValue
 
 // ExperimentCallback function that is executed every time a user is included
 // in an Experiment, with the user context the evaluation ran with.

--- a/client_option.go
+++ b/client_option.go
@@ -278,9 +278,19 @@ func (c *Client) WithForcedVariations(forcedVariations ForcedVariationsMap) (*Cl
 	return c.cloneWith(WithForcedVariations(forcedVariations))
 }
 
-// WithForcedFeatures creates child client with updated forced feature values.
+// WithForcedFeatures creates a child client whose forced feature values are
+// merged over the parent's (child keys take precedence). The supplied map must
+// not be mutated concurrently.
 func (c *Client) WithForcedFeatures(forcedFeatures ForcedFeaturesMap) (*Client, error) {
-	return c.cloneWith(WithForcedFeatures(forcedFeatures))
+	// Merge into the parent's forced features (child entries take precedence),
+	// mirroring how the JS SDK combines global and user-scoped maps. The parent
+	// is left untouched.
+	merged := maps.Clone(c.forcedFeatures)
+	if merged == nil {
+		merged = make(ForcedFeaturesMap, len(forcedFeatures))
+	}
+	maps.Copy(merged, forcedFeatures)
+	return c.cloneWith(WithForcedFeatures(merged))
 }
 
 // WithGroups creates child client with updated legacy group membership.

--- a/client_option.go
+++ b/client_option.go
@@ -101,6 +101,15 @@ func WithForcedVariations(forcedVariations ForcedVariationsMap) ClientOption {
 	}
 }
 
+// WithForcedFeatures forces specific features to always evaluate to a given value,
+// bypassing rules and experiments. The result uses the "override" source. Useful for QA.
+func WithForcedFeatures(forcedFeatures ForcedFeaturesMap) ClientOption {
+	return func(c *Client) error {
+		c.forcedFeatures = forcedFeatures
+		return nil
+	}
+}
+
 // WithGroups sets legacy group membership for the user, used by experiments that
 // declare a `groups` array. Distinct from saved groups, which power $inGroup
 // conditions on `condition`.
@@ -267,6 +276,11 @@ func (c *Client) WithUrl(rawUrl string) (*Client, error) {
 // WithForcedVariations creates child client with updated forced variations.
 func (c *Client) WithForcedVariations(forcedVariations ForcedVariationsMap) (*Client, error) {
 	return c.cloneWith(WithForcedVariations(forcedVariations))
+}
+
+// WithForcedFeatures creates child client with updated forced feature values.
+func (c *Client) WithForcedFeatures(forcedFeatures ForcedFeaturesMap) (*Client, error) {
+	return c.cloneWith(WithForcedFeatures(forcedFeatures))
 }
 
 // WithGroups creates child client with updated legacy group membership.

--- a/evaluator.go
+++ b/evaluator.go
@@ -36,6 +36,14 @@ func (e *evaluator) doEvalFeature(key string) *FeatureResult {
 	e.evaluated.push(key)
 	defer e.evaluated.pop()
 
+	// Global override: a forced feature value short-circuits evaluation,
+	// returning the forced value with the "override" source. Works even for
+	// keys not present in the feature map.
+	if v, ok := e.client.forcedFeatures[key]; ok {
+		e.client.logger.DebugContext(e.ctx, "Global override for forced feature", "key", key)
+		return getFeatureResult(v, OverrideResultSource, "", nil, nil)
+	}
+
 	feature := e.features[key]
 	if feature == nil {
 		return getFeatureResult(nil, UnknownFeatureResultSource, "", nil, nil)

--- a/feature_test.go
+++ b/feature_test.go
@@ -514,6 +514,46 @@ func TestForcedFeatureWorksForUnknownFeature(t *testing.T) {
 	require.Equal(t, OverrideResultSource, result.Source)
 }
 
+// featureUsageSpyPlugin counts OnFeatureEvaluated calls for tests.
+type featureUsageSpyPlugin struct{ featureEvaluated int }
+
+func (p *featureUsageSpyPlugin) Init(*Client) error { return nil }
+func (p *featureUsageSpyPlugin) Close() error       { return nil }
+func (p *featureUsageSpyPlugin) OnExperimentViewed(context.Context, *Experiment, *ExperimentResult) {
+}
+func (p *featureUsageSpyPlugin) OnFeatureEvaluated(context.Context, string, *FeatureResult) {
+	p.featureEvaluated++
+}
+
+func TestForcedFeatureDoesNotReportFeatureUsage(t *testing.T) {
+	featuresJson := `{
+    "feature": {"defaultValue": 0, "rules": [{"force": 1, "id": "foo"}]},
+    "normal": {"defaultValue": 5}
+    }`
+
+	var calls int
+	spy := &featureUsageSpyPlugin{}
+	client, _ := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithForcedFeatures(ForcedFeaturesMap{"feature": 99}),
+		WithPlugins(spy),
+		WithFeatureUsageCallback(func(_ context.Context, _ string, _ *FeatureResult, _ any) {
+			calls++
+		}))
+
+	// Forced (override) result must not be reported as feature usage on either
+	// the callback or the plugin.
+	res := client.EvalFeature(ctx, "feature")
+	require.Equal(t, OverrideResultSource, res.Source)
+	require.Equal(t, 0, calls)
+	require.Equal(t, 0, spy.featureEvaluated)
+
+	// A normal (non-forced) evaluation still reports usage on both.
+	client.EvalFeature(ctx, "normal")
+	require.Equal(t, 1, calls)
+	require.Equal(t, 1, spy.featureEvaluated)
+}
+
 func TestForcedFeatureDoesNotAffectOtherFeatures(t *testing.T) {
 	featuresJson := `{
     "feature": {"defaultValue": 0, "rules": [{"force": 1, "id": "foo"}]}

--- a/feature_test.go
+++ b/feature_test.go
@@ -487,3 +487,63 @@ func TestReturnsNullWhenHittingPrerequisiteCycle(t *testing.T) {
 	require.Nil(t, result.Value)
 	require.Equal(t, CyclicPrerequisiteResultSource, result.Source)
 }
+
+func TestForcedFeatureOverridesRulesAndDefault(t *testing.T) {
+	featuresJson := `{
+    "feature": {"defaultValue": 0, "rules": [{"force": 1, "id": "foo"}]}
+    }`
+
+	client, _ := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithForcedFeatures(ForcedFeaturesMap{"feature": 99}))
+
+	result := client.EvalFeature(ctx, "feature")
+	require.Equal(t, 99, result.Value)
+	require.Equal(t, OverrideResultSource, result.Source)
+	require.True(t, result.On)
+	// Forced override skips rules, so no rule id is reported.
+	require.Equal(t, "", result.RuleId)
+}
+
+func TestForcedFeatureWorksForUnknownFeature(t *testing.T) {
+	client, _ := NewClient(ctx,
+		WithForcedFeatures(ForcedFeaturesMap{"missing": "forced"}))
+
+	result := client.EvalFeature(ctx, "missing")
+	require.Equal(t, "forced", result.Value)
+	require.Equal(t, OverrideResultSource, result.Source)
+}
+
+func TestForcedFeatureDoesNotAffectOtherFeatures(t *testing.T) {
+	featuresJson := `{
+    "feature": {"defaultValue": 0, "rules": [{"force": 1, "id": "foo"}]}
+    }`
+
+	client, _ := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithForcedFeatures(ForcedFeaturesMap{"other": true}))
+
+	result := client.EvalFeature(ctx, "feature")
+	require.Equal(t, float64(1), result.Value)
+	require.Equal(t, ForceResultSource, result.Source)
+}
+
+func TestChildClientWithForcedFeatures(t *testing.T) {
+	featuresJson := `{
+    "feature": {"defaultValue": 0, "rules": [{"force": 1, "id": "foo"}]}
+    }`
+
+	parent, _ := NewClient(ctx, WithJsonFeatures(featuresJson))
+	child, err := parent.WithForcedFeatures(ForcedFeaturesMap{"feature": 42})
+	require.Nil(t, err)
+
+	// Child sees the override.
+	childResult := child.EvalFeature(ctx, "feature")
+	require.Equal(t, 42, childResult.Value)
+	require.Equal(t, OverrideResultSource, childResult.Source)
+
+	// Parent is unaffected.
+	parentResult := parent.EvalFeature(ctx, "feature")
+	require.Equal(t, float64(1), parentResult.Value)
+	require.Equal(t, ForceResultSource, parentResult.Source)
+}

--- a/feature_test.go
+++ b/feature_test.go
@@ -587,3 +587,28 @@ func TestChildClientWithForcedFeatures(t *testing.T) {
 	require.Equal(t, float64(1), parentResult.Value)
 	require.Equal(t, ForceResultSource, parentResult.Source)
 }
+
+func TestChildForcedFeaturesMergeWithParent(t *testing.T) {
+	featuresJson := `{
+    "a": {"defaultValue": "da"},
+    "b": {"defaultValue": "db"},
+    "c": {"defaultValue": "dc"}
+    }`
+
+	parent, _ := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithForcedFeatures(ForcedFeaturesMap{"a": "A", "b": "B"}),
+	)
+	child, err := parent.WithForcedFeatures(ForcedFeaturesMap{"b": "B2", "c": "C"})
+	require.Nil(t, err)
+
+	// Child merges over the parent: a kept, b overridden, c added.
+	require.Equal(t, "A", child.EvalFeature(ctx, "a").Value)
+	require.Equal(t, "B2", child.EvalFeature(ctx, "b").Value)
+	require.Equal(t, "C", child.EvalFeature(ctx, "c").Value)
+
+	// Parent is unaffected by the child merge.
+	require.Equal(t, "A", parent.EvalFeature(ctx, "a").Value)
+	require.Equal(t, "B", parent.EvalFeature(ctx, "b").Value)
+	require.Equal(t, "dc", parent.EvalFeature(ctx, "c").Value)
+}

--- a/tracking.go
+++ b/tracking.go
@@ -149,6 +149,11 @@ func (e *evaluator) recordFeatureUsage(key string, res *FeatureResult) {
 	if !e.recording {
 		return
 	}
+	// Forced (override) results are QA/test overrides, not real feature usage,
+	// so they are excluded from feature-usage reporting (callback and plugins).
+	if res.Source == OverrideResultSource {
+		return
+	}
 	stringified := stringifyFeatureValue(res.Value)
 	if prev, ok := e.trackedFeatures[key]; ok && prev == stringified {
 		return


### PR DESCRIPTION
## What
  Adds support for forcing feature values locally.
  - New `ForcedFeaturesMap` type and `WithForcedFeatures(...)` option (root + child client)
  - `EvalFeature` short-circuits when a key is forced, returning the value with the 
    reserved `override` source; forced overrides are excluded from feature-usage
    reporting (callback + plugins)
  - Works for keys not present in the feature map
  
## Testing
  - New tests in `feature_test.go`; full suite green, `-race` clean