### PR TITLE
feat: add pluggable FeatureCache for external/shared feature storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Add a pluggable `FeatureCache` (with `WithFeatureCache`) for persisting the
+  raw feature payload across restarts or sharing it between instances (e.g.
+  Redis). The client seeds from it on startup without writing back and writes
+  through after successful updates; `Get`/`Set` return backend errors, which are
+  logged and never fail evaluation.
+
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
 - **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project will be documented in this file.
   Redis). The client seeds from it on startup without writing back and writes
   through after successful updates; `Get`/`Set` return backend errors, which are
   logged and never fail evaluation.
+- `FeatureCacheEntry` gains `UpdatedAt`, stamped on every write. Backends with
+  no expiry of their own — a file-based cache, say — need it to age entries out;
+  ones with a TTL can ignore it. Entries stored without it still seed.
+- Fix: marshaling features no longer drops their targeting conditions.
+  `json.Marshal` on the `FeatureMap` returned by `Client.Features()` emitted
+  `"condition":{}` without an error, so a re-parsed rule matched every user
+  instead of its intended audience.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 

--- a/client.go
+++ b/client.go
@@ -7,9 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"time"
 
-	"github.com/growthbook/growthbook-golang/internal/condition"
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
 
@@ -97,48 +95,48 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 }
 
 // seedFromCache populates features from the configured FeatureCache when the
