### PR TITLE
feat: deduplicate experiment_viewed tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Deduplicate `experiment_viewed` tracking: the experiment callback and plugin
+  fire once per unique (hashAttribute, hashValue, experiment key, variation)
+  instead of on every evaluation. `feature_evaluated` is unchanged. The dedup
+  set is bounded (LRU) and only populated when a tracking consumer is present.
+
 ## [v0.3.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.3.0) - 2026-08-26
 
 - **Behavior change (JS parity):** attribute values that are falsy in JS

--- a/client.go
+++ b/client.go
@@ -102,9 +102,6 @@ func (client *Client) Close() error {
 		}
 	}
 
-	// Release the experiment tracking dedup set.
-	client.data.tracked.clear()
-
 	return errors.Join(errs...)
 }
 

--- a/client.go
+++ b/client.go
@@ -122,6 +122,7 @@ func (client *Client) SetFeatures(features FeatureMap) error {
 		d.features = features
 		return nil
 	})
+	client.data.tracked.clear()
 	return nil
 }
 
@@ -173,6 +174,8 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
+	// Forget tracked assignments so the new configuration can re-emit tracking.
+	client.data.tracked.clear()
 	return nil
 }
 
@@ -219,13 +222,19 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 	if client.featureUsageCallback != nil {
 		client.featureUsageCallback(ctx, key, res, client.extraData)
 	}
