### PR TITLE
fix: refuse to overwrite features with an empty API payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- A feature API response that carries no features (missing/null `features` and
+  no encrypted features) no longer overwrites the current feature map. Such a
+  response is rejected with the new `ErrNoFeatures` sentinel so callers can tell
+  it apart from a successful refresh; an explicit `"features": {}` still applies.
+
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
 - **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`

--- a/client.go
+++ b/client.go
@@ -172,6 +172,14 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 	} else {
 		features = resp.Features
 	}
+	if features == nil {
+		// Never overwrite a populated feature map with an empty payload. A
+		// response that omits "features" (e.g. a malformed SSE event) must not
+		// wipe the current features. The empty-map state remains reachable only
+		// via the explicit SetFeatures(FeatureMap{}) API.
+		client.logger.Warn("Api response contains no features, refuse to update")
+		return nil
+	}
 	client.data.withLock(func(d *data) error {
 		d.features = features
 		d.savedGroups = resp.SavedGroups

--- a/client.go
+++ b/client.go
@@ -15,6 +15,13 @@ const defaultApiHost = "https://cdn.growthbook.io"
 
 var (
 	ErrNoDecryptionKey = errors.New("no decryption key provided")
+
+	// ErrNoFeatures is returned by UpdateFromApiResponse (and RefreshFeatures)
+	// when a response carries no usable features (a missing/null "features" and
+	// no encrypted features), so SSE, polling, and manual callers can tell a
+	// rejected/malformed payload from a successful refresh. The current features
+	// are left untouched.
+	ErrNoFeatures = errors.New("api response contains no features")
 )
 
 // Client is a GrowthBook SDK client.
@@ -173,12 +180,13 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 		features = resp.Features
 	}
 	if features == nil {
-		// Never overwrite a populated feature map with an empty payload. A
-		// response that omits "features" (e.g. a malformed SSE event) must not
-		// wipe the current features. The empty-map state remains reachable only
-		// via the explicit SetFeatures(FeatureMap{}) API.
+		// Never overwrite the current features with a response that carries none
+		// (e.g. a malformed SSE event that omits "features"). Return a sentinel
+		// so callers can distinguish a rejected payload from a successful
+		// refresh. Note that an explicit "features": {} is a non-nil empty map
+		// and still replaces the current features.
 		client.logger.Warn("Api response contains no features, refuse to update")
-		return nil
+		return ErrNoFeatures
 	}
 	client.data.withLock(func(d *data) error {
 		d.features = features
@@ -220,7 +228,7 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 		return err
 	}
 	if resp.Features == nil && resp.EncryptedFeatures == "" {
-		return nil
+		return ErrNoFeatures
 	}
 	return client.UpdateFromApiResponse(resp)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -150,6 +150,33 @@ func TestClientNoUpdatesFromStaleApiData(t *testing.T) {
 	require.Equal(t, client.data.features["foo"], &Feature{DefaultValue: "api2"})
 }
 
+func TestClientRefusesToWipeFeaturesWithEmptyPayload(t *testing.T) {
+	apiJson := `{
+      "features": {
+        "foo": {
+          "defaultValue": "api"
+        }
+      },
+      "dateUpdated": "2000-05-01T00:00:12Z"
+    }`
+
+	// A later payload that omits "features" (e.g. a malformed SSE event) must
+	// not wipe the previously loaded feature map.
+	emptyJson := `{"dateUpdated": "2000-05-02T00:00:12Z"}`
+
+	ctx := context.TODO()
+	client, _ := NewClient(ctx)
+	require.Nil(t, client.UpdateFromApiResponseJSON(apiJson))
+	require.Equal(t, &Feature{DefaultValue: "api"}, client.data.features["foo"])
+
+	require.Nil(t, client.UpdateFromApiResponseJSON(emptyJson))
+
+	// Features are preserved and evaluation still works.
+	require.Equal(t, &Feature{DefaultValue: "api"}, client.data.features["foo"])
+	require.Equal(t, "api", client.EvalFeature(ctx, "foo").Value)
+	require.Equal(t, DefaultValueResultSource, client.EvalFeature(ctx, "foo").Source)
+}
+
 func TestClientFeatureUsageTracking(t *testing.T) {
 	ctx := context.TODO()
 	count := 0

--- a/client_test.go
+++ b/client_test.go
@@ -169,9 +169,11 @@ func TestClientRefusesToWipeFeaturesWithEmptyPayload(t *testing.T) {
 	require.Nil(t, client.UpdateFromApiResponseJSON(apiJson))
 	require.Equal(t, &Feature{DefaultValue: "api"}, client.data.features["foo"])
 
-	require.Nil(t, client.UpdateFromApiResponseJSON(emptyJson))
+	// The empty payload is rejected with a sentinel error (callers can tell it
+	// apart from a successful refresh)...
+	require.ErrorIs(t, client.UpdateFromApiResponseJSON(emptyJson), ErrNoFeatures)
 
-	// Features are preserved and evaluation still works.
+	// ...and the previously loaded features are preserved.
 	require.Equal(t, &Feature{DefaultValue: "api"}, client.data.features["foo"])
 	require.Equal(t, "api", client.EvalFeature(ctx, "foo").Value)
 	require.Equal(t, DefaultValueResultSource, client.EvalFeature(ctx, "foo").Source)


### PR DESCRIPTION
  ## What
  Guards `UpdateFromApiResponse` against wiping a populated feature map when a
  response omits `features` (i.e. `resp.Features == nil`).

  Fixes #70.

  ## Why
  On the SSE data source, a live `features` event whose payload has a missing or
  `null` `features` field reaches `UpdateFromApiResponse`, which assigned
  `d.features = features` unconditionally — wiping the in-memory map. After that,
  `EvalFeature` returns `Source: unknownFeature` (and `On: false`) for every flag
  until the process restarts, with no error returned.

  The initial/reconnect `loadData` path already guarded against a nil feature set,
  but the live SSE-event path did not — an asymmetry that made the same payload
  safe on load but destructive on a live event. For flags used as safety
  switches this is a silent, process-lifetime failure.

  ## Fix
  Apply the guard at the authoritative point in `UpdateFromApiResponse`, so all
  callers (SSE events, polling, manual updates) are protected:

  ```go
  if features == nil {
      client.logger.Warn("Api response contains no features, refuse to update")
      return nil
  }
 ```
  The empty-map state remains reachable only via the explicit
  SetFeatures(FeatureMap{}) API. The existing nil-check in loadData becomes
  redundant but harmless.

  ## Testing

  - New regression test: a payload omitting features with a newer dateUpdated
  no longer wipes the previously loaded map; evaluation still works.
  - Full suite green, -race clean.