-// client has no fresher data yet. It is a no-op when no cache is configured.
+// client has no features yet, parsing the stored raw payload through the normal
+// update path. It is a no-op when no cache is configured or features are already
+// set (so an inline WithFeatures is respected).
 func (client *Client) seedFromCache(ctx context.Context) {
 	cache := client.data.getFeatureCache()
-	if cache == nil {
+	if cache == nil || client.data.getFeatures() != nil {
 		return
 	}
 	entry, ok := cache.Get(ctx, client.data.cacheKey())
-	if !ok || entry == nil {
+	if !ok || entry == nil || len(entry.Payload) == 0 {
 		return
 	}
-	client.data.withLock(func(d *data) error {
-		// Respect features the caller already provided (e.g. WithFeatures);
-		// only seed when we have nothing yet.
-		if d.features != nil {
-			return nil
-		}
-		d.features = entry.Features
-		d.savedGroups = entry.SavedGroups
-		d.dateUpdated = entry.DateUpdated
-		return nil
-	})
+	var resp FeatureApiResponse
+	if err := json.Unmarshal(entry.Payload, &resp); err != nil {
+		client.logger.WarnContext(ctx, "Failed to parse cached features", "error", err)
+		return
+	}
+	resp.raw = entry.Payload
+	resp.Etag = entry.Etag
+	if err := client.updateFromApiResponse(ctx, &resp); err != nil {
+		client.logger.WarnContext(ctx, "Failed to seed features from cache", "error", err)
+	}
 }
 
-// writeCache persists the latest feature data to the configured FeatureCache.
-// A previously stored etag is preserved when this update carries none (e.g. SSE
-// events), so conditional requests still work after a restart.
-func (client *Client) writeCache(features FeatureMap, savedGroups condition.SavedGroups, dateUpdated time.Time, etag string) {
+// writeCache persists the raw feature payload to the configured FeatureCache. A
+// previously stored etag is preserved when this update carries none (e.g. SSE
+// events), so conditional requests still work after a restart. Writes are
+// skipped when there is no raw payload to store faithfully.
+func (client *Client) writeCache(ctx context.Context, payload json.RawMessage, etag string) {
 	cache := client.data.getFeatureCache()
-	if cache == nil {
+	if cache == nil || len(payload) == 0 {
 		return
 	}
 	key := client.data.cacheKey()
 	if etag == "" {
-		if prev, ok := cache.Get(context.Background(), key); ok && prev != nil {
+		if prev, ok := cache.Get(ctx, key); ok && prev != nil {
 			etag = prev.Etag
 		}
 	}
-	cache.Set(context.Background(), key, &FeatureCacheEntry{
-		Features:    features,
-		SavedGroups: savedGroups,
-		DateUpdated: dateUpdated,
-		Etag:        etag,
+	cache.Set(ctx, key, &FeatureCacheEntry{
+		Payload: payload,
+		Etag:    etag,
 	})
 }
 
@@ -208,6 +206,12 @@ func (client *Client) SetEncryptedJSONFeatures(encryptedJSON string) error {
 
 // UpdateFromApiResponse updates shared data from Growthbook API response
 func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
+	return client.updateFromApiResponse(context.Background(), resp)
+}
+
+// updateFromApiResponse applies an API response and writes through to the
+// feature cache, using ctx for the cache backend.
+func (client *Client) updateFromApiResponse(ctx context.Context, resp *FeatureApiResponse) error {
 	dataUpdated := client.data.getDateUpdated()
 	apiUpdated := resp.DateUpdated
 	if apiUpdated.Before(dataUpdated) {
@@ -231,7 +235,7 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
-	client.writeCache(features, resp.SavedGroups, resp.DateUpdated, resp.Etag)
+	client.writeCache(ctx, resp.raw, resp.Etag)
 	return nil
 }
 
@@ -254,7 +258,9 @@ func (client *Client) UpdateFromApiResponseJSON(respJSON string) error {
 	if err != nil {
 		return err
 	}
-	return client.UpdateFromApiResponse(&resp)
+	// Preserve the raw payload so it can be persisted verbatim to the cache.
+	resp.raw = json.RawMessage(respJSON)
+	return client.updateFromApiResponse(context.Background(), &resp)
 }
 
 // RefreshFeatures immediately fetches the latest features from the GrowthBook API
@@ -268,7 +274,7 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 	if resp.Features == nil && resp.EncryptedFeatures == "" {
 		return nil
 	}
-	return client.UpdateFromApiResponse(resp)
+	return client.updateFromApiResponse(ctx, resp)
 }
 
 // EvalFeature evaluates feature based on attributes and features map

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
@@ -147,7 +148,8 @@ func (client *Client) writeCache(ctx context.Context, payload json.RawMessage, e
 			etag = prev.Etag
 		}
 	}
-	if err := cache.Set(ctx, key, &FeatureCacheEntry{Payload: payload, Etag: etag}); err != nil {
+	entry := &FeatureCacheEntry{Payload: payload, Etag: etag, UpdatedAt: time.Now().UTC()}
+	if err := cache.Set(ctx, key, entry); err != nil {
 		client.logger.WarnContext(ctx, "Failed to write features to cache", "error", err)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
+	"github.com/growthbook/growthbook-golang/internal/condition"
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
 
@@ -82,11 +84,62 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 		}
 	}
 
+	// Seed features from the cache before starting the data source so they are
+	// available immediately and survive an initial API failure (offline
+	// resilience).
+	client.seedFromCache(ctx)
+
 	if client.data.dataSource != nil {
 		go client.startDataSource(ctx)
 	}
 
 	return client, nil
+}
+
+// seedFromCache populates features from the configured FeatureCache when the
+// client has no fresher data yet. It is a no-op when no cache is configured.
+func (client *Client) seedFromCache(ctx context.Context) {
+	cache := client.data.getFeatureCache()
+	if cache == nil {
+		return
+	}
+	entry, ok := cache.Get(ctx, client.data.cacheKey())
+	if !ok || entry == nil {
+		return
+	}
+	client.data.withLock(func(d *data) error {
+		// Respect features the caller already provided (e.g. WithFeatures);
+		// only seed when we have nothing yet.
+		if d.features != nil {
+			return nil
+		}
+		d.features = entry.Features
+		d.savedGroups = entry.SavedGroups
+		d.dateUpdated = entry.DateUpdated
+		return nil
+	})
+}
+
+// writeCache persists the latest feature data to the configured FeatureCache.
+// A previously stored etag is preserved when this update carries none (e.g. SSE
+// events), so conditional requests still work after a restart.
+func (client *Client) writeCache(features FeatureMap, savedGroups condition.SavedGroups, dateUpdated time.Time, etag string) {
+	cache := client.data.getFeatureCache()
+	if cache == nil {
+		return
+	}
+	key := client.data.cacheKey()
+	if etag == "" {
+		if prev, ok := cache.Get(context.Background(), key); ok && prev != nil {
+			etag = prev.Etag
+		}
+	}
+	cache.Set(context.Background(), key, &FeatureCacheEntry{
+		Features:    features,
+		SavedGroups: savedGroups,
+		DateUpdated: dateUpdated,
+		Etag:        etag,
+	})
 }
 
 // Close client's background goroutines and plugins.
@@ -178,6 +231,7 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
+	client.writeCache(features, resp.SavedGroups, resp.DateUpdated, resp.Etag)
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -103,8 +103,12 @@ func (client *Client) seedFromCache(ctx context.Context) {
 	if cache == nil || client.data.getFeatures() != nil {
 		return
 	}
-	entry, ok := cache.Get(ctx, client.data.cacheKey())
-	if !ok || entry == nil || len(entry.Payload) == 0 {
+	entry, found, err := cache.Get(ctx, client.data.cacheKey())
+	if err != nil {
+		client.logger.WarnContext(ctx, "Feature cache read failed on startup, continuing without it", "error", err)
+		return
+	}
+	if !found || entry == nil || len(entry.Payload) == 0 {
 		return
 	}
 	var resp FeatureApiResponse
@@ -114,9 +118,18 @@ func (client *Client) seedFromCache(ctx context.Context) {
 	}
 	resp.raw = entry.Payload
 	resp.Etag = entry.Etag
-	if err := client.updateFromApiResponse(ctx, &resp); err != nil {
+	// Apply without writing back: a seed must not refresh a TTL backend's expiry.
+	if err := client.applyApiResponse(&resp); err != nil {
 		client.logger.WarnContext(ctx, "Failed to seed features from cache", "error", err)
+		return
 	}
+	// Record the etag we actually seeded with so the poll data source can issue a
+	// conditional first request. Only set when the cache was adopted, so inline
+	// features (WithFeatures) never reuse an unrelated cached etag.
+	client.data.withLock(func(d *data) error {
+		d.seededEtag = entry.Etag
+		return nil
+	})
 }
 
 // writeCache persists the raw feature payload to the configured FeatureCache. A
@@ -130,14 +143,13 @@ func (client *Client) writeCache(ctx context.Context, payload json.RawMessage, e
 	}
 	key := client.data.cacheKey()
 	if etag == "" {
-		if prev, ok := cache.Get(ctx, key); ok && prev != nil {
+		if prev, found, err := cache.Get(ctx, key); err == nil && found && prev != nil {
 			etag = prev.Etag
 		}
 	}
-	cache.Set(ctx, key, &FeatureCacheEntry{
-		Payload: payload,
-		Etag:    etag,
-	})
+	if err := cache.Set(ctx, key, &FeatureCacheEntry{Payload: payload, Etag: etag}); err != nil {
+		client.logger.WarnContext(ctx, "Failed to write features to cache", "error", err)
+	}
 }
 
 // Close client's background goroutines and plugins.
@@ -212,6 +224,17 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 // updateFromApiResponse applies an API response and writes through to the
 // feature cache, using ctx for the cache backend.
 func (client *Client) updateFromApiResponse(ctx context.Context, resp *FeatureApiResponse) error {
+	if err := client.applyApiResponse(resp); err != nil {
+		return err
+	}
+	client.writeCache(ctx, resp.raw, resp.Etag)
+	return nil
+}
+
+// applyApiResponse updates the client's shared data from an API response without
+// writing through to the feature cache. Seeding uses this so a cache read never
+// turns into a cache write (which would refresh a TTL backend's expiry).
+func (client *Client) applyApiResponse(resp *FeatureApiResponse) error {
 	dataUpdated := client.data.getDateUpdated()
 	apiUpdated := resp.DateUpdated
 	if apiUpdated.Before(dataUpdated) {
@@ -235,7 +258,6 @@ func (client *Client) updateFromApiResponse(ctx context.Context, resp *FeatureAp
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
-	client.writeCache(ctx, resp.raw, resp.Etag)
 	return nil
 }
 

--- a/client_data.go
+++ b/client_data.go
@@ -23,6 +23,7 @@ type data struct {
 	dsStartErr    error
 	plugins       []Plugin
 	subscribers   subscriberRegistry
+	featureCache  FeatureCache
 }
 
 func newData() *data {
@@ -79,6 +80,20 @@ func (d *data) getClientKey() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.clientKey
+}
+
+func (d *data) getFeatureCache() FeatureCache {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.featureCache
+}
+
+// cacheKey identifies this client's feature data in a FeatureCache. Keyed by
+// API host and client key so distinct endpoints never collide.
+func (d *data) cacheKey() string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.apiHost + "::" + d.clientKey
 }
 
 type dataUpdate func(*data) error

--- a/client_data.go
+++ b/client_data.go
@@ -24,6 +24,10 @@ type data struct {
 	plugins       []Plugin
 	subscribers   subscriberRegistry
 	featureCache  FeatureCache
+	// seededEtag is the etag of the cache entry that actually seeded this client
+	// on startup, or "" when nothing was seeded. The poll data source reuses it
+	// for a conditional first request.
+	seededEtag string
 }
 
 func newData() *data {
@@ -86,6 +90,12 @@ func (d *data) getFeatureCache() FeatureCache {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.featureCache
+}
+
+func (d *data) getSeededEtag() string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.seededEtag
 }
 
 // cacheKey identifies this client's feature data in a FeatureCache. Keyed by

--- a/client_option.go
+++ b/client_option.go
@@ -101,6 +101,17 @@ func WithForcedVariations(forcedVariations ForcedVariationsMap) ClientOption {
 	}
 }
 
+// WithFeatureCache sets a pluggable cache backend for feature data. The client
+// seeds features from it on startup and writes back after each successful
+// update, enabling faster cold starts, offline resilience, and shared state
+// across instances. Without this option no external cache is used.
+func WithFeatureCache(cache FeatureCache) ClientOption {
+	return func(c *Client) error {
+		c.data.featureCache = cache
+		return nil
+	}
+}
+
 // WithGroups sets legacy group membership for the user, used by experiments that
 // declare a `groups` array. Distinct from saved groups, which power $inGroup
 // conditions on `condition`.

--- a/datasource_poll.go
+++ b/datasource_poll.go
@@ -123,7 +123,7 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 		return nil
 	}
 
-	err = ds.client.UpdateFromApiResponse(resp)
+	err = ds.client.updateFromApiResponse(ctx, resp)
 	if err != nil {
 		return err
 	}

--- a/datasource_poll.go
+++ b/datasource_poll.go
@@ -98,14 +98,13 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 	etag := ds.etag
 	ds.mu.RUnlock()
 
-	// On a cold start, reuse the etag stored alongside cached features so the
-	// first request can be conditional and a 304 keeps the seeded data.
+	// On a cold start, reuse the etag of the cache entry that actually seeded
+	// this client, so the first request is conditional and a 304 keeps the
+	// seeded data. It is empty when the cache was not adopted (e.g. inline
+	// WithFeatures), so those clients fetch the API payload instead of 304ing
+	// into an unrelated inline feature set.
 	if etag == "" {
-		if cache := ds.client.data.getFeatureCache(); cache != nil {
-			if entry, ok := cache.Get(ctx, ds.client.data.cacheKey()); ok && entry != nil {
-				etag = entry.Etag
-			}
-		}
+		etag = ds.client.data.getSeededEtag()
 	}
 
 	resp, err := ds.client.CallFeatureApi(ctx, etag)

--- a/datasource_poll.go
+++ b/datasource_poll.go
@@ -98,6 +98,16 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 	etag := ds.etag
 	ds.mu.RUnlock()
 
+	// On a cold start, reuse the etag stored alongside cached features so the
+	// first request can be conditional and a 304 keeps the seeded data.
+	if etag == "" {
+		if cache := ds.client.data.getFeatureCache(); cache != nil {
+			if entry, ok := cache.Get(ctx, ds.client.data.cacheKey()); ok && entry != nil {
+				etag = entry.Etag
+			}
+		}
+	}
+
 	resp, err := ds.client.CallFeatureApi(ctx, etag)
 	if err != nil {
 		return err

--- a/datasource_sse.go
+++ b/datasource_sse.go
@@ -153,7 +153,7 @@ func (ds *SseDataSource) loadData(ctx context.Context) error {
 		return nil
 	}
 
-	err = ds.client.UpdateFromApiResponse(resp)
+	err = ds.client.updateFromApiResponse(ctx, resp)
 	if err != nil {
 		return err
 	}

--- a/feature_api.go
+++ b/feature_api.go
@@ -19,6 +19,9 @@ type FeatureApiResponse struct {
 	EncryptedFeatures string                `json:"encryptedFeatures"`
 	SseSupport        bool
 	Etag              string
+	// raw holds the original response body so it can be persisted verbatim to a
+	// FeatureCache (parsed conditions do not marshal back to JSON without loss).
+	raw json.RawMessage
 }
 
 const userAgent = "Growhthbook Go SDK client"
@@ -62,6 +65,7 @@ func (c *Client) CallFeatureApi(ctx context.Context, etag string) (*FeatureApiRe
 		c.logger.ErrorContext(ctx, "Error parsing features response", "error", err)
 		return &apiResp, err
 	}
+	apiResp.raw = body
 
 	return &apiResp, err
 }

--- a/feature_cache.go
+++ b/feature_cache.go
@@ -2,18 +2,22 @@ package growthbook
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
-	"time"
-
-	"github.com/growthbook/growthbook-golang/internal/condition"
 )
 
 // FeatureCacheEntry is a snapshot of feature data persisted by a FeatureCache.
+//
+// Payload holds the raw GrowthBook feature API response JSON rather than parsed
+// structures. This keeps the entry trivially serializable for external backends
+// (e.g. Redis) and lets it round-trip without loss: parsed conditions do not
+// marshal back to JSON, so storing them would silently drop targeting rules.
+// Storing the raw payload also avoids aliasing the client's live feature map.
 type FeatureCacheEntry struct {
-	Features    FeatureMap
-	SavedGroups condition.SavedGroups
-	DateUpdated time.Time
-	Etag        string
+	// Payload is the raw feature API response JSON (may contain encrypted features).
+	Payload json.RawMessage
+	// Etag is the HTTP ETag for the payload, enabling conditional requests after a restart.
+	Etag string
 }
 
 // FeatureCache is a pluggable backend for persisting feature data so it can

--- a/feature_cache.go
+++ b/feature_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"time"
 )
 
 // FeatureCacheEntry is a snapshot of feature data persisted by a FeatureCache.
@@ -18,6 +19,10 @@ type FeatureCacheEntry struct {
 	Payload json.RawMessage
 	// Etag is the HTTP ETag for the payload, enabling conditional requests after a restart.
 	Etag string
+	// UpdatedAt is when the SDK wrote this entry, in UTC. Backends without their
+	// own expiry — a file, say — need it to age entries out, and it is what a
+	// stale-while-revalidate policy would be built on.
+	UpdatedAt time.Time
 }
 
 // FeatureCache is a pluggable backend for persisting feature data so it can

--- a/feature_cache.go
+++ b/feature_cache.go
@@ -1,0 +1,59 @@
+package growthbook
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/growthbook/growthbook-golang/internal/condition"
+)
+
+// FeatureCacheEntry is a snapshot of feature data persisted by a FeatureCache.
+type FeatureCacheEntry struct {
+	Features    FeatureMap
+	SavedGroups condition.SavedGroups
+	DateUpdated time.Time
+	Etag        string
+}
+
+// FeatureCache is a pluggable backend for persisting feature data so it can
+// survive restarts or be shared across instances (for example, a Redis-backed
+// implementation). When configured via WithFeatureCache, the client seeds
+// features from the cache on startup and writes back after every successful
+// update.
+//
+// Implementations must be safe for concurrent use. Expiry (TTL) is the
+// backend's responsibility; the SDK's data source already governs how often
+// features are refreshed from the API.
+type FeatureCache interface {
+	// Get returns the cached entry for key. ok is false on a miss.
+	Get(ctx context.Context, key string) (entry *FeatureCacheEntry, ok bool)
+	// Set stores entry under key.
+	Set(ctx context.Context, key string, entry *FeatureCacheEntry)
+}
+
+// InMemoryFeatureCache is a thread-safe, process-local FeatureCache. It is the
+// default reference implementation; for sharing state across instances supply
+// your own (for example, Redis-backed) implementation of FeatureCache.
+type InMemoryFeatureCache struct {
+	mu    sync.RWMutex
+	store map[string]*FeatureCacheEntry
+}
+
+// NewInMemoryFeatureCache returns an empty in-memory FeatureCache.
+func NewInMemoryFeatureCache() *InMemoryFeatureCache {
+	return &InMemoryFeatureCache{store: make(map[string]*FeatureCacheEntry)}
+}
+
+func (c *InMemoryFeatureCache) Get(_ context.Context, key string) (*FeatureCacheEntry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.store[key]
+	return entry, ok
+}
+
+func (c *InMemoryFeatureCache) Set(_ context.Context, key string, entry *FeatureCacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store[key] = entry
+}

--- a/feature_cache.go
+++ b/feature_cache.go
@@ -29,11 +29,17 @@ type FeatureCacheEntry struct {
 // Implementations must be safe for concurrent use. Expiry (TTL) is the
 // backend's responsibility; the SDK's data source already governs how often
 // features are refreshed from the API.
+//
+// Both methods return a backend error so failures (e.g. a Redis outage) are
+// distinct from a cache miss. The SDK never fails evaluation on a cache error:
+// a failed Get on startup is logged and the client continues without a seed,
+// and a failed Set is logged.
 type FeatureCache interface {
-	// Get returns the cached entry for key. ok is false on a miss.
-	Get(ctx context.Context, key string) (entry *FeatureCacheEntry, ok bool)
-	// Set stores entry under key.
-	Set(ctx context.Context, key string, entry *FeatureCacheEntry)
+	// Get returns the cached entry for key. found is false on a miss; a non-nil
+	// error signals a backend failure (distinct from a miss).
+	Get(ctx context.Context, key string) (entry *FeatureCacheEntry, found bool, err error)
+	// Set stores entry under key, returning any backend error.
+	Set(ctx context.Context, key string, entry *FeatureCacheEntry) error
 }
 
 // InMemoryFeatureCache is a thread-safe, process-local FeatureCache. It is the
@@ -49,15 +55,16 @@ func NewInMemoryFeatureCache() *InMemoryFeatureCache {
 	return &InMemoryFeatureCache{store: make(map[string]*FeatureCacheEntry)}
 }
 
-func (c *InMemoryFeatureCache) Get(_ context.Context, key string) (*FeatureCacheEntry, bool) {
+func (c *InMemoryFeatureCache) Get(_ context.Context, key string) (*FeatureCacheEntry, bool, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	entry, ok := c.store[key]
-	return entry, ok
+	return entry, ok, nil
 }
 
-func (c *InMemoryFeatureCache) Set(_ context.Context, key string, entry *FeatureCacheEntry) {
+func (c *InMemoryFeatureCache) Set(_ context.Context, key string, entry *FeatureCacheEntry) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.store[key] = entry
+	return nil
 }

--- a/feature_cache_test.go
+++ b/feature_cache_test.go
@@ -1,19 +1,12 @@
 package growthbook
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-func featureMapFromJSON(t *testing.T, s string) FeatureMap {
-	t.Helper()
-	fm := FeatureMap{}
-	require.NoError(t, json.Unmarshal([]byte(s), &fm))
-	return fm
-}
 
 func TestInMemoryFeatureCacheGetSet(t *testing.T) {
 	cache := NewInMemoryFeatureCache()
@@ -22,9 +15,8 @@ func TestInMemoryFeatureCacheGetSet(t *testing.T) {
 	require.False(t, ok)
 
 	entry := &FeatureCacheEntry{
-		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":"v"}}`),
-		DateUpdated: time.Now(),
-		Etag:        "e1",
+		Payload: json.RawMessage(`{"features":{"feat":{"defaultValue":"v"}}}`),
+		Etag:    "e1",
 	}
 	cache.Set(ctx, "k", entry)
 
@@ -36,9 +28,8 @@ func TestInMemoryFeatureCacheGetSet(t *testing.T) {
 func TestSeedsFeaturesFromCacheOnStartup(t *testing.T) {
 	cache := NewInMemoryFeatureCache()
 	cache.Set(ctx, "https://example.com::k", &FeatureCacheEntry{
-		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":"cached"}}`),
-		DateUpdated: time.Now(),
-		Etag:        "e1",
+		Payload: json.RawMessage(`{"features":{"feat":{"defaultValue":"cached"}}}`),
+		Etag:    "e1",
 	})
 
 	client, err := NewClient(ctx,
@@ -60,17 +51,15 @@ func TestWriteThroughToCacheOnUpdate(t *testing.T) {
 		WithFeatureCache(cache))
 	require.NoError(t, err)
 
-	resp := &FeatureApiResponse{
-		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":"fromApi"}}`),
-		DateUpdated: time.Now(),
-		Etag:        "etag123",
-	}
-	require.NoError(t, client.UpdateFromApiResponse(resp))
+	payload := `{"features":{"feat":{"defaultValue":"fromApi"}},"dateUpdated":"2020-01-01T00:00:00Z"}`
+	resp := &FeatureApiResponse{Etag: "etag123", raw: json.RawMessage(payload)}
+	require.NoError(t, json.Unmarshal([]byte(payload), resp))
+	require.NoError(t, client.updateFromApiResponse(ctx, resp))
 
 	entry, ok := cache.Get(ctx, "https://example.com::k")
 	require.True(t, ok)
 	require.Equal(t, "etag123", entry.Etag)
-	require.Contains(t, entry.Features, "feat")
+	require.JSONEq(t, payload, string(entry.Payload))
 }
 
 func TestWriteThroughPreservesEtagWhenUpdateHasNone(t *testing.T) {
@@ -82,17 +71,14 @@ func TestWriteThroughPreservesEtagWhenUpdateHasNone(t *testing.T) {
 	require.NoError(t, err)
 
 	// First update carries an etag (e.g. from a poll response).
-	require.NoError(t, client.UpdateFromApiResponse(&FeatureApiResponse{
-		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":1}}`),
-		DateUpdated: time.Now(),
-		Etag:        "etag-1",
-	}))
+	p1 := `{"features":{"feat":{"defaultValue":1}},"dateUpdated":"2020-01-01T00:00:00Z"}`
+	r1 := &FeatureApiResponse{Etag: "etag-1", raw: json.RawMessage(p1)}
+	require.NoError(t, json.Unmarshal([]byte(p1), r1))
+	require.NoError(t, client.updateFromApiResponse(ctx, r1))
 
 	// Second update has no etag (e.g. an SSE event) — must not clobber it.
-	require.NoError(t, client.UpdateFromApiResponse(&FeatureApiResponse{
-		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":2}}`),
-		DateUpdated: time.Now().Add(time.Second),
-	}))
+	p2 := `{"features":{"feat":{"defaultValue":2}},"dateUpdated":"2020-01-02T00:00:00Z"}`
+	require.NoError(t, client.UpdateFromApiResponseJSON(p2))
 
 	entry, ok := cache.Get(ctx, "https://example.com::k")
 	require.True(t, ok)
@@ -102,8 +88,7 @@ func TestWriteThroughPreservesEtagWhenUpdateHasNone(t *testing.T) {
 func TestInlineFeaturesNotOverwrittenByCache(t *testing.T) {
 	cache := NewInMemoryFeatureCache()
 	cache.Set(ctx, "https://example.com::k", &FeatureCacheEntry{
-		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":"cached"}}`),
-		DateUpdated: time.Now(),
+		Payload: json.RawMessage(`{"features":{"feat":{"defaultValue":"cached"}}}`),
 	})
 
 	client, err := NewClient(ctx,
@@ -121,9 +106,51 @@ func TestNoCacheConfiguredIsNoop(t *testing.T) {
 	// Without WithFeatureCache, updates must not panic and evaluation works.
 	client, err := NewClient(ctx, WithClientKey("k"))
 	require.NoError(t, err)
-	require.NoError(t, client.UpdateFromApiResponse(&FeatureApiResponse{
-		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":true}}`),
-		DateUpdated: time.Now(),
-	}))
+	require.NoError(t, client.UpdateFromApiResponseJSON(
+		`{"features":{"feat":{"defaultValue":true}},"dateUpdated":"2020-01-01T00:00:00Z"}`))
 	require.True(t, client.EvalFeature(ctx, "feat").On)
+}
+
+// jsonRoundTripCache simulates an external backend (e.g. Redis) that serializes
+// entries to JSON and back, to prove FeatureCacheEntry survives a round-trip.
+type jsonRoundTripCache struct{ store map[string][]byte }
+
+func (c *jsonRoundTripCache) Get(_ context.Context, key string) (*FeatureCacheEntry, bool) {
+	b, ok := c.store[key]
+	if !ok {
+		return nil, false
+	}
+	var entry FeatureCacheEntry
+	if err := json.Unmarshal(b, &entry); err != nil {
+		return nil, false
+	}
+	return &entry, true
+}
+
+func (c *jsonRoundTripCache) Set(_ context.Context, key string, entry *FeatureCacheEntry) {
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	c.store[key] = b
+}
+
+func TestCachedFeatureWithConditionSurvivesJSONRoundTrip(t *testing.T) {
+	cache := &jsonRoundTripCache{store: map[string][]byte{}}
+	cache.Set(ctx, "https://example.com::k", &FeatureCacheEntry{
+		Payload: json.RawMessage(
+			`{"features":{"feat":{"defaultValue":"off","rules":[{"condition":{"country":"US"},"force":"on"}]}}}`),
+	})
+
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"),
+		WithClientKey("k"),
+		WithAttributes(Attributes{"country": "US"}),
+		WithFeatureCache(cache))
+	require.NoError(t, err)
+
+	// If the condition survived serialization, the rule forces "on" for US.
+	res := client.EvalFeature(ctx, "feat")
+	require.Equal(t, "on", res.Value)
+	require.Equal(t, ForceResultSource, res.Source)
 }

--- a/feature_cache_test.go
+++ b/feature_cache_test.go
@@ -253,3 +253,34 @@ func TestPollIgnoresCachedEtagWhenInlineFeaturesUsed(t *testing.T) {
 	require.Empty(t, sentEtag)
 	require.Equal(t, "fromApi", client.EvalFeature(ctx, "feat").Value)
 }
+
+func TestWriteThroughStampsUpdatedAt(t *testing.T) {
+	cache := NewInMemoryFeatureCache()
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"), WithClientKey("k"), WithFeatureCache(cache))
+	require.NoError(t, err)
+
+	before := time.Now().UTC()
+	require.NoError(t, client.UpdateFromApiResponseJSON(
+		`{"features":{"feat":{"defaultValue":"v"}},"dateUpdated":"2020-01-01T00:00:00Z"}`))
+
+	entry, ok, err := cache.Get(ctx, "https://example.com::k")
+	require.NoError(t, err)
+	require.True(t, ok)
+	// A backend with no expiry of its own (e.g. a file) ages entries out by this.
+	require.False(t, entry.UpdatedAt.Before(before))
+	require.Equal(t, time.UTC, entry.UpdatedAt.Location())
+}
+
+func TestSeedDoesNotDependOnUpdatedAt(t *testing.T) {
+	// Entries written before UpdatedAt existed (zero value) must still seed.
+	cache := NewInMemoryFeatureCache()
+	require.NoError(t, cache.Set(ctx, "https://example.com::k", &FeatureCacheEntry{
+		Payload: json.RawMessage(`{"features":{"feat":{"defaultValue":"cached"}}}`),
+	}))
+
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"), WithClientKey("k"), WithFeatureCache(cache))
+	require.NoError(t, err)
+	require.Equal(t, "cached", client.EvalFeature(ctx, "feat").Value)
+}

--- a/feature_cache_test.go
+++ b/feature_cache_test.go
@@ -1,0 +1,129 @@
+package growthbook
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func featureMapFromJSON(t *testing.T, s string) FeatureMap {
+	t.Helper()
+	fm := FeatureMap{}
+	require.NoError(t, json.Unmarshal([]byte(s), &fm))
+	return fm
+}
+
+func TestInMemoryFeatureCacheGetSet(t *testing.T) {
+	cache := NewInMemoryFeatureCache()
+
+	_, ok := cache.Get(ctx, "missing")
+	require.False(t, ok)
+
+	entry := &FeatureCacheEntry{
+		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":"v"}}`),
+		DateUpdated: time.Now(),
+		Etag:        "e1",
+	}
+	cache.Set(ctx, "k", entry)
+
+	got, ok := cache.Get(ctx, "k")
+	require.True(t, ok)
+	require.Equal(t, "e1", got.Etag)
+}
+
+func TestSeedsFeaturesFromCacheOnStartup(t *testing.T) {
+	cache := NewInMemoryFeatureCache()
+	cache.Set(ctx, "https://example.com::k", &FeatureCacheEntry{
+		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":"cached"}}`),
+		DateUpdated: time.Now(),
+		Etag:        "e1",
+	})
+
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"),
+		WithClientKey("k"),
+		WithFeatureCache(cache))
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "feat")
+	require.Equal(t, "cached", res.Value)
+	require.Equal(t, DefaultValueResultSource, res.Source)
+}
+
+func TestWriteThroughToCacheOnUpdate(t *testing.T) {
+	cache := NewInMemoryFeatureCache()
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"),
+		WithClientKey("k"),
+		WithFeatureCache(cache))
+	require.NoError(t, err)
+
+	resp := &FeatureApiResponse{
+		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":"fromApi"}}`),
+		DateUpdated: time.Now(),
+		Etag:        "etag123",
+	}
+	require.NoError(t, client.UpdateFromApiResponse(resp))
+
+	entry, ok := cache.Get(ctx, "https://example.com::k")
+	require.True(t, ok)
+	require.Equal(t, "etag123", entry.Etag)
+	require.Contains(t, entry.Features, "feat")
+}
+
+func TestWriteThroughPreservesEtagWhenUpdateHasNone(t *testing.T) {
+	cache := NewInMemoryFeatureCache()
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"),
+		WithClientKey("k"),
+		WithFeatureCache(cache))
+	require.NoError(t, err)
+
+	// First update carries an etag (e.g. from a poll response).
+	require.NoError(t, client.UpdateFromApiResponse(&FeatureApiResponse{
+		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":1}}`),
+		DateUpdated: time.Now(),
+		Etag:        "etag-1",
+	}))
+
+	// Second update has no etag (e.g. an SSE event) — must not clobber it.
+	require.NoError(t, client.UpdateFromApiResponse(&FeatureApiResponse{
+		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":2}}`),
+		DateUpdated: time.Now().Add(time.Second),
+	}))
+
+	entry, ok := cache.Get(ctx, "https://example.com::k")
+	require.True(t, ok)
+	require.Equal(t, "etag-1", entry.Etag)
+}
+
+func TestInlineFeaturesNotOverwrittenByCache(t *testing.T) {
+	cache := NewInMemoryFeatureCache()
+	cache.Set(ctx, "https://example.com::k", &FeatureCacheEntry{
+		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":"cached"}}`),
+		DateUpdated: time.Now(),
+	})
+
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"),
+		WithClientKey("k"),
+		WithFeatureCache(cache),
+		WithJsonFeatures(`{"feat":{"defaultValue":"inline"}}`))
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "feat")
+	require.Equal(t, "inline", res.Value)
+}
+
+func TestNoCacheConfiguredIsNoop(t *testing.T) {
+	// Without WithFeatureCache, updates must not panic and evaluation works.
+	client, err := NewClient(ctx, WithClientKey("k"))
+	require.NoError(t, err)
+	require.NoError(t, client.UpdateFromApiResponse(&FeatureApiResponse{
+		Features:    featureMapFromJSON(t, `{"feat":{"defaultValue":true}}`),
+		DateUpdated: time.Now(),
+	}))
+	require.True(t, client.EvalFeature(ctx, "feat").On)
+}

--- a/feature_cache_test.go
+++ b/feature_cache_test.go
@@ -3,7 +3,11 @@ package growthbook
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -11,16 +15,18 @@ import (
 func TestInMemoryFeatureCacheGetSet(t *testing.T) {
 	cache := NewInMemoryFeatureCache()
 
-	_, ok := cache.Get(ctx, "missing")
+	_, ok, err := cache.Get(ctx, "missing")
+	require.NoError(t, err)
 	require.False(t, ok)
 
 	entry := &FeatureCacheEntry{
 		Payload: json.RawMessage(`{"features":{"feat":{"defaultValue":"v"}}}`),
 		Etag:    "e1",
 	}
-	cache.Set(ctx, "k", entry)
+	require.NoError(t, cache.Set(ctx, "k", entry))
 
-	got, ok := cache.Get(ctx, "k")
+	got, ok, err := cache.Get(ctx, "k")
+	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "e1", got.Etag)
 }
@@ -56,7 +62,8 @@ func TestWriteThroughToCacheOnUpdate(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(payload), resp))
 	require.NoError(t, client.updateFromApiResponse(ctx, resp))
 
-	entry, ok := cache.Get(ctx, "https://example.com::k")
+	entry, ok, err := cache.Get(ctx, "https://example.com::k")
+	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "etag123", entry.Etag)
 	require.JSONEq(t, payload, string(entry.Payload))
@@ -80,7 +87,8 @@ func TestWriteThroughPreservesEtagWhenUpdateHasNone(t *testing.T) {
 	p2 := `{"features":{"feat":{"defaultValue":2}},"dateUpdated":"2020-01-02T00:00:00Z"}`
 	require.NoError(t, client.UpdateFromApiResponseJSON(p2))
 
-	entry, ok := cache.Get(ctx, "https://example.com::k")
+	entry, ok, err := cache.Get(ctx, "https://example.com::k")
+	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, "etag-1", entry.Etag)
 }
@@ -115,24 +123,25 @@ func TestNoCacheConfiguredIsNoop(t *testing.T) {
 // entries to JSON and back, to prove FeatureCacheEntry survives a round-trip.
 type jsonRoundTripCache struct{ store map[string][]byte }
 
-func (c *jsonRoundTripCache) Get(_ context.Context, key string) (*FeatureCacheEntry, bool) {
+func (c *jsonRoundTripCache) Get(_ context.Context, key string) (*FeatureCacheEntry, bool, error) {
 	b, ok := c.store[key]
 	if !ok {
-		return nil, false
+		return nil, false, nil
 	}
 	var entry FeatureCacheEntry
 	if err := json.Unmarshal(b, &entry); err != nil {
-		return nil, false
+		return nil, false, err
 	}
-	return &entry, true
+	return &entry, true, nil
 }
 
-func (c *jsonRoundTripCache) Set(_ context.Context, key string, entry *FeatureCacheEntry) {
+func (c *jsonRoundTripCache) Set(_ context.Context, key string, entry *FeatureCacheEntry) error {
 	b, err := json.Marshal(entry)
 	if err != nil {
-		return
+		return err
 	}
 	c.store[key] = b
+	return nil
 }
 
 func TestCachedFeatureWithConditionSurvivesJSONRoundTrip(t *testing.T) {
@@ -153,4 +162,94 @@ func TestCachedFeatureWithConditionSurvivesJSONRoundTrip(t *testing.T) {
 	res := client.EvalFeature(ctx, "feat")
 	require.Equal(t, "on", res.Value)
 	require.Equal(t, ForceResultSource, res.Source)
+}
+
+// recordingCache counts Set calls so tests can assert seeding does not write back.
+type recordingCache struct {
+	entry *FeatureCacheEntry
+	sets  int
+}
+
+func (c *recordingCache) Get(context.Context, string) (*FeatureCacheEntry, bool, error) {
+	if c.entry == nil {
+		return nil, false, nil
+	}
+	return c.entry, true, nil
+}
+
+func (c *recordingCache) Set(_ context.Context, _ string, e *FeatureCacheEntry) error {
+	c.sets++
+	c.entry = e
+	return nil
+}
+
+func TestSeedDoesNotWriteBackToCache(t *testing.T) {
+	cache := &recordingCache{entry: &FeatureCacheEntry{
+		Payload: json.RawMessage(`{"features":{"feat":{"defaultValue":"cached"}},"dateUpdated":"2020-01-01T00:00:00Z"}`),
+		Etag:    "e1",
+	}}
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"), WithClientKey("k"), WithFeatureCache(cache))
+	require.NoError(t, err)
+
+	// The cache was adopted...
+	require.Equal(t, "cached", client.EvalFeature(ctx, "feat").Value)
+	// ...but seeding must not write back, which would refresh a TTL backend's expiry.
+	require.Equal(t, 0, cache.sets)
+}
+
+// errorCache always fails, simulating a backend outage.
+type errorCache struct{}
+
+func (errorCache) Get(context.Context, string) (*FeatureCacheEntry, bool, error) {
+	return nil, false, errors.New("backend down")
+}
+func (errorCache) Set(context.Context, string, *FeatureCacheEntry) error {
+	return errors.New("backend down")
+}
+
+func TestCacheBackendErrorsAreNonFatal(t *testing.T) {
+	client, err := NewClient(ctx,
+		WithApiHost("https://example.com"), WithClientKey("k"),
+		WithFeatureCache(errorCache{}), withSilentTestLogger())
+	require.NoError(t, err) // a Get failure on startup must not fail construction
+
+	// A Set failure during an update is logged, not propagated, and the update applies.
+	require.NoError(t, client.UpdateFromApiResponseJSON(
+		`{"features":{"feat":{"defaultValue":"api"}},"dateUpdated":"2020-01-02T00:00:00Z"}`))
+	require.Equal(t, "api", client.EvalFeature(ctx, "feat").Value)
+}
+
+func TestPollIgnoresCachedEtagWhenInlineFeaturesUsed(t *testing.T) {
+	var sentEtag string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sentEtag = r.Header.Get("If-None-Match")
+		if sentEtag == "cached-etag" {
+			// The bug: a 304 here would freeze the unrelated inline features.
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("etag", "fresh-etag")
+		_, _ = w.Write([]byte(`{"features":{"feat":{"defaultValue":"fromApi"}},"dateUpdated":"2100-01-01T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	cache := NewInMemoryFeatureCache()
+	require.NoError(t, cache.Set(ctx, srv.URL+"::k", &FeatureCacheEntry{
+		Payload: json.RawMessage(`{"features":{"feat":{"defaultValue":"cached"}}}`),
+		Etag:    "cached-etag",
+	}))
+
+	client, err := NewClient(ctx,
+		withSilentTestLogger(),
+		WithHttpClient(srv.Client()), WithApiHost(srv.URL), WithClientKey("k"),
+		WithFeatureCache(cache),
+		WithJsonFeatures(`{"feat":{"defaultValue":"inline"}}`), // inline → seed is skipped
+		WithPollDataSource(time.Hour))
+	require.NoError(t, err)
+	require.NoError(t, client.EnsureLoaded(ctx))
+
+	// Seed was skipped, so poll must not reuse the cached etag; it fetches fresh.
+	require.Empty(t, sentEtag)
+	require.Equal(t, "fromApi", client.EvalFeature(ctx, "feat").Value)
 }

--- a/feature_test.go
+++ b/feature_test.go
@@ -487,3 +487,42 @@ func TestReturnsNullWhenHittingPrerequisiteCycle(t *testing.T) {
 	require.Nil(t, result.Value)
 	require.Equal(t, CyclicPrerequisiteResultSource, result.Source)
 }
+
+// Features are part of the public API, so users marshal them for debug
+// endpoints, diagnostics and home-grown caches. A round-trip must not quietly
+// drop targeting: a rule whose condition is lost fires for every user.
+func TestFeatureMapSurvivesJSONRoundTrip(t *testing.T) {
+	src := `{"feat":{"defaultValue":"off","rules":[{
+		"condition":{"country":"US"},
+		"force":"on",
+		"namespace":["ns",0,0.5],
+		"ranges":[[0,0.5],[0.5,1]]
+	}]}}`
+
+	var features FeatureMap
+	require.NoError(t, json.Unmarshal([]byte(src), &features))
+
+	out, err := json.Marshal(features)
+	require.NoError(t, err)
+
+	var back FeatureMap
+	require.NoError(t, json.Unmarshal(out, &back), "re-parsing marshaled features must not fail")
+
+	rule := back["feat"].Rules[0]
+	require.JSONEq(t, `{"country":"US"}`, mustMarshal(t, rule.Condition))
+	require.Equal(t, Namespace{Id: "ns", Start: 0, End: 0.5}, *rule.Namespace)
+	require.Equal(t, []BucketRange{{0, 0.5}, {0.5, 1}}, rule.Ranges)
+
+	// The decisive check: the rule must still be scoped to US users.
+	client, err := NewClient(ctx, WithFeatures(back), WithAttributes(Attributes{"country": "UA"}))
+	require.NoError(t, err)
+	require.Equal(t, "off", client.EvalFeature(ctx, "feat").Value,
+		"a non-US user must not get the forced value")
+}
+
+func mustMarshal(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}

--- a/internal/condition/marshal.go
+++ b/internal/condition/marshal.go
@@ -1,6 +1,7 @@
 package condition
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -11,6 +12,12 @@ import (
 
 type Base struct {
 	cond Condition
+	// raw is the condition's source JSON, compacted, kept so it can be marshaled
+	// back. Parsing is one-way — the condition tree holds compiled regexps and
+	// operator nodes that cannot be rendered as JSON again — so without it
+	// marshaling would emit an empty object, silently turning a targeted rule
+	// into one that matches everyone.
+	raw json.RawMessage
 }
 
 func (base Base) Eval(actual value.Value, groups SavedGroups) bool {
@@ -26,13 +33,31 @@ func (base *Base) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	json := value.New(m)
-	cond, err := buildBaseCond(json)
+	cond, err := buildBaseCond(value.New(m))
 	if err != nil {
 		return err
 	}
-	*base = Base{cond}
+	// Compact rather than copy the input: it drops insignificant whitespace, so
+	// two conditions that differ only in formatting stay equal under
+	// reflect.DeepEqual, and the buffer is ours (encoding/json may reuse the one
+	// backing data once we return).
+	var raw bytes.Buffer
+	if err := json.Compact(&raw, data); err != nil {
+		return err
+	}
+	*base = Base{cond: cond, raw: raw.Bytes()}
 	return nil
+}
+
+// MarshalJSON writes the condition's source JSON back out, so a feature payload
+// survives a round-trip through JSON without losing its targeting rules. A zero
+// Base (a rule that declares no condition) marshals to an empty object, which
+// parses back to a condition matching everyone — the same meaning it has now.
+func (base Base) MarshalJSON() ([]byte, error) {
+	if len(base.raw) == 0 {
+		return []byte("{}"), nil
+	}
+	return base.raw, nil
 }
 
 func buildBaseCond(json value.Value) (Condition, error) {

--- a/internal/condition/marshal_test.go
+++ b/internal/condition/marshal_test.go
@@ -148,3 +148,45 @@ func TestCaseInsensitiveOperators(t *testing.T) {
 		require.False(t, b.Eval(value.New(map[string]any{"tags": []string{"python", "django"}}), nil))
 	})
 }
+
+func TestBaseMarshalPreservesCondition(t *testing.T) {
+	src := `{"country":"US","age":{"$gt":18},"tags":{"$in":["a","b"]}}`
+
+	var base Base
+	require.NoError(t, json.Unmarshal([]byte(src), &base))
+
+	out, err := json.Marshal(base)
+	require.NoError(t, err)
+	require.JSONEq(t, src, string(out))
+
+	// The re-parsed condition must behave identically to the original.
+	var back Base
+	require.NoError(t, json.Unmarshal(out, &back))
+	attrs := value.New(map[string]any{"country": "US", "age": 21, "tags": []any{"a"}})
+	require.True(t, base.Eval(attrs, nil))
+	require.True(t, back.Eval(attrs, nil))
+
+	other := value.New(map[string]any{"country": "UA", "age": 21, "tags": []any{"a"}})
+	require.False(t, base.Eval(other, nil))
+	require.False(t, back.Eval(other, nil), "round-tripped condition must still reject non-matching users")
+}
+
+func TestZeroBaseMarshalsToEmptyObject(t *testing.T) {
+	// A rule with no condition: marshals to {} and parses back to match-everyone.
+	out, err := json.Marshal(Base{})
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(out))
+
+	var back Base
+	require.NoError(t, json.Unmarshal(out, &back))
+	require.True(t, back.Eval(value.New(map[string]any{}), nil))
+}
+
+func TestBaseEqualityIgnoresFormatting(t *testing.T) {
+	// Conditions are compared by value inside FeatureRule/Experiment, so keeping
+	// the raw JSON must not make formatting significant.
+	var compact, pretty Base
+	require.NoError(t, json.Unmarshal([]byte(`{"premium":true}`), &compact))
+	require.NoError(t, json.Unmarshal([]byte("{\n  \"premium\": true\n}"), &pretty))
+	require.Equal(t, compact, pretty)
+}


### PR DESCRIPTION
## What

Adds a pluggable cache backend for feature data.
- New `FeatureCache` interface (`Get` / `Set`, both returning a backend error) and `FeatureCacheEntry` (raw payload, etag, `UpdatedAt`)
- New `WithFeatureCache(...)` client option
- Thread-safe `InMemoryFeatureCache` reference implementation
- The client seeds features from the cache on startup and writes back after every successful update

## Why

Lets feature data survive restarts and be shared across instances (e.g. a Redis-backed implementation), giving faster cold starts and offline resilience.

## How it works

**The entry stores the raw API response JSON, not parsed structures.** This is the central design decision. A parsed condition tree cannot be marshaled back to JSON — it holds compiled regexps and operator nodes — so persisting parsed features would emit `"condition":{}` and silently drop every targeting rule, making rules match all users. The raw payload round-trips losslessly and also avoids aliasing the client's live feature map.

- Write-through happens on every successful update, so polling, SSE and manual refresh are all covered by one hook.
- **Seeding never writes back.** Applying a cached entry goes through a path that skips the cache write, so a startup read cannot refresh a TTL backend's expiry — otherwise frequent restarts would keep a stale entry alive forever.
- **Cache errors are non-fatal.** `Get`/`Set` distinguish a miss from a backend failure; failures are logged and never fail evaluation.
- On a cold start the poll data source reuses the cached etag **only when the cache actually seeded the client**, so a conditional first request can 304 into the seeded data. With inline `WithFeatures` the seed is skipped, so no etag is reused and the API payload is fetched.
- An etag-less update (e.g. an SSE event) preserves the previously stored etag.
- Inline `WithFeatures` is respected — the cache only seeds when no features are set yet.
- `UpdatedAt` is stamped on every write so backends without their own expiry (a file, say) can age entries out; backends with a TTL (Redis) can ignore it. Stale-while-revalidate can be added later as an additive change.