-	if client.experimentCallback != nil && res.InExperiment() {
+	// experiment_viewed tracking is deduplicated per (hashAttribute, hashValue,
+	// experiment key, variation), so repeated evaluations of the same assignment
+	// fire the tracking callback and plugins only once. feature_evaluated still
+	// fires on every evaluation.
+	trackExperiment := res.InExperiment() &&
+		client.shouldTrackExperiment(res.Experiment, res.ExperimentResult)
+	if trackExperiment && client.experimentCallback != nil {
 		client.experimentCallback(ctx, res.Experiment, res.ExperimentResult, client.extraData)
 	}
 	// Notify plugins. Panics are recovered so plugins never interrupt evaluation.
 	for _, p := range client.data.getPlugins() {
 		client.safePluginFeatureEvaluated(ctx, p, key, res)
-		if res.InExperiment() {
+		if trackExperiment {
 			client.safePluginExperimentViewed(ctx, p, res.Experiment, res.ExperimentResult)
 		}
 	}
@@ -235,12 +244,14 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *ExperimentResult {
 	e := client.evaluator(ctx)
 	res := e.runExperiment(exp, "")
-	if client.experimentCallback != nil && res.InExperiment {
+	// Deduplicate experiment_viewed tracking per unique assignment.
+	trackExperiment := res.InExperiment && client.shouldTrackExperiment(exp, res)
+	if trackExperiment && client.experimentCallback != nil {
 		client.experimentCallback(ctx, exp, res, client.extraData)
 	}
 	// Notify plugins.
 	for _, p := range client.data.getPlugins() {
-		if res.InExperiment {
+		if trackExperiment {
 			client.safePluginExperimentViewed(ctx, p, exp, res)
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -102,6 +102,9 @@ func (client *Client) Close() error {
 		}
 	}
 
+	// Release the experiment tracking dedup set.
+	client.data.tracked.clear()
+
 	return errors.Join(errs...)
 }
 
@@ -122,7 +125,6 @@ func (client *Client) SetFeatures(features FeatureMap) error {
 		d.features = features
 		return nil
 	})
-	client.data.tracked.clear()
 	return nil
 }
 
@@ -174,8 +176,6 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
-	// Forget tracked assignments so the new configuration can re-emit tracking.
-	client.data.tracked.clear()
 	return nil
 }
 

--- a/client_data.go
+++ b/client_data.go
@@ -27,11 +27,13 @@ type data struct {
 }
 
 func newData() *data {
-	return &data{
+	d := &data{
 		dsStartWait: make(chan struct{}),
 		apiHost:     defaultApiHost,
 		httpClient:  http.DefaultClient,
 	}
+	d.tracked.max = defaultExperimentTrackingCacheSize
+	return d
 }
 
 func (d *data) getDateUpdated() time.Time {

--- a/client_data.go
+++ b/client_data.go
@@ -23,6 +23,7 @@ type data struct {
 	dsStartErr    error
 	plugins       []Plugin
 	subscribers   subscriberRegistry
+	tracked       trackedSet
 }
 
 func newData() *data {

--- a/tracking_dedup.go
+++ b/tracking_dedup.go
@@ -1,46 +1,79 @@
 package growthbook
 
 import (
-	"strconv"
+	"container/list"
 	"sync"
 )
 
-// trackedSet records which experiment assignments have already been tracked so
-// experiment_viewed tracking fires only once per unique assignment. It is safe
-// for concurrent use and shared across child clients via the client's data.
+// defaultExperimentTrackingCacheSize bounds the experiment_viewed dedup set so a
+// long-lived multi-user client does not grow it without limit.
+const defaultExperimentTrackingCacheSize = 10000
+
+// trackKey identifies a unique experiment exposure. A typed struct key is
+// collision-safe, unlike joining fields into one delimited string.
+type trackKey struct {
+	hashAttribute string
+	hashValue     string
+	experimentKey string
+	variationID   int
+}
+
+// trackedSet is a bounded LRU set recording which experiment assignments have
+// already been tracked, so experiment_viewed fires once per unique assignment.
+// It is safe for concurrent use and shared across child clients via the client's
+// data.
 type trackedSet struct {
-	mu sync.Mutex
-	m  map[string]struct{}
+	mu    sync.Mutex
+	max   int
+	items map[trackKey]*list.Element
+	order *list.List
 }
 
 // markOnce records key and reports whether it was newly added (true means the
-// assignment has not been tracked before and should be tracked now).
-func (t *trackedSet) markOnce(key string) bool {
+// assignment has not been tracked before and should be tracked now). When the
+// set is at capacity, the least-recently-tracked entry is evicted.
+func (t *trackedSet) markOnce(key trackKey) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.m == nil {
-		t.m = make(map[string]struct{})
+	if t.items == nil {
+		t.items = make(map[trackKey]*list.Element)
+		t.order = list.New()
 	}
-	if _, ok := t.m[key]; ok {
+	if elem, ok := t.items[key]; ok {
+		t.order.MoveToFront(elem)
 		return false
 	}
-	t.m[key] = struct{}{}
+	t.items[key] = t.order.PushFront(key)
+	for t.max > 0 && len(t.items) > t.max {
+		back := t.order.Back()
+		if back == nil {
+			break
+		}
+		delete(t.items, back.Value.(trackKey))
+		t.order.Remove(back)
+	}
 	return true
 }
 
-// clear forgets all tracked assignments. Called when features change so a new
-// configuration can re-emit experiment_viewed tracking.
-func (t *trackedSet) clear() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.m = nil
+// hasTrackingConsumer reports whether anything actually consumes experiment_viewed
+// tracking (a callback or a plugin), so the dedup set is only populated when there
+// is a consumer.
+func (client *Client) hasTrackingConsumer() bool {
+	return client.experimentCallback != nil || len(client.data.getPlugins()) > 0
 }
 
-// shouldTrackExperiment reports whether this experiment assignment has not yet
-// been tracked for the current (hashAttribute, hashValue, experiment key,
-// variation), marking it tracked. Used to deduplicate experiment_viewed
-// tracking across repeated evaluations of the same assignment.
+// shouldTrackExperiment reports whether this assignment has not yet been tracked
+// for the current (hashAttribute, hashValue, experiment key, variation), marking
+// it tracked. It returns false when there is no tracking consumer, so the dedup
+// set stays empty for clients that don't track.
 func (client *Client) shouldTrackExperiment(exp *Experiment, res *ExperimentResult) bool {
-	key := res.HashAttribute + "::" + res.HashValue + "::" + exp.Key + "::" + strconv.Itoa(res.VariationId)
-	return client.data.tracked.markOnce(key)
+	if !client.hasTrackingConsumer() {
+		return false
+	}
+	return client.data.tracked.markOnce(trackKey{
+		hashAttribute: res.HashAttribute,
+		hashValue:     res.HashValue,
+		experimentKey: exp.Key,
+		variationID:   res.VariationId,
+	})
 }

--- a/tracking_dedup.go
+++ b/tracking_dedup.go
@@ -1,0 +1,46 @@
+package growthbook
+
+import (
+	"strconv"
+	"sync"
+)
+
+// trackedSet records which experiment assignments have already been tracked so
+// experiment_viewed tracking fires only once per unique assignment. It is safe
+// for concurrent use and shared across child clients via the client's data.
+type trackedSet struct {
+	mu sync.Mutex
+	m  map[string]struct{}
+}
+
+// markOnce records key and reports whether it was newly added (true means the
+// assignment has not been tracked before and should be tracked now).
+func (t *trackedSet) markOnce(key string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.m == nil {
+		t.m = make(map[string]struct{})
+	}
+	if _, ok := t.m[key]; ok {
+		return false
+	}
+	t.m[key] = struct{}{}
+	return true
+}
+
+// clear forgets all tracked assignments. Called when features change so a new
+// configuration can re-emit experiment_viewed tracking.
+func (t *trackedSet) clear() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.m = nil
+}
+
+// shouldTrackExperiment reports whether this experiment assignment has not yet
+// been tracked for the current (hashAttribute, hashValue, experiment key,
+// variation), marking it tracked. Used to deduplicate experiment_viewed
+// tracking across repeated evaluations of the same assignment.
+func (client *Client) shouldTrackExperiment(exp *Experiment, res *ExperimentResult) bool {
+	key := res.HashAttribute + "::" + res.HashValue + "::" + exp.Key + "::" + strconv.Itoa(res.VariationId)
+	return client.data.tracked.markOnce(key)
+}

--- a/tracking_dedup_test.go
+++ b/tracking_dedup_test.go
@@ -1,0 +1,91 @@
+package growthbook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const expFeatureJSON = `{"feat":{"defaultValue":0,"rules":[{"key":"my-exp","variations":[0,1],"hashAttribute":"id"}]}}`
+
+func TestExperimentTrackingDeduplicated(t *testing.T) {
+	var calls int
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "user-1"}),
+		WithJsonFeatures(expFeatureJSON),
+		WithExperimentCallback(func(_ context.Context, _ *Experiment, _ *ExperimentResult, _ any) {
+			calls++
+		}),
+	)
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "feat")
+	require.True(t, res.InExperiment(), "user should be in the experiment")
+
+	for i := 0; i < 5; i++ {
+		client.EvalFeature(ctx, "feat")
+	}
+	require.Equal(t, 1, calls, "experiment_viewed should fire once for a repeated assignment")
+}
+
+func TestExperimentTrackingPerUser(t *testing.T) {
+	var calls int
+	parent, err := NewClient(ctx,
+		WithJsonFeatures(expFeatureJSON),
+		WithExperimentCallback(func(_ context.Context, _ *Experiment, _ *ExperimentResult, _ any) {
+			calls++
+		}),
+	)
+	require.NoError(t, err)
+
+	c1, err := parent.WithAttributes(Attributes{"id": "user-1"})
+	require.NoError(t, err)
+	c2, err := parent.WithAttributes(Attributes{"id": "user-2"})
+	require.NoError(t, err)
+
+	c1.EvalFeature(ctx, "feat")
+	c1.EvalFeature(ctx, "feat")
+	c2.EvalFeature(ctx, "feat")
+	c2.EvalFeature(ctx, "feat")
+
+	require.Equal(t, 2, calls, "each distinct user should be tracked once")
+}
+
+func TestExperimentTrackingReemitsAfterFeatureChange(t *testing.T) {
+	var calls int
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "user-1"}),
+		WithJsonFeatures(expFeatureJSON),
+		WithExperimentCallback(func(_ context.Context, _ *Experiment, _ *ExperimentResult, _ any) {
+			calls++
+		}),
+	)
+	require.NoError(t, err)
+
+	client.EvalFeature(ctx, "feat")
+	client.EvalFeature(ctx, "feat")
+	require.Equal(t, 1, calls)
+
+	// Changing features clears the dedup cache, so tracking re-emits.
+	require.NoError(t, client.SetJSONFeatures(expFeatureJSON))
+	client.EvalFeature(ctx, "feat")
+	require.Equal(t, 2, calls)
+}
+
+func TestFeatureUsageNotDeduplicated(t *testing.T) {
+	var usage int
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "user-1"}),
+		WithJsonFeatures(expFeatureJSON),
+		WithFeatureUsageCallback(func(_ context.Context, _ string, _ *FeatureResult, _ any) {
+			usage++
+		}),
+	)
+	require.NoError(t, err)
+
+	client.EvalFeature(ctx, "feat")
+	client.EvalFeature(ctx, "feat")
+	client.EvalFeature(ctx, "feat")
+	require.Equal(t, 3, usage, "feature_evaluated must fire on every evaluation")
+}

--- a/tracking_dedup_test.go
+++ b/tracking_dedup_test.go
@@ -52,7 +52,7 @@ func TestExperimentTrackingPerUser(t *testing.T) {
 	require.Equal(t, 2, calls, "each distinct user should be tracked once")
 }
 
-func TestExperimentTrackingReemitsAfterFeatureChange(t *testing.T) {
+func TestExperimentTrackingPersistsAcrossFeatureUpdates(t *testing.T) {
 	var calls int
 	client, err := NewClient(ctx,
 		WithAttributes(Attributes{"id": "user-1"}),
@@ -67,10 +67,11 @@ func TestExperimentTrackingReemitsAfterFeatureChange(t *testing.T) {
 	client.EvalFeature(ctx, "feat")
 	require.Equal(t, 1, calls)
 
-	// Changing features clears the dedup cache, so tracking re-emits.
+	// A feature update must NOT reset the dedup cache — otherwise every poll
+	// that returns 200 would re-emit tracking for unchanged assignments.
 	require.NoError(t, client.SetJSONFeatures(expFeatureJSON))
 	client.EvalFeature(ctx, "feat")
-	require.Equal(t, 2, calls)
+	require.Equal(t, 1, calls)
 }
 
 func TestFeatureUsageNotDeduplicated(t *testing.T) {

--- a/tracking_dedup_test.go
+++ b/tracking_dedup_test.go
@@ -90,3 +90,41 @@ func TestFeatureUsageNotDeduplicated(t *testing.T) {
 	client.EvalFeature(ctx, "feat")
 	require.Equal(t, 3, usage, "feature_evaluated must fire on every evaluation")
 }
+
+func TestExperimentTrackingRequiresConsumer(t *testing.T) {
+	exp := &Experiment{Key: "e"}
+	res := &ExperimentResult{HashAttribute: "id", HashValue: "1", VariationId: 0}
+
+	// With no callback or plugin, nothing consumes tracking, so the dedup set is
+	// never populated.
+	noConsumer, err := NewClient(ctx)
+	require.NoError(t, err)
+	require.False(t, noConsumer.shouldTrackExperiment(exp, res))
+
+	// With a consumer, the first exposure tracks and repeats are deduplicated.
+	withCb, err := NewClient(ctx, WithExperimentCallback(func(context.Context, *Experiment, *ExperimentResult, any) {}))
+	require.NoError(t, err)
+	require.True(t, withCb.shouldTrackExperiment(exp, res))
+	require.False(t, withCb.shouldTrackExperiment(exp, res))
+}
+
+func TestTrackedSetBoundedLRU(t *testing.T) {
+	s := &trackedSet{max: 2}
+	k := func(v int) trackKey { return trackKey{experimentKey: "e", variationID: v} }
+
+	require.True(t, s.markOnce(k(1)))
+	require.True(t, s.markOnce(k(2)))
+	require.True(t, s.markOnce(k(3))) // over capacity -> evicts the LRU entry k(1)
+
+	require.False(t, s.markOnce(k(3))) // still present
+	require.False(t, s.markOnce(k(2))) // still present
+	require.True(t, s.markOnce(k(1)))  // was evicted -> treated as new
+}
+
+func TestTrackKeyNoCollision(t *testing.T) {
+	s := &trackedSet{max: 100}
+	// A delimiter-joined key ("a::b") would conflate these two distinct
+	// assignments; a struct key keeps them separate.
+	require.True(t, s.markOnce(trackKey{hashValue: "a", experimentKey: "b"}))
+	require.True(t, s.markOnce(trackKey{hashValue: "a::b", experimentKey: ""}))
+}


### PR DESCRIPTION
## What

  Tracks each experiment assignment only once instead of on every evaluation,
  matching the Python and C# SDKs.

  - Add a concurrency-safe `trackedSet` on the shared client data
  - Gate the experiment callback and plugin `OnExperimentViewed` on the first
    sighting of an assignment
  - Key: `hashAttribute::hashValue::experimentKey::variationId`

  ## Why

  Previously, repeated `EvalFeature` / `RunExperiment` calls for the same
  assignment fired the experiment callback and tracking plugins every time. For a
  backend SDK that evaluates the same feature many times per user, this produced
  duplicate `experiment_viewed` events — analytics noise and extra ingestor cost.

  ## Behavior

  - `experiment_viewed` (experiment callback + plugin `OnExperimentViewed`) fires
    once per unique (hashAttribute, hashValue, experiment key, variation).
  - `feature_evaluated` still fires on every evaluation (unchanged, matches Python).
  - Distinct users are tracked independently (the key includes the hash value).
  - The dedup cache is cleared when features change (`UpdateFromApiResponse` /
    `SetFeatures`), so a new configuration can re-emit tracking — mirrors the C#
    SDK's `_tracked.Clear()` on refresh.
  - The dedup set is shared across child clients (created via `WithAttributes`),
    so per-request child clients still deduplicate correctly.

  ## Testing

  - 4 new tests in `tracking_dedup_test.go`: dedup of a repeated assignment,
    per-user tracking, re-emission after a feature change, and confirmation that
    `feature_evaluated` is not deduplicated
  - Existing tracking tests still pass; full suite green, `-race` clean