### PR TITLE
Fix bool-vs-null direct equality; sync conformance corpus; add corpus-freshness CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,27 @@
 name: Lint, Build and Test
 on:
   pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
+  corpus-freshness:
+    # Drift check between cases.json and the JS SDK's cases.json.
+    # Fails the build on any "missing" or body-"drift" case not listed in
+    # tests/scripts/corpus_skiplist.json. Extras (Go's local additions) are
+    # reported but never fail.
+    name: Corpus Freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Check corpus freshness vs JS SDK
+        run: python3 tests/scripts/check_corpus_freshness.py
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,8 @@
 name: Lint, Build and Test
 on:
   pull_request:
-  push:
-    branches: [ main ]
 
 jobs:
-  corpus-freshness:
-    # Drift check between cases.json and the JS SDK's cases.json.
-    # Fails the build on any "missing" or body-"drift" case not listed in
-    # tests/scripts/corpus_skiplist.json. Extras (Go's local additions) are
-    # reported but never fail.
-    name: Corpus Freshness
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Check corpus freshness vs JS SDK
-        run: python3 tests/scripts/check_corpus_freshness.py
-
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/corpus-freshness.yml
+++ b/.github/workflows/corpus-freshness.yml
@@ -1,0 +1,47 @@
+# Drift check between cases.json and the JS SDK's cases.json
+# (tests/scripts/check_corpus_freshness.py). Two modes:
+#
+#   - pull_request (path-filtered): deterministic — compares against the pinned
+#     JS revision the local corpus was last synced from, so unrelated Go PRs
+#     can't turn red when JS main moves. Bump PINNED_JS_CASES_URL in the same
+#     commit that syncs cases.json.
+#   - schedule / workflow_dispatch: audit — compares against live JS main to
+#     surface upstream corpus drift; a failed fetch fails the run (an alert
+#     nobody sees is no alert).
+#
+# Fails on any "missing" or body-"drift" case not listed in
+# tests/scripts/corpus_skiplist.json. Extras (Go's local additions) are
+# reported but never fail.
+name: Corpus Freshness
+
+on:
+  pull_request:
+    paths:
+      - 'cases.json'
+      - 'tests/scripts/**'
+      - '.github/workflows/corpus-freshness.yml'
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+env:
+  PINNED_JS_CASES_URL: https://raw.githubusercontent.com/growthbook/growthbook/05fe635c749bf7bac92cc5221cf523b69d572ada/packages/sdk-js/test/cases.json
+
+jobs:
+  corpus-freshness:
+    name: Corpus Freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Check corpus vs pinned JS revision
+        if: github.event_name == 'pull_request'
+        run: python3 tests/scripts/check_corpus_freshness.py --js-source "$PINNED_JS_CASES_URL"
+
+      - name: Audit corpus vs live JS main
+        if: github.event_name != 'pull_request'
+        run: python3 tests/scripts/check_corpus_freshness.py --strict-fetch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Direct (no-operator) condition comparison is now strict, matching the JS SDK's
-  `JSON.stringify` equality: a condition like `{"userId": false}` no longer
-  matches a missing attribute, and values of different types (e.g. `5` vs `"5"`)
-  no longer match. **Compatibility note:** no API changes, but this can change
-  feature targeting results for conditions that relied on the previous coercive
-  equality behavior.
+- Direct (no-operator) boolean condition comparison now matches the JS SDK
+  exactly: a condition like `{"userId": false}` no longer matches a missing or
+  null attribute (JS: `value !== null && !!value === condition`). String and
+  number conditions keep JS's coercive comparison (`value + ""`, `value * 1`).
+  **Compatibility note:** no API changes, but boolean conditions evaluated
+  against missing/null attributes now return false instead of matching `false`.
 - Synced `cases.json` with the JS SDK conformance corpus (0.8.0 bodies; spec
   label 0.7.1 — the four contextual-bandit cases are skiplisted as CB rules are
   not implemented).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Direct (no-operator) condition comparison is now strict, matching the JS SDK's
+  `JSON.stringify` equality: a condition like `{"userId": false}` no longer
+  matches a missing attribute, and values of different types (e.g. `5` vs `"5"`)
+  no longer match. **Compatibility note:** no API changes, but this can change
+  feature targeting results for conditions that relied on the previous coercive
+  equality behavior.
+- Synced `cases.json` with the JS SDK conformance corpus (0.8.0 bodies; spec
+  label 0.7.1 — the four contextual-bandit cases are skiplisted as CB rules are
+  not implemented).
+- Added a corpus-freshness CI check against the JS SDK cases corpus to catch
+  missing or drifted cases (`tests/scripts/check_corpus_freshness.py`).
+
 ## [v0.2.1](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.2.1) - 2025-01-25
 
 - fix WithAttributeOverrides panic when applied to nil attributes

--- a/cases.json
+++ b/cases.json
@@ -6741,6 +6741,31 @@
         "source": "force",
         "ruleId": ""
       }
+    ],
+    [
+      "object value with hashValue key is not coerced",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": {
+              "hashValue": 123
+            }
+          }
+        }
+      },
+      "feature",
+      {
+        "value": {
+          "hashValue": 123
+        },
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
     ]
   ],
   "run": [

--- a/cases.json
+++ b/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.7.0",
+  "specVersion": "0.7.1",
   "evalCondition": [
     [
       "$not - pass",
@@ -63,24 +63,32 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": { "$eq": "a" }
+              "$elemMatch": {
+                "$eq": "a"
+              }
             }
           },
           {
             "$groups": {
-              "$elemMatch": { "$eq": "b" }
+              "$elemMatch": {
+                "$eq": "b"
+              }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": { "$eq": "c" }
+                  "$elemMatch": {
+                    "$eq": "c"
+                  }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": { "$eq": "e" }
+                  "$elemMatch": {
+                    "$eq": "e"
+                  }
                 }
               }
             ]
@@ -88,21 +96,30 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": { "$eq": "f" }
+                "$elemMatch": {
+                  "$eq": "f"
+                }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": { "$eq": "g" }
+                "$elemMatch": {
+                  "$eq": "g"
+                }
               }
             }
           }
         ]
       },
       {
-        "$groups": ["a", "b", "c", "d"]
+        "$groups": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
       },
       true
     ],
@@ -112,24 +129,32 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": { "$eq": "a" }
+              "$elemMatch": {
+                "$eq": "a"
+              }
             }
           },
           {
             "$groups": {
-              "$elemMatch": { "$eq": "b" }
+              "$elemMatch": {
+                "$eq": "b"
+              }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": { "$eq": "c" }
+                  "$elemMatch": {
+                    "$eq": "c"
+                  }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": { "$eq": "e" }
+                  "$elemMatch": {
+                    "$eq": "e"
+                  }
                 }
               }
             ]
@@ -137,21 +162,30 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": { "$eq": "d" }
+                "$elemMatch": {
+                  "$eq": "d"
+                }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": { "$eq": "g" }
+                "$elemMatch": {
+                  "$eq": "g"
+                }
               }
             }
           }
         ]
       },
       {
-        "$groups": ["a", "b", "c", "d"]
+        "$groups": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
       },
       false
     ],
@@ -389,7 +423,11 @@
       "$in - pass",
       {
         "num": {
-          "$in": [1, 2, 3]
+          "$in": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
@@ -401,7 +439,11 @@
       "$in - fail",
       {
         "num": {
-          "$in": [1, 2, 3]
+          "$in": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
@@ -425,11 +467,18 @@
       "$in - array pass 1",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "e", "a"]
+        "tags": [
+          "d",
+          "e",
+          "a"
+        ]
       },
       true
     ],
@@ -437,11 +486,18 @@
       "$in - array pass 2",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "b", "f"]
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
       },
       true
     ],
@@ -449,11 +505,18 @@
       "$in - array pass 3",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "b", "a"]
+        "tags": [
+          "d",
+          "b",
+          "a"
+        ]
       },
       true
     ],
@@ -461,11 +524,18 @@
       "$in - array fail 1",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "e", "f"]
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
       },
       false
     ],
@@ -473,7 +543,10 @@
       "$in - array fail 2",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
@@ -482,10 +555,29 @@
       false
     ],
     [
+      "$in - fail (case sensitive mismatch)",
+      {
+        "country": {
+          "$in": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
       "$nin - pass",
       {
         "num": {
-          "$nin": [1, 2, 3]
+          "$nin": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
@@ -497,7 +589,11 @@
       "$nin - fail",
       {
         "num": {
-          "$nin": [1, 2, 3]
+          "$nin": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
@@ -521,11 +617,18 @@
       "$nin - array fail 1",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "e", "a"]
+        "tags": [
+          "d",
+          "e",
+          "a"
+        ]
       },
       false
     ],
@@ -533,11 +636,18 @@
       "$nin - array fail 2",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "b", "f"]
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
       },
       false
     ],
@@ -545,11 +655,18 @@
       "$nin - array fail 3",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "b", "a"]
+        "tags": [
+          "d",
+          "b",
+          "a"
+        ]
       },
       false
     ],
@@ -557,11 +674,18 @@
       "$nin - array pass 1",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "e", "f"]
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
       },
       true
     ],
@@ -569,13 +693,274 @@
       "$nin - array pass 2",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
         "tags": []
       },
       true
+    ],
+    [
+      "$nin - pass (case sensitive mismatch)",
+      {
+        "country": {
+          "$nin": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (case insensitive match)",
+      {
+        "country": {
+          "$ini": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$ini": [
+            "US",
+            "UK"
+          ]
+        }
+      },
+      {
+        "country": "us"
+      },
+      true
+    ],
+    [
+      "$ini - pass (mixed case)",
+      {
+        "country": {
+          "$ini": [
+            "Us",
+            "Uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - fail (no match)",
+      {
+        "country": {
+          "$ini": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      false
+    ],
+    [
+      "$ini - array pass 1",
+      {
+        "tags": {
+          "$ini": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "A"
+        ]
+      },
+      true
+    ],
+    [
+      "$ini - array pass 2",
+      {
+        "tags": {
+          "$ini": [
+            "A",
+            "B"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
+      },
+      true
+    ],
+    [
+      "$ini - array fail",
+      {
+        "tags": {
+          "$ini": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
+      },
+      false
+    ],
+    [
+      "$ini - not array",
+      {
+        "num": {
+          "$ini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
+    ],
+    [
+      "$nini - pass (case insensitive match)",
+      {
+        "country": {
+          "$nini": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      true
+    ],
+    [
+      "$nini - fail (case insensitive match)",
+      {
+        "country": {
+          "$nini": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
+      "$nini - fail (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$nini": [
+            "US",
+            "UK"
+          ]
+        }
+      },
+      {
+        "country": "us"
+      },
+      false
+    ],
+    [
+      "$nini - array pass",
+      {
+        "tags": {
+          "$nini": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
+      },
+      true
+    ],
+    [
+      "$nini - array fail 1",
+      {
+        "tags": {
+          "$nini": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "A"
+        ]
+      },
+      false
+    ],
+    [
+      "$nini - array fail 2",
+      {
+        "tags": {
+          "$nini": [
+            "A",
+            "B"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
+      },
+      false
+    ],
+    [
+      "$nini - not array",
+      {
+        "num": {
+          "$nini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
     ],
     [
       "$elemMatch - pass - flat arrays",
@@ -587,7 +972,12 @@
         }
       },
       {
-        "nums": [0, 5, -20, 15]
+        "nums": [
+          0,
+          5,
+          -20,
+          15
+        ]
       },
       true
     ],
@@ -601,7 +991,12 @@
         }
       },
       {
-        "nums": [0, 5, -20, 8]
+        "nums": [
+          0,
+          5,
+          -20,
+          8
+        ]
       },
       false
     ],
@@ -609,7 +1004,9 @@
       "missing attribute - fail",
       {
         "pets.dog.name": {
-          "$in": ["fido"]
+          "$in": [
+            "fido"
+          ]
         }
       },
       {
@@ -750,6 +1147,54 @@
       {
         "userAgent": {
           "$regex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      false
+    ],
+    [
+      "$regex - fail (case sensitive mismatch)",
+      {
+        "userAgent": {
+          "$regex": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
+      "$regexi - pass (case insensitive match)",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      true
+    ],
+    [
+      "$regexi - pass (uppercase pattern, lowercase value)",
+      {
+        "userAgent": {
+          "$regexi": "(MOBILE|TABLET)"
+        }
+      },
+      {
+        "userAgent": "android mobile browser"
+      },
+      true
+    ],
+    [
+      "$regexi - fail",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
         }
       },
       {
@@ -1063,7 +1508,10 @@
         }
       },
       {
-        "a": [1, 2]
+        "a": [
+          1,
+          2
+        ]
       },
       true
     ],
@@ -1118,7 +1566,9 @@
     [
       "$size empty - pass",
       {
-        "tags": { "$size": 0 }
+        "tags": {
+          "$size": 0
+        }
       },
       {
         "tags": []
@@ -1128,10 +1578,14 @@
     [
       "$size empty - fail",
       {
-        "tags": { "$size": 0 }
+        "tags": {
+          "$size": 0
+        }
       },
       {
-        "tags": [10]
+        "tags": [
+          10
+        ]
       },
       false
     ],
@@ -1143,7 +1597,11 @@
         }
       },
       {
-        "tags": ["a", "b", "c"]
+        "tags": [
+          "a",
+          "b",
+          "c"
+        ]
       },
       true
     ],
@@ -1155,7 +1613,10 @@
         }
       },
       {
-        "tags": ["a", "b"]
+        "tags": [
+          "a",
+          "b"
+        ]
       },
       false
     ],
@@ -1167,7 +1628,12 @@
         }
       },
       {
-        "tags": ["a", "b", "c", "d"]
+        "tags": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
       },
       false
     ],
@@ -1193,7 +1659,11 @@
         }
       },
       {
-        "tags": [0, 1, 2]
+        "tags": [
+          0,
+          1,
+          2
+        ]
       },
       true
     ],
@@ -1207,7 +1677,10 @@
         }
       },
       {
-        "tags": [0, 1]
+        "tags": [
+          0,
+          1
+        ]
       },
       false
     ],
@@ -1221,7 +1694,9 @@
         }
       },
       {
-        "tags": [0]
+        "tags": [
+          0
+        ]
       },
       false
     ],
@@ -1235,7 +1710,11 @@
         }
       },
       {
-        "tags": ["foo", "bar", "baz"]
+        "tags": [
+          "foo",
+          "bar",
+          "baz"
+        ]
       },
       true
     ],
@@ -1249,7 +1728,10 @@
         }
       },
       {
-        "tags": ["foo", "baz"]
+        "tags": [
+          "foo",
+          "baz"
+        ]
       },
       false
     ],
@@ -1258,12 +1740,19 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": ["a", "b"]
+            "$in": [
+              "a",
+              "b"
+            ]
           }
         }
       },
       {
-        "tags": ["d", "e", "b"]
+        "tags": [
+          "d",
+          "e",
+          "b"
+        ]
       },
       true
     ],
@@ -1272,12 +1761,19 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": ["a", "b"]
+            "$in": [
+              "a",
+              "b"
+            ]
           }
         }
       },
       {
-        "tags": ["d", "e", "f"]
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
       },
       false
     ],
@@ -1293,7 +1789,10 @@
         }
       },
       {
-        "tags": ["foo", "baz"]
+        "tags": [
+          "foo",
+          "baz"
+        ]
       },
       true
     ],
@@ -1309,7 +1808,11 @@
         }
       },
       {
-        "tags": ["foo", "bar", "baz"]
+        "tags": [
+          "foo",
+          "bar",
+          "baz"
+        ]
       },
       false
     ],
@@ -1410,11 +1913,18 @@
       "$all - pass",
       {
         "tags": {
-          "$all": ["one", "three"]
+          "$all": [
+            "one",
+            "three"
+          ]
         }
       },
       {
-        "tags": ["one", "two", "three"]
+        "tags": [
+          "one",
+          "two",
+          "three"
+        ]
       },
       true
     ],
@@ -1422,11 +1932,18 @@
       "$all - fail",
       {
         "tags": {
-          "$all": ["one", "three"]
+          "$all": [
+            "one",
+            "three"
+          ]
         }
       },
       {
-        "tags": ["one", "two", "four"]
+        "tags": [
+          "one",
+          "two",
+          "four"
+        ]
       },
       false
     ],
@@ -1434,7 +1951,120 @@
       "$all - fail not array",
       {
         "tags": {
-          "$all": ["one", "three"]
+          "$all": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": "hello"
+      },
+      false
+    ],
+    [
+      "$all - fail (case sensitive mismatch)",
+      {
+        "tags": {
+          "$all": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "ONE",
+          "two",
+          "THREE"
+        ]
+      },
+      false
+    ],
+    [
+      "$alli - pass (case insensitive match)",
+      {
+        "tags": {
+          "$alli": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "ONE",
+          "two",
+          "THREE"
+        ]
+      },
+      true
+    ],
+    [
+      "$alli - pass (uppercase pattern, lowercase value)",
+      {
+        "tags": {
+          "$alli": [
+            "ONE",
+            "THREE"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "one",
+          "two",
+          "three"
+        ]
+      },
+      true
+    ],
+    [
+      "$alli - pass (mixed case)",
+      {
+        "tags": {
+          "$alli": [
+            "One",
+            "Three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "ONE",
+          "two",
+          "three"
+        ]
+      },
+      true
+    ],
+    [
+      "$alli - fail (case insensitive, missing value)",
+      {
+        "tags": {
+          "$alli": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "ONE",
+          "two",
+          "four"
+        ]
+      },
+      false
+    ],
+    [
+      "$alli - fail not array",
+      {
+        "tags": {
+          "$alli": [
+            "one",
+            "three"
+          ]
         }
       },
       {
@@ -1525,47 +2155,74 @@
     [
       "equals array - pass",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       true
     ],
     [
       "equals array - fail order",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
-        "tags": ["world", "hello"]
+        "tags": [
+          "world",
+          "hello"
+        ]
       },
       false
     ],
     [
       "equals array - fail missing item",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
-        "tags": ["hello"]
+        "tags": [
+          "hello"
+        ]
       },
       false
     ],
     [
       "equals array - fail extra item",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
-        "tags": ["hello", "world", "foo"]
+        "tags": [
+          "hello",
+          "world",
+          "foo"
+        ]
       },
       false
     ],
     [
       "equals array - fail type mismatch",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
         "tags": "hello world"
@@ -1671,6 +2328,34 @@
       {
         "userId": ""
       },
+      false
+    ],
+    [
+      "null condition - false attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": false
+      },
+      false
+    ],
+    [
+      "false condition - missing attribute",
+      {
+        "userId": false
+      },
+      {},
+      false
+    ],
+    [
+      "false strict condition - missing attribute",
+      {
+        "userId": {
+          "$eq": false
+        }
+      },
+      {},
       false
     ],
     [
@@ -2779,7 +3464,14 @@
     [
       "$or pass but second condition fail",
       {
-        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
         "baz": 2
       },
       {
@@ -2792,7 +3484,14 @@
     [
       "$or and second condition both pass",
       {
-        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
         "baz": 2
       },
       {
@@ -2805,8 +3504,22 @@
     [
       "$and condition pass but $or fail",
       {
-        "$and": [{ "foo": 1 }, { "bar": 1 }],
-        "$or": [{ "baz": 1 }, { "empty": 1 }]
+        "$and": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
+        "$or": [
+          {
+            "baz": 1
+          },
+          {
+            "empty": 1
+          }
+        ]
       },
       {
         "foo": 1,
@@ -2818,8 +3531,22 @@
     [
       "$and and $or both pass",
       {
-        "$and": [{ "foo": 1 }, { "bar": 1 }],
-        "$or": [{ "baz": 1 }, { "empty": 1 }]
+        "$and": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
+        "$or": [
+          {
+            "baz": 1
+          },
+          {
+            "empty": 1
+          }
+        ]
       },
       {
         "foo": 1,
@@ -2832,202 +3559,529 @@
     [
       "$inGroup passes for member of known group id",
       {
-        "id": { "$inGroup": "group_id" }
+        "id": {
+          "$inGroup": "group_id"
+        }
       },
-      { "id": 1 },
+      {
+        "id": 1
+      },
       true,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$inGroup fails for non-member of known group id",
       {
-        "id": { "$inGroup": "group_id" }
+        "id": {
+          "$inGroup": "group_id"
+        }
       },
-      { "id": 5 },
+      {
+        "id": 5
+      },
       false,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$inGroup fails for unknown group id",
       {
-        "id": { "$inGroup": "unknowngroup_id" }
+        "id": {
+          "$inGroup": "unknowngroup_id"
+        }
       },
-      { "id": 1 },
+      {
+        "id": 1
+      },
       false,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$notInGroup fails for member of known group id",
       {
-        "id": { "$notInGroup": "group_id" }
+        "id": {
+          "$notInGroup": "group_id"
+        }
       },
-      { "id": 1 },
+      {
+        "id": 1
+      },
       false,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$notInGroup passes for non-member of known group id",
       {
-        "id": { "$notInGroup": "group_id" }
+        "id": {
+          "$notInGroup": "group_id"
+        }
       },
-      { "id": 5 },
+      {
+        "id": 5
+      },
       true,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$notInGroup passes for unknown group id",
       {
-        "id": { "$notInGroup": "unknowngroup_id" }
+        "id": {
+          "$notInGroup": "unknowngroup_id"
+        }
       },
-      { "id": 1 },
+      {
+        "id": 1
+      },
       true,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$inGroup passes for properly typed data",
       {
-        "id": { "$inGroup": "group_id" }
+        "id": {
+          "$inGroup": "group_id"
+        }
       },
-      { "id": "2" },
+      {
+        "id": "2"
+      },
       true,
-      { "group_id": [1, "2", 3] }
+      {
+        "group_id": [
+          1,
+          "2",
+          3
+        ]
+      }
     ],
     [
       "$inGroup fails for improperly typed data",
       {
-        "id": { "$inGroup": "group_id" }
+        "id": {
+          "$inGroup": "group_id"
+        }
       },
-      { "id": "3" },
+      {
+        "id": "3"
+      },
       false,
-      { "group_id": [1, "2", 3] }
+      {
+        "group_id": [
+          1,
+          "2",
+          3
+        ]
+      }
     ]
   ],
   "hash": [
-    ["", "a", 1, 0.22],
-    ["", "b", 1, 0.077],
-    ["b", "a", 1, 0.946],
-    ["ef", "d", 1, 0.652],
-    ["asdf", "8952klfjas09ujk", 1, 0.549],
-    ["", "123", 1, 0.011],
-    ["", "___)((*\":&", 1, 0.563],
-    ["seed", "a", 2, 0.0505],
-    ["seed", "b", 2, 0.2696],
-    ["foo", "ab", 2, 0.2575],
-    ["foo", "def", 2, 0.2019],
-    ["89123klj", "8952klfjas09ujkasdf", 2, 0.124],
-    ["90850943850283058242805", "123", 2, 0.7516],
-    ["()**(%$##$%#$#", "___)((*\":&", 2, 0.0128],
-    ["abc", "def", 99, null]
+    [
+      "",
+      "a",
+      1,
+      0.22
+    ],
+    [
+      "",
+      "b",
+      1,
+      0.077
+    ],
+    [
+      "b",
+      "a",
+      1,
+      0.946
+    ],
+    [
+      "ef",
+      "d",
+      1,
+      0.652
+    ],
+    [
+      "asdf",
+      "8952klfjas09ujk",
+      1,
+      0.549
+    ],
+    [
+      "",
+      "123",
+      1,
+      0.011
+    ],
+    [
+      "",
+      "___)((*\":&",
+      1,
+      0.563
+    ],
+    [
+      "seed",
+      "a",
+      2,
+      0.0505
+    ],
+    [
+      "seed",
+      "b",
+      2,
+      0.2696
+    ],
+    [
+      "foo",
+      "ab",
+      2,
+      0.2575
+    ],
+    [
+      "foo",
+      "def",
+      2,
+      0.2019
+    ],
+    [
+      "89123klj",
+      "8952klfjas09ujkasdf",
+      2,
+      0.124
+    ],
+    [
+      "90850943850283058242805",
+      "123",
+      2,
+      0.7516
+    ],
+    [
+      "()**(%$##$%#$#",
+      "___)((*\":&",
+      2,
+      0.0128
+    ],
+    [
+      "abc",
+      "def",
+      99,
+      null
+    ]
   ],
   "getBucketRange": [
     [
       "normal 50/50",
-      [2, 1, null],
       [
-        [0, 0.5],
-        [0.5, 1]
+        2,
+        1,
+        null
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "reduced coverage",
-      [2, 0.5, null],
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        2,
+        0.5,
+        null
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ]
     ],
     [
       "zero coverage",
-      [2, 0, null],
       [
-        [0, 0],
-        [0.5, 0.5]
+        2,
+        0,
+        null
+      ],
+      [
+        [
+          0,
+          0
+        ],
+        [
+          0.5,
+          0.5
+        ]
       ]
     ],
     [
       "4 variations",
-      [4, 1, null],
       [
-        [0, 0.25],
-        [0.25, 0.5],
-        [0.5, 0.75],
-        [0.75, 1]
+        4,
+        1,
+        null
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.25,
+          0.5
+        ],
+        [
+          0.5,
+          0.75
+        ],
+        [
+          0.75,
+          1
+        ]
       ]
     ],
     [
       "uneven weights",
-      [2, 1, [0.4, 0.6]],
       [
-        [0, 0.4],
-        [0.4, 1]
+        2,
+        1,
+        [
+          0.4,
+          0.6
+        ]
+      ],
+      [
+        [
+          0,
+          0.4
+        ],
+        [
+          0.4,
+          1
+        ]
       ]
     ],
     [
       "uneven weights, 3 variations",
-      [3, 1, [0.2, 0.3, 0.5]],
       [
-        [0, 0.2],
-        [0.2, 0.5],
-        [0.5, 1]
+        3,
+        1,
+        [
+          0.2,
+          0.3,
+          0.5
+        ]
+      ],
+      [
+        [
+          0,
+          0.2
+        ],
+        [
+          0.2,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "uneven weights, reduced coverage, 3 variations",
-      [3, 0.2, [0.2, 0.3, 0.5]],
       [
-        [0, 0.04],
-        [0.2, 0.26],
-        [0.5, 0.6]
+        3,
+        0.2,
+        [
+          0.2,
+          0.3,
+          0.5
+        ]
+      ],
+      [
+        [
+          0,
+          0.04
+        ],
+        [
+          0.2,
+          0.26
+        ],
+        [
+          0.5,
+          0.6
+        ]
       ]
     ],
     [
       "negative coverage",
-      [2, -0.2, null],
       [
-        [0, 0],
-        [0.5, 0.5]
+        2,
+        -0.2,
+        null
+      ],
+      [
+        [
+          0,
+          0
+        ],
+        [
+          0.5,
+          0.5
+        ]
       ]
     ],
     [
       "coverage above 1",
-      [2, 1.5, null],
       [
-        [0, 0.5],
-        [0.5, 1]
+        2,
+        1.5,
+        null
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "weights sum below 1",
-      [2, 1, [0.4, 0.1]],
       [
-        [0, 0.5],
-        [0.5, 1]
+        2,
+        1,
+        [
+          0.4,
+          0.1
+        ]
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "weights sum above 1",
-      [2, 1, [0.7, 0.6]],
       [
-        [0, 0.5],
-        [0.5, 1]
+        2,
+        1,
+        [
+          0.7,
+          0.6
+        ]
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "weights.length not equal to num variations",
-      [4, 1, [0.4, 0.4, 0.2]],
       [
-        [0, 0.25],
-        [0.25, 0.5],
-        [0.5, 0.75],
-        [0.75, 1]
+        4,
+        1,
+        [
+          0.4,
+          0.4,
+          0.2
+        ]
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.25,
+          0.5
+        ],
+        [
+          0.5,
+          0.75
+        ],
+        [
+          0.75,
+          1
+        ]
       ]
     ],
     [
       "weights sum almost equals 1",
-      [2, 1, [0.4, 0.5999]],
       [
-        [0, 0.4],
-        [0.4, 0.9999]
+        2,
+        1,
+        [
+          0.4,
+          0.5999
+        ]
+      ],
+      [
+        [
+          0,
+          0.4
+        ],
+        [
+          0.4,
+          0.9999
+        ]
       ]
     ]
   ],
@@ -3040,40 +4094,60 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "unknownFeature"
+        "source": "unknownFeature",
+        "ruleId": ""
       }
     ],
     [
       "defaults when empty",
-      { "features": { "feature": {} } },
+      {
+        "features": {
+          "feature": {}
+        }
+      },
       "feature",
       {
         "value": null,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
       "uses defaultValue - number",
-      { "features": { "feature": { "defaultValue": 1 } } },
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 1
+          }
+        }
+      },
       "feature",
       {
         "value": 1,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
       "uses custom values - string",
-      { "features": { "feature": { "defaultValue": "yes" } } },
+      {
+        "features": {
+          "feature": {
+            "defaultValue": "yes"
+          }
+        }
+      },
       "feature",
       {
         "value": "yes",
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3095,7 +4169,32 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rule with rule id",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "id": "a",
+                "force": 1
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": "a"
       }
     ],
     [
@@ -3117,7 +4216,8 @@
         "value": false,
         "on": false,
         "off": true,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3143,7 +4243,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3169,7 +4270,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3183,6 +4285,7 @@
             "defaultValue": 2,
             "rules": [
               {
+                "id": "a",
                 "force": 1,
                 "coverage": 0.5
               }
@@ -3195,7 +4298,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3219,7 +4323,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3246,7 +4351,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3263,7 +4369,12 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": { "$in": ["US", "CA"] },
+                  "country": {
+                    "$in": [
+                      "US",
+                      "CA"
+                    ]
+                  },
                   "browser": "firefox"
                 }
               }
@@ -3276,7 +4387,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3293,7 +4405,12 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": { "$in": ["US", "CA"] },
+                  "country": {
+                    "$in": [
+                      "US",
+                      "CA"
+                    ]
+                  },
                   "browser": "firefox"
                 }
               }
@@ -3306,7 +4423,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3333,7 +4451,64 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 includes user",
+      {
+        "attributes": {
+          "id": "user2"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 excludes user that v1 would include",
+      {
+        "attributes": {
+          "id": "user3"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3341,7 +4516,9 @@
       {
         "features": {
           "feature": {
-            "rules": [{}]
+            "rules": [
+              {}
+            ]
           }
         }
       },
@@ -3350,7 +4527,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3363,7 +4541,11 @@
           "feature": {
             "rules": [
               {
-                "variations": ["a", "b", "c"]
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
               }
             ]
           }
@@ -3376,7 +4558,11 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": ["a", "b", "c"]
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -3390,7 +4576,8 @@
           "key": "2",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": ""
       }
     ],
     [
@@ -3403,7 +4590,12 @@
           "feature": {
             "rules": [
               {
-                "variations": ["a", "b", "c"]
+                "id": "id",
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
               }
             ]
           }
@@ -3416,7 +4608,11 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": ["a", "b", "c"]
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -3430,7 +4626,8 @@
           "key": "0",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": "id"
       }
     ],
     [
@@ -3443,7 +4640,11 @@
           "feature": {
             "rules": [
               {
-                "variations": ["a", "b", "c"]
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
               }
             ]
           }
@@ -3456,7 +4657,11 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": ["a", "b", "c"]
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -3470,7 +4675,8 @@
           "key": "1",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": ""
       }
     ],
     [
@@ -3491,8 +4697,14 @@
                 "name": "Test",
                 "phase": "1",
                 "ranges": [
-                  [0, 0.1],
-                  [0.1, 1.0]
+                  [
+                    0,
+                    0.1
+                  ],
+                  [
+                    0.1,
+                    1.0
+                  ]
                 ],
                 "meta": [
                   {
@@ -3508,14 +4720,32 @@
                   {
                     "attribute": "anonId",
                     "seed": "pricing",
-                    "ranges": [[0, 1]]
+                    "ranges": [
+                      [
+                        0,
+                        1
+                      ]
+                    ]
                   }
                 ],
-                "namespace": ["pricing", 0, 1],
+                "namespace": [
+                  "pricing",
+                  0,
+                  1
+                ],
                 "key": "hello",
-                "variations": [true, false],
-                "weights": [0.1, 0.9],
-                "condition": { "premium": true }
+                "variations": [
+                  true,
+                  false
+                ],
+                "weights": [
+                  0.1,
+                  0.9
+                ],
+                "condition": {
+                  "premium": true
+                },
+                "foo": "bar"
               }
             ]
           }
@@ -3530,8 +4760,14 @@
         "experiment": {
           "coverage": 0.99,
           "ranges": [
-            [0, 0.1],
-            [0.1, 1.0]
+            [
+              0,
+              0.1
+            ],
+            [
+              0.1,
+              1.0
+            ]
           ],
           "meta": [
             {
@@ -3547,7 +4783,12 @@
             {
               "attribute": "anonId",
               "seed": "pricing",
-              "ranges": [[0, 1]]
+              "ranges": [
+                [
+                  0,
+                  1
+                ]
+              ]
             }
           ],
           "name": "Test",
@@ -3555,11 +4796,23 @@
           "seed": "feature",
           "hashVersion": 2,
           "hashAttribute": "anonId",
-          "namespace": ["pricing", 0, 1],
+          "namespace": [
+            "pricing",
+            0,
+            1
+          ],
           "key": "hello",
-          "variations": [true, false],
-          "weights": [0.1, 0.9],
-          "condition": { "premium": true }
+          "variations": [
+            true,
+            false
+          ],
+          "weights": [
+            0.1,
+            0.9
+          ],
+          "condition": {
+            "premium": true
+          }
         },
         "experimentResult": {
           "featureId": "feature",
@@ -3573,7 +4826,8 @@
           "key": "v1",
           "name": "variation 1",
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -3588,15 +4842,21 @@
             "rules": [
               {
                 "force": 1,
-                "condition": { "browser": "chrome" }
+                "condition": {
+                  "browser": "chrome"
+                }
               },
               {
                 "force": 2,
-                "condition": { "browser": "firefox" }
+                "condition": {
+                  "browser": "firefox"
+                }
               },
               {
                 "force": 3,
-                "condition": { "browser": "safari" }
+                "condition": {
+                  "browser": "safari"
+                }
               }
             ]
           }
@@ -3607,7 +4867,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3622,15 +4883,24 @@
             "rules": [
               {
                 "force": 1,
-                "condition": { "browser": "chrome" }
+                "id": "1",
+                "condition": {
+                  "browser": "chrome"
+                }
               },
               {
+                "id": "2",
                 "force": 2,
-                "condition": { "browser": "firefox" }
+                "condition": {
+                  "browser": "firefox"
+                }
               },
               {
+                "id": "3",
                 "force": 3,
-                "condition": { "browser": "safari" }
+                "condition": {
+                  "browser": "safari"
+                }
               }
             ]
           }
@@ -3641,7 +4911,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": "3"
       }
     ],
     [
@@ -3656,15 +4927,21 @@
             "rules": [
               {
                 "force": 1,
-                "condition": { "browser": "chrome" }
+                "condition": {
+                  "browser": "chrome"
+                }
               },
               {
                 "force": 2,
-                "condition": { "browser": "firefox" }
+                "condition": {
+                  "browser": "firefox"
+                }
               },
               {
                 "force": 3,
-                "condition": { "browser": "safari" }
+                "condition": {
+                  "browser": "safari"
+                }
               }
             ]
           }
@@ -3675,19 +4952,27 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
       "skips experiment on coverage",
       {
-        "attributes": { "id": "123" },
+        "attributes": {
+          "id": "123"
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3],
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
                 "coverage": 0.01
               },
               {
@@ -3702,20 +4987,32 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
       "skips experiment on namespace",
       {
-        "attributes": { "id": "123" },
+        "attributes": {
+          "id": "123"
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3],
-                "namespace": ["pricing", 0, 0.01]
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "namespace": [
+                  "pricing",
+                  0,
+                  0.01
+                ]
               },
               {
                 "force": 3
@@ -3729,19 +5026,25 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
       "handles integer hashAttribute",
       {
-        "attributes": { "id": 123 },
+        "attributes": {
+          "id": 123
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1]
+                "variations": [
+                  0,
+                  1
+                ]
               }
             ]
           }
@@ -3755,12 +5058,15 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [0, 1]
+          "variations": [
+            0,
+            1
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
           "hashAttribute": "id",
-          "hashValue": "123",
+          "hashValue": 123,
           "hashUsed": true,
           "inExperiment": true,
           "value": 1,
@@ -3768,19 +5074,27 @@
           "key": "1",
           "bucket": 0.863,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
       "skip experiment on missing hashAttribute",
       {
-        "attributes": { "id": "123" },
+        "attributes": {
+          "id": "123"
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3],
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
                 "hashAttribute": "company"
               },
               {
@@ -3795,13 +5109,16 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
       "include experiments when forced",
       {
-        "attributes": { "id": "123" },
+        "attributes": {
+          "id": "123"
+        },
         "forcedVariations": {
           "feature": 1
         },
@@ -3810,7 +5127,12 @@
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3]
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ]
               },
               {
                 "force": 3
@@ -3827,7 +5149,12 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [0, 1, 2, 3]
+          "variations": [
+            0,
+            1,
+            2,
+            3
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -3839,7 +5166,8 @@
           "hashValue": "123",
           "key": "1",
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -3855,7 +5183,10 @@
               {
                 "force": 2,
                 "coverage": 0.01,
-                "range": [0, 0.99]
+                "range": [
+                  0,
+                  0.99
+                ]
               }
             ]
           }
@@ -3866,7 +5197,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3882,7 +5214,10 @@
               {
                 "force": 2,
                 "hashVersion": 2,
-                "range": [0.96, 0.97]
+                "range": [
+                  0.96,
+                  0.97
+                ]
               }
             ]
           }
@@ -3893,7 +5228,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3908,7 +5244,10 @@
             "rules": [
               {
                 "force": 2,
-                "range": [0, 0.01]
+                "range": [
+                  0,
+                  0.01
+                ]
               }
             ]
           }
@@ -3919,7 +5258,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3937,7 +5277,12 @@
                 "filters": [
                   {
                     "seed": "seed",
-                    "ranges": [[0, 0.01]]
+                    "ranges": [
+                      [
+                        0,
+                        0.01
+                      ]
+                    ]
                   }
                 ]
               }
@@ -3950,7 +5295,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3965,7 +5311,10 @@
             "rules": [
               {
                 "force": 2,
-                "range": [0, 0.5],
+                "range": [
+                  0,
+                  0.5
+                ],
                 "seed": "fjdslafdsa",
                 "hashVersion": 2
               }
@@ -3978,7 +5327,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3993,11 +5343,20 @@
             "rules": [
               {
                 "key": "holdout",
-                "variations": [1, 2],
+                "variations": [
+                  1,
+                  2
+                ],
                 "hashVersion": 2,
                 "ranges": [
-                  [0, 0.01],
-                  [0.01, 1.0]
+                  [
+                    0,
+                    0.01
+                  ],
+                  [
+                    0.01,
+                    1.0
+                  ]
                 ],
                 "meta": [
                   {},
@@ -4008,11 +5367,20 @@
               },
               {
                 "key": "experiment",
-                "variations": [3, 4],
+                "variations": [
+                  3,
+                  4
+                ],
                 "hashVersion": 2,
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
@@ -4028,10 +5396,19 @@
         "experiment": {
           "key": "experiment",
           "hashVersion": 2,
-          "variations": [3, 4],
+          "variations": [
+            3,
+            4
+          ],
           "ranges": [
-            [0, 0.5],
-            [0.5, 1.0]
+            [
+              0,
+              0.5
+            ],
+            [
+              0.5,
+              1.0
+            ]
           ]
         },
         "experimentResult": {
@@ -4045,7 +5422,8 @@
           "variationId": 0,
           "bucket": 0.4413,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -4061,10 +5439,19 @@
               {
                 "key": "holdout",
                 "hashVersion": 2,
-                "variations": [1, 2],
+                "variations": [
+                  1,
+                  2
+                ],
                 "ranges": [
-                  [0, 0.99],
-                  [0.99, 1.0]
+                  [
+                    0,
+                    0.99
+                  ],
+                  [
+                    0.99,
+                    1.0
+                  ]
                 ],
                 "meta": [
                   {},
@@ -4076,10 +5463,19 @@
               {
                 "key": "experiment",
                 "hashVersion": 2,
-                "variations": [3, 4],
+                "variations": [
+                  3,
+                  4
+                ],
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
@@ -4095,8 +5491,14 @@
         "experiment": {
           "hashVersion": 2,
           "ranges": [
-            [0, 0.99],
-            [0.99, 1.0]
+            [
+              0,
+              0.99
+            ],
+            [
+              0.99,
+              1.0
+            ]
           ],
           "meta": [
             {},
@@ -4105,7 +5507,10 @@
             }
           ],
           "key": "holdout",
-          "variations": [1, 2]
+          "variations": [
+            1,
+            2
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4118,7 +5523,8 @@
           "variationId": 0,
           "bucket": 0.8043,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -4134,11 +5540,20 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": { "country": "Canada" },
+                "condition": {
+                  "country": "Canada"
+                },
                 "force": "red"
               },
               {
-                "condition": { "country": { "$in": ["USA", "Mexico"] } },
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
                 "force": "green"
               }
             ]
@@ -4150,13 +5565,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -4168,7 +5587,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4187,13 +5607,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -4205,7 +5629,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4221,11 +5646,20 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": { "country": "Canada" },
+                "condition": {
+                  "country": "Canada"
+                },
                 "force": "red"
               },
               {
-                "condition": { "country": { "$in": ["USA", "Mexico"] } },
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
                 "force": "green"
               }
             ]
@@ -4237,13 +5671,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -4255,7 +5693,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4271,11 +5710,20 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": { "country": "Canada" },
+                "condition": {
+                  "country": "Canada"
+                },
                 "force": "red"
               },
               {
-                "condition": { "country": { "$in": ["USA", "Mexico"] } },
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
                 "force": "green"
               }
             ]
@@ -4284,7 +5732,9 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": { "id": "123" },
+                "condition": {
+                  "id": "123"
+                },
                 "force": 2
               }
             ]
@@ -4296,7 +5746,9 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
@@ -4305,13 +5757,19 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": { "value": { "$gt": 1 } },
+                    "condition": {
+                      "value": {
+                        "$gt": 1
+                      }
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -4323,7 +5781,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4342,17 +5801,30 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": { "value": { "$gt": 1 } },
+                    "condition": {
+                      "value": {
+                        "$gt": 1
+                      }
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "country": "Canada" },
+                "condition": {
+                  "country": "Canada"
+                },
                 "force": "red"
               },
               {
-                "condition": { "country": { "$in": ["USA", "Mexico"] } },
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
                 "force": "green"
               }
             ]
@@ -4361,7 +5833,9 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": { "id": "123" },
+                "condition": {
+                  "id": "123"
+                },
                 "force": 2
               }
             ]
@@ -4373,13 +5847,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -4391,7 +5869,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4408,12 +5887,21 @@
             "rules": [
               {
                 "key": "experiment",
-                "variations": [0, 1],
+                "variations": [
+                  0,
+                  1
+                ],
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
@@ -4425,13 +5913,17 @@
                 "parentConditions": [
                   {
                     "id": "parentExperimentFlag",
-                    "condition": { "value": 1 },
+                    "condition": {
+                      "value": 1
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -4443,7 +5935,74 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite experiment flag in target bucket, evaluate skip dependent flag if not bucketed",
+      {
+        "attributes": {
+          "id": "1234",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentExperimentFlag": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "variations": [
+                  0,
+                  1
+                ],
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "ranges": [
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
+                ]
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentExperimentFlag",
+                    "condition": {
+                      "value": 0
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "memberType": "basic"
+                },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4460,7 +6019,9 @@
                 "parentConditions": [
                   {
                     "id": "flag2",
-                    "condition": { "value": true },
+                    "condition": {
+                      "value": true
+                    },
                     "gate": true
                   }
                 ]
@@ -4474,7 +6035,9 @@
                 "parentConditions": [
                   {
                     "id": "flag1",
-                    "condition": { "value": true },
+                    "condition": {
+                      "value": true
+                    },
                     "gate": true
                   }
                 ]
@@ -4488,7 +6051,85 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "cyclicPrerequisite"
+        "source": "cyclicPrerequisite",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Multiple references to same prerequisite, do not break",
+      {
+        "attributes": {
+          "id": "123",
+          "browser": "edge"
+        },
+        "features": {
+          "childFlag": {
+            "defaultValue": true,
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": {
+                        "$ne": false
+                      }
+                    },
+                    "gate": true
+                  },
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": true
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "browser": "safari"
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": true
+                    }
+                  }
+                ],
+                "force": "C"
+              },
+              {
+                "condition": {
+                  "browser": {
+                    "$ne": "safari"
+                  }
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": true
+                    }
+                  }
+                ],
+                "force": "T"
+              }
+            ]
+          },
+          "parentFlag": {
+            "defaultValue": true
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "T",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4503,17 +6144,30 @@
             "rules": [
               {
                 "force": true,
-                "condition": { "id": { "$inGroup": "group_id" } }
+                "condition": {
+                  "id": {
+                    "$inGroup": "group_id"
+                  }
+                }
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [123, 456]
+          "group_id": [
+            123,
+            456
+          ]
         }
       },
       "inGroup_force_rule",
-      { "value": true, "on": true, "off": false, "source": "force" }
+      {
+        "value": true,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
     ],
     [
       "SavedGroups correctly pulled from context for experiment rule",
@@ -4527,19 +6181,35 @@
             "rules": [
               {
                 "key": "experiment",
-                "condition": { "id": { "$inGroup": "group_id" } },
+                "condition": {
+                  "id": {
+                    "$inGroup": "group_id"
+                  }
+                },
                 "hashVersion": 2,
-                "variations": [1, 2],
+                "variations": [
+                  1,
+                  2
+                ],
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [123, 456]
+          "group_id": [
+            123,
+            456
+          ]
         }
       },
       "inGroup_experiment_rule",
@@ -4550,11 +6220,24 @@
         "source": "experiment",
         "experiment": {
           "hashVersion": 2,
-          "condition": { "id": { "$inGroup": "group_id" } },
-          "variations": [1, 2],
+          "condition": {
+            "id": {
+              "$inGroup": "group_id"
+            }
+          },
+          "variations": [
+            1,
+            2
+          ],
           "ranges": [
-            [0, 0.5],
-            [0.5, 1.0]
+            [
+              0,
+              0.5
+            ],
+            [
+              0.5,
+              1.0
+            ]
           ],
           "key": "experiment"
         },
@@ -4562,342 +6245,1291 @@
           "featureId": "inGroup_experiment_rule",
           "hashAttribute": "id",
           "hashUsed": true,
-          "hashValue": "123",
+          "hashValue": 123,
           "inExperiment": true,
           "key": "0",
           "value": 1,
           "variationId": 0,
           "bucket": 0.1736,
           "stickyBucketUsed": false
+        },
+        "ruleId": ""
+      }
+    ],
+    [
+      "multi-armed-bandit type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "multi-armed-bandit"
+              }
+            ]
+          }
         }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "standard type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "standard"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "unknown bandit fields on a non-CB rule are ignored",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "banditVersion": 9
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "force rules - coverage rollout uses seed (included)",
+      {
+        "attributes": {
+          "id": "2"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "seed": "s1"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage rollout uses seed (excluded)",
+      {
+        "attributes": {
+          "id": "5"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "seed": "s1"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage rollout respects filters (filtered out)",
+      {
+        "attributes": {
+          "id": "5"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "filters": [
+                  {
+                    "seed": "s2",
+                    "ranges": [
+                      [
+                        0,
+                        0.5
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage rollout respects filters (in filter range)",
+      {
+        "attributes": {
+          "id": "3"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "filters": [
+                  {
+                    "seed": "s2",
+                    "ranges": [
+                      [
+                        0,
+                        0.5
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage boundary is inclusive (n == coverage)",
+      {
+        "attributes": {
+          "id": "3152"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - skip if hashAttribute missing and no sticky bucketing (fallbackAttribute set)",
+      {
+        "attributes": {
+          "id": "1",
+          "deviceId": "d123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 1,
+                "hashAttribute": "email",
+                "fallbackAttribute": "deviceId"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - skip if hashAttribute missing (no fallback to id)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 1,
+                "hashAttribute": "email"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashAttribute present is used for coverage",
+      {
+        "attributes": {
+          "id": "1",
+          "email": "a@b.c"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 1,
+                "hashAttribute": "email"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
       }
     ]
   ],
   "run": [
     [
       "default weights - 1",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 2",
-      { "attributes": { "id": "2" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "default weights - 3",
-      { "attributes": { "id": "3" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "default weights - 4",
-      { "attributes": { "id": "4" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 5",
-      { "attributes": { "id": "5" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 6",
-      { "attributes": { "id": "6" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 7",
-      { "attributes": { "id": "7" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "default weights - 8",
-      { "attributes": { "id": "8" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 9",
-      { "attributes": { "id": "9" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "uneven weights - 1",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 2",
-      { "attributes": { "id": "2" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 3",
-      { "attributes": { "id": "3" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "uneven weights - 4",
-      { "attributes": { "id": "4" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 5",
-      { "attributes": { "id": "5" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 6",
-      { "attributes": { "id": "6" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 7",
-      { "attributes": { "id": "7" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "uneven weights - 8",
-      { "attributes": { "id": "8" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 9",
-      { "attributes": { "id": "9" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "coverage - 1",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       false,
       false
     ],
     [
       "coverage - 2",
-      { "attributes": { "id": "2" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       true,
       true
     ],
     [
       "coverage - 3",
-      { "attributes": { "id": "3" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       true,
       true
     ],
     [
       "coverage - 4",
-      { "attributes": { "id": "4" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       false,
       false
     ],
     [
       "coverage - 5",
-      { "attributes": { "id": "5" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       1,
       true,
       true
     ],
     [
       "coverage - 6",
-      { "attributes": { "id": "6" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       false,
       false
     ],
     [
       "coverage - 7",
-      { "attributes": { "id": "7" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       true,
       true
     ],
     [
       "coverage - 8",
-      { "attributes": { "id": "8" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       1,
       true,
       true
     ],
     [
       "coverage - 9",
-      { "attributes": { "id": "9" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       false,
       false
     ],
     [
       "three way test - 1",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       2,
       true,
       true
     ],
     [
       "three way test - 2",
-      { "attributes": { "id": "2" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "three way test - 3",
-      { "attributes": { "id": "3" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "three way test - 4",
-      { "attributes": { "id": "4" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       2,
       true,
       true
     ],
     [
       "three way test - 5",
-      { "attributes": { "id": "5" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "three way test - 6",
-      { "attributes": { "id": "6" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       2,
       true,
       true
     ],
     [
       "three way test - 7",
-      { "attributes": { "id": "7" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "three way test - 8",
-      { "attributes": { "id": "8" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "three way test - 9",
-      { "attributes": { "id": "9" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "test name - my-test",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "test name - my-test-3",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test-3", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test-3",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "empty id",
-      { "attributes": { "id": "" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": ""
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       false,
       false
     ],
     [
       "null id",
-      { "attributes": { "id": null } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": null
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       false,
       false
     ],
     [
       "missing id",
-      { "attributes": {} },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {}
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       false,
       false
@@ -4905,31 +7537,68 @@
     [
       "missing attributes",
       {},
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       false,
       false
     ],
     [
       "single variation",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0
+        ]
+      },
       0,
       false,
       false
     ],
     [
       "negative forced variation",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1], "force": -8 },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "force": -8
+      },
       0,
       false,
       false
     ],
     [
       "high forced variation",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1], "force": 25 },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "force": 25
+      },
       0,
       false,
       false
@@ -4944,7 +7613,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "condition": {
           "browser": "firefox"
         }
@@ -4963,7 +7635,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "condition": {
           "browser": "firefox"
         }
@@ -4982,7 +7657,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "hashAttribute": "companyId"
       },
       1,
@@ -4999,7 +7677,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       false,
@@ -5015,7 +7696,10 @@
       },
       {
         "key": "forced-test-qs",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -5031,7 +7715,10 @@
       {
         "key": "my-test",
         "active": true,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -5047,7 +7734,10 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       false,
@@ -5064,7 +7754,10 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -5081,7 +7774,10 @@
         "key": "my-test",
         "force": 1,
         "coverage": 0.01,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       false,
@@ -5117,12 +7813,19 @@
     [
       "Force variation from context",
       {
-        "attributes": { "id": "1" },
-        "forcedVariations": { "my-test": 0 }
+        "attributes": {
+          "id": "1"
+        },
+        "forcedVariations": {
+          "my-test": 0
+        }
       },
       {
         "key": "my-test",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       true,
@@ -5131,12 +7834,17 @@
     [
       "Skips experiments in QA mode",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       false,
@@ -5145,13 +7853,20 @@
     [
       "Works in QA mode if forced in context",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "qaMode": true,
-        "forcedVariations": { "my-test": 1 }
+        "forcedVariations": {
+          "my-test": 1
+        }
       },
       {
         "key": "my-test",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -5160,12 +7875,17 @@
     [
       "Works in QA mode if forced in experiment",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "force": 1
       },
       1,
@@ -5181,8 +7901,15 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
-        "namespace": ["namespace", 0.1, 1]
+        "variations": [
+          0,
+          1
+        ],
+        "namespace": [
+          "namespace",
+          0.1,
+          1
+        ]
       },
       1,
       true,
@@ -5197,8 +7924,15 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
-        "namespace": ["namespace", 0, 0.1]
+        "variations": [
+          0,
+          1
+        ],
+        "namespace": [
+          "namespace",
+          0,
+          0.1
+        ]
       },
       0,
       false,
@@ -5213,7 +7947,10 @@
       },
       {
         "key": "no-coverage",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "coverage": 0
       },
       0,
@@ -5230,19 +7967,33 @@
       },
       {
         "key": "filtered",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [0, 0.1],
-              [0.2, 0.4]
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [[0.8, 1.0]]
+            "ranges": [
+              [
+                0.8,
+                1.0
+              ]
+            ]
           }
         ]
       },
@@ -5260,19 +8011,33 @@
       },
       {
         "key": "filtered",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [0, 0.1],
-              [0.2, 0.4]
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [[0.6, 0.8]]
+            "ranges": [
+              [
+                0.6,
+                0.8
+              ]
+            ]
           }
         ]
       },
@@ -5289,17 +8054,30 @@
       },
       {
         "key": "filtered",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [0, 0.1],
-              [0.2, 0.4]
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
             ]
           }
         ],
-        "namespace": ["test", 0, 0.001]
+        "namespace": [
+          "test",
+          0,
+          0.001
+        ]
       },
       1,
       true,
@@ -5314,13 +8092,25 @@
       },
       {
         "key": "ranges",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "ranges": [
-          [0.99, 1.0],
-          [0.0, 0.99]
+          [
+            0.99,
+            1.0
+          ],
+          [
+            0.0,
+            0.99
+          ]
         ],
         "coverage": 0.01,
-        "weights": [0.99, 0.01]
+        "weights": [
+          0.99,
+          0.01
+        ]
       },
       1,
       true,
@@ -5335,10 +8125,19 @@
       },
       {
         "key": "configs",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "ranges": [
-          [0, 0.1],
-          [0.9, 1.0]
+          [
+            0,
+            0.1
+          ],
+          [
+            0.9,
+            1.0
+          ]
         ]
       },
       0,
@@ -5356,10 +8155,19 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "ranges": [
-          [0, 0.5],
-          [0.5, 1.0]
+          [
+            0,
+            0.5
+          ],
+          [
+            0.5,
+            1.0
+          ]
         ]
       },
       1,
@@ -5377,7 +8185,10 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -5394,8 +8205,14 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [0, 1],
-        "weights": [0.5, 0.5],
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.5,
+          0.5
+        ],
         "coverage": 0.99
       },
       1,
@@ -5405,7 +8222,9 @@
     [
       "Prerequisite condition passes",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "features": {
           "parentFlag": {
             "defaultValue": true
@@ -5414,7 +8233,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -5431,7 +8253,9 @@
     [
       "Prerequisite condition fails",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "features": {
           "parentFlag": {
             "defaultValue": false
@@ -5440,7 +8264,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -5457,15 +8284,29 @@
     [
       "SavedGroups correctly pulled from context for experiment",
       {
-        "attributes": { "id": "4" },
-        "savedGroups": { "group_id": ["4", "5", "6"] }
+        "attributes": {
+          "id": "4"
+        },
+        "savedGroups": {
+          "group_id": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
       },
       {
         "key": "group-filtered-test",
         "condition": {
-          "id": { "$inGroup": "group_id" }
+          "id": {
+            "$inGroup": "group_id"
+          }
         },
-        "variations": [0, 1, 2]
+        "variations": [
+          0,
+          1,
+          2
+        ]
       },
       0,
       true,
@@ -5477,8 +8318,14 @@
       "even range, 0.2",
       0.2,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       0
     ],
@@ -5486,8 +8333,14 @@
       "even range, 0.4",
       0.4,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       0
     ],
@@ -5495,8 +8348,14 @@
       "even range, 0.6",
       0.6,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       1
     ],
@@ -5504,8 +8363,14 @@
       "even range, 0.8",
       0.8,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       1
     ],
@@ -5513,8 +8378,14 @@
       "even range, 0",
       0,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       0
     ],
@@ -5522,8 +8393,14 @@
       "even range, 0.5",
       0.5,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       1
     ],
@@ -5531,8 +8408,14 @@
       "reduced range, 0.2",
       0.2,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       0
     ],
@@ -5540,8 +8423,14 @@
       "reduced range, 0.4",
       0.4,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       -1
     ],
@@ -5549,8 +8438,14 @@
       "reduced range, 0.6",
       0.6,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       1
     ],
@@ -5558,8 +8453,14 @@
       "reduced range, 0.8",
       0.8,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       -1
     ],
@@ -5567,8 +8468,14 @@
       "reduced range, 0.25",
       0.25,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       -1
     ],
@@ -5576,8 +8483,14 @@
       "reduced range, 0.5",
       0.5,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       1
     ],
@@ -5585,17 +8498,44 @@
       "zero range",
       0.5,
       [
-        [0, 0.5],
-        [0.5, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       2
     ]
   ],
   "getQueryStringOverride": [
-    ["empty url", "my-test", "", 2, null],
-    ["no query string", "my-test", "http://example.com", 2, null],
-    ["empty query string", "my-test", "http://example.com?", 2, null],
+    [
+      "empty url",
+      "my-test",
+      "",
+      2,
+      null
+    ],
+    [
+      "no query string",
+      "my-test",
+      "http://example.com",
+      2,
+      null
+    ],
+    [
+      "empty query string",
+      "my-test",
+      "http://example.com?",
+      2,
+      null
+    ],
     [
       "no query string match",
       "my-test",
@@ -5603,14 +8543,62 @@
       2,
       null
     ],
-    ["invalid query string", "my-test", "http://example.com??&&&?#", 2, null],
-    ["simple match 0", "my-test", "http://example.com?my-test=0", 2, 0],
-    ["simple match 1", "my-test", "http://example.com?my-test=1", 2, 1],
-    ["negative variation", "my-test", "http://example.com?my-test=-1", 2, null],
-    ["float", "my-test", "http://example.com?my-test=2.054", 2, null],
-    ["string", "my-test", "http://example.com?my-test=foo", 2, null],
-    ["variation too high", "my-test", "http://example.com?my-test=5", 2, null],
-    ["high numVariations", "my-test", "http://example.com?my-test=5", 6, 5],
+    [
+      "invalid query string",
+      "my-test",
+      "http://example.com??&&&?#",
+      2,
+      null
+    ],
+    [
+      "simple match 0",
+      "my-test",
+      "http://example.com?my-test=0",
+      2,
+      0
+    ],
+    [
+      "simple match 1",
+      "my-test",
+      "http://example.com?my-test=1",
+      2,
+      1
+    ],
+    [
+      "negative variation",
+      "my-test",
+      "http://example.com?my-test=-1",
+      2,
+      null
+    ],
+    [
+      "float",
+      "my-test",
+      "http://example.com?my-test=2.054",
+      2,
+      null
+    ],
+    [
+      "string",
+      "my-test",
+      "http://example.com?my-test=foo",
+      2,
+      null
+    ],
+    [
+      "variation too high",
+      "my-test",
+      "http://example.com?my-test=5",
+      2,
+      null
+    ],
+    [
+      "high numVariations",
+      "my-test",
+      "http://example.com?my-test=5",
+      6,
+      5
+    ],
     [
       "equal to numVariations",
       "my-test",
@@ -5632,33 +8620,215 @@
       2,
       1
     ],
-    ["anchor", "my-test", "http://example.com?my-test=1#foo", 2, 1]
+    [
+      "anchor",
+      "my-test",
+      "http://example.com?my-test=1#foo",
+      2,
+      1
+    ]
   ],
   "inNamespace": [
-    ["user 1, namespace1, 1", "1", ["namespace1", 0, 0.4], false],
-    ["user 1, namespace1, 2", "1", ["namespace1", 0.4, 1], true],
-    ["user 1, namespace2, 1", "1", ["namespace2", 0, 0.4], false],
-    ["user 1, namespace2, 2", "1", ["namespace2", 0.4, 1], true],
-    ["user 2, namespace1, 1", "2", ["namespace1", 0, 0.4], false],
-    ["user 2, namespace1, 2", "2", ["namespace1", 0.4, 1], true],
-    ["user 2, namespace2, 1", "2", ["namespace2", 0, 0.4], false],
-    ["user 2, namespace2, 2", "2", ["namespace2", 0.4, 1], true],
-    ["user 3, namespace1, 1", "3", ["namespace1", 0, 0.4], false],
-    ["user 3, namespace1, 2", "3", ["namespace1", 0.4, 1], true],
-    ["user 3, namespace2, 1", "3", ["namespace2", 0, 0.4], true],
-    ["user 3, namespace2, 2", "3", ["namespace2", 0.4, 1], false],
-    ["user 4, namespace1, 1", "4", ["namespace1", 0, 0.4], false],
-    ["user 4, namespace1, 2", "4", ["namespace1", 0.4, 1], true],
-    ["user 4, namespace2, 1", "4", ["namespace2", 0, 0.4], true],
-    ["user 4, namespace2, 2", "4", ["namespace2", 0.4, 1], false]
+    [
+      "user 1, namespace1, 1",
+      "1",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 1, namespace1, 2",
+      "1",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 1, namespace2, 1",
+      "1",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 1, namespace2, 2",
+      "1",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 2, namespace1, 1",
+      "2",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 2, namespace1, 2",
+      "2",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 2, namespace2, 1",
+      "2",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 2, namespace2, 2",
+      "2",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 3, namespace1, 1",
+      "3",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 3, namespace1, 2",
+      "3",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 3, namespace2, 1",
+      "3",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      true
+    ],
+    [
+      "user 3, namespace2, 2",
+      "3",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      false
+    ],
+    [
+      "user 4, namespace1, 1",
+      "4",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 4, namespace1, 2",
+      "4",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 4, namespace2, 1",
+      "4",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      true
+    ],
+    [
+      "user 4, namespace2, 2",
+      "4",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      false
+    ]
   ],
   "getEqualWeights": [
-    [-1, []],
-    [0, []],
-    [1, [1]],
-    [2, [0.5, 0.5]],
-    [3, [0.33333333, 0.33333333, 0.33333333]],
-    [4, [0.25, 0.25, 0.25, 0.25]]
+    [
+      -1,
+      []
+    ],
+    [
+      0,
+      []
+    ],
+    [
+      1,
+      [
+        1
+      ]
+    ],
+    [
+      2,
+      [
+        0.5,
+        0.5
+      ]
+    ],
+    [
+      3,
+      [
+        0.33333333,
+        0.33333333,
+        0.33333333
+      ]
+    ],
+    [
+      4,
+      [
+        0.25,
+        0.25,
+        0.25,
+        0.25
+      ]
+    ]
   ],
   "decrypt": [
     [
@@ -5726,13 +8896,20 @@
     [
       "use fallbackAttribute when missing hashAttribute",
       {
-        "attributes": { "anonymousId": "123" },
+        "attributes": {
+          "anonymousId": "123"
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3],
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
                 "hashAttribute": "id",
                 "fallbackAttribute": "anonymousId"
               }
@@ -5756,7 +8933,9 @@
       },
       {
         "anonymousId||123": {
-          "assignments": { "feature__0": "3" },
+          "assignments": {
+            "feature__0": "3"
+          },
           "attributeName": "anonymousId",
           "attributeValue": "123"
         }
@@ -5782,11 +8961,31 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -5810,7 +9009,9 @@
       },
       {
         "deviceId||d123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -5836,11 +9037,31 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -5871,7 +9092,9 @@
       },
       {
         "deviceId||d123": {
-          "assignments": { "feature-exp__0": "2" },
+          "assignments": {
+            "feature-exp__0": "2"
+          },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -5897,11 +9120,31 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -5932,7 +9175,9 @@
       },
       {
         "deviceId||d123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -5958,11 +9203,31 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -5993,12 +9258,16 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -6024,11 +9293,31 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -6066,12 +9355,16 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": { "feature-exp__0": "2" },
+          "assignments": {
+            "feature-exp__0": "2"
+          },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -6096,11 +9389,31 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 3,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -6109,7 +9422,9 @@
       },
       [
         {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -6158,11 +9473,31 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -6171,7 +9506,9 @@
       },
       [
         {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -6185,6 +9522,333 @@
           },
           "attributeName": "id",
           "attributeValue": "i123"
+        }
+      }
+    ],
+    [
+      "uses a sticky bucket when sticky bucket version == experiment.minBucketVersion === experiment.bucketVersion",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__3": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "2",
+        "stickyBucketUsed": true,
+        "value": "blue",
+        "variationId": 2
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "skips assignment when sticky bucket version < experiment.minBucketVersion",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__2": "2"
+          }
+        }
+      ],
+      "exp1",
+      null,
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__2": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when bucket version > experiment.bucketVersion (invalid version)",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__4": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "1",
+            "feature-exp__4": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when bucket version < experiment.bucketVersion (invalid version)",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 4,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__3": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "2",
+            "feature-exp__4": "1"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
         }
       }
     ],
@@ -6208,11 +9872,31 @@
                 "hashVersion": 2,
                 "bucketVersion": 1,
                 "disableStickyBucketing": true,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -6223,7 +9907,9 @@
         {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": { "feature-exp__0": "1" }
+          "assignments": {
+            "feature-exp__0": "1"
+          }
         }
       ],
       "exp1",
@@ -6243,7 +9929,9 @@
         "id||i123": {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": { "feature-exp__0": "1" }
+          "assignments": {
+            "feature-exp__0": "1"
+          }
         }
       }
     ]
@@ -6252,7 +9940,9 @@
     [
       "redirects correctly without query strings",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -6264,7 +9954,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -6285,7 +9978,9 @@
     [
       "redirects with query string on original url and persistQueryString enabled",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "url": "http://www.example.com/home?color=blue&food=sushi",
         "experiments": [
           {
@@ -6297,7 +9992,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -6319,7 +10017,9 @@
     [
       "merges query strings on original url & redirect url with param conflicts correctly when persistQueryString enabled",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "url": "http://www.example.com/home?color=blue&food=sushi&title=original",
         "experiments": [
           {
@@ -6331,7 +10031,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -6353,7 +10056,9 @@
     [
       "only performs a redirect for first eligible experiment when there are multiple eligible experiments",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -6365,7 +10070,10 @@
                 "pattern": "http://www.example.com/"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -6382,7 +10090,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -6399,7 +10110,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {

--- a/cases_test.go
+++ b/cases_test.go
@@ -70,15 +70,26 @@ type featureCase struct {
 	Expected    *expectedFeatureResult
 }
 
-// expectedFeatureResult decodes a corpus expected-result blob, stringifying
-// numeric hashValue fields (see stringifyHashValues). Scoped to expected
-// results only so corpus inputs are never modified before evaluation.
+// expectedFeatureResult decodes a corpus expected FeatureResult, stringifying
+// only the nested experimentResult's own hashValue field (see
+// stringifyTopLevelHashValue). Feature values that happen to contain a
+// hashValue key are left untouched.
 type expectedFeatureResult struct{ FeatureResult }
 
 func (e *expectedFeatureResult) UnmarshalJSON(data []byte) error {
-	data, err := stringifyHashValues(data)
-	if err != nil {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
 		return err
+	}
+	if raw, ok := obj["experimentResult"]; ok {
+		fixed, err := stringifyTopLevelHashValue(raw)
+		if err != nil {
+			return err
+		}
+		obj["experimentResult"] = fixed
+		if data, err = json.Marshal(obj); err != nil {
+			return err
+		}
 	}
 	return json.Unmarshal(data, &e.FeatureResult)
 }
@@ -88,7 +99,7 @@ func (e *expectedFeatureResult) UnmarshalJSON(data []byte) error {
 type expectedExperimentResult struct{ ExperimentResult }
 
 func (e *expectedExperimentResult) UnmarshalJSON(data []byte) error {
-	data, err := stringifyHashValues(data)
+	data, err := stringifyTopLevelHashValue(data)
 	if err != nil {
 		return err
 	}
@@ -207,34 +218,26 @@ func TestCasesJson(t *testing.T) {
 	cases.StickyBucket.run("stickyBucket", t)
 }
 
-// stringifyHashValues converts numeric hashValue fields in an expected-result
-// blob to strings. The JS corpus stores hashValue with the raw attribute type,
-// while ExperimentResult.HashValue is a string. Only applied to expected
-// results (via expectedFeatureResult/expectedExperimentResult) — never to
-// corpus inputs.
-func stringifyHashValues(data []byte) ([]byte, error) {
-	var doc any
-	if err := json.Unmarshal(data, &doc); err != nil {
+// stringifyTopLevelHashValue converts a numeric top-level "hashValue" in an
+// ExperimentResult JSON blob to a string. The JS corpus stores hashValue with
+// the raw attribute type, while ExperimentResult.HashValue is a string. Only
+// the blob's own hashValue key is touched — nested values that happen to
+// contain a hashValue key are left as-is.
+func stringifyTopLevelHashValue(data []byte) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil || obj == nil {
+		return data, err
+	}
+	var num float64
+	if err := json.Unmarshal(obj["hashValue"], &num); err != nil {
+		return data, nil
+	}
+	quoted, err := json.Marshal(strconv.FormatFloat(num, 'f', -1, 64))
+	if err != nil {
 		return nil, err
 	}
-	var walk func(node any)
-	walk = func(node any) {
-		switch n := node.(type) {
-		case map[string]any:
-			if v, ok := n["hashValue"].(float64); ok {
-				n["hashValue"] = strconv.FormatFloat(v, 'f', -1, 64)
-			}
-			for _, v := range n {
-				walk(v)
-			}
-		case []any:
-			for _, v := range n {
-				walk(v)
-			}
-		}
-	}
-	walk(doc)
-	return json.Marshal(doc)
+	obj["hashValue"] = quoted
+	return json.Marshal(obj)
 }
 
 func (c evalConditionCase) test(t *testing.T) {

--- a/cases_test.go
+++ b/cases_test.go
@@ -67,7 +67,32 @@ type featureCase struct {
 	Name        string
 	Env         env
 	FeatureName string
-	Expected    *FeatureResult
+	Expected    *expectedFeatureResult
+}
+
+// expectedFeatureResult decodes a corpus expected-result blob, stringifying
+// numeric hashValue fields (see stringifyHashValues). Scoped to expected
+// results only so corpus inputs are never modified before evaluation.
+type expectedFeatureResult struct{ FeatureResult }
+
+func (e *expectedFeatureResult) UnmarshalJSON(data []byte) error {
+	data, err := stringifyHashValues(data)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, &e.FeatureResult)
+}
+
+// expectedExperimentResult is the ExperimentResult counterpart of
+// expectedFeatureResult.
+type expectedExperimentResult struct{ ExperimentResult }
+
+func (e *expectedExperimentResult) UnmarshalJSON(data []byte) error {
+	data, err := stringifyHashValues(data)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, &e.ExperimentResult)
 }
 
 type getBucketRangeCase struct {
@@ -112,7 +137,7 @@ type stickyBucketTestCase struct {
 	Env                 env
 	ExistingAssignments []StickyBucketAssignmentDoc
 	FeatureName         string
-	Expected            *ExperimentResult
+	Expected            *expectedExperimentResult
 	ExpectedAssignments map[string]*StickyBucketAssignmentDoc
 }
 
@@ -164,11 +189,6 @@ func TestCasesJson(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err = stringifyHashValues(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var cases cases
 	if err := json.Unmarshal(data, &cases); err != nil {
 		t.Fatal(err)
@@ -187,9 +207,11 @@ func TestCasesJson(t *testing.T) {
 	cases.StickyBucket.run("stickyBucket", t)
 }
 
-// stringifyHashValues converts numeric hashValue fields in the corpus to
-// strings. The JS corpus stores hashValue with the raw attribute type, while
-// ExperimentResult.HashValue is a string.
+// stringifyHashValues converts numeric hashValue fields in an expected-result
+// blob to strings. The JS corpus stores hashValue with the raw attribute type,
+// while ExperimentResult.HashValue is a string. Only applied to expected
+// results (via expectedFeatureResult/expectedExperimentResult) — never to
+// corpus inputs.
 func stringifyHashValues(data []byte) ([]byte, error) {
 	var doc any
 	if err := json.Unmarshal(data, &doc); err != nil {
@@ -253,7 +275,11 @@ func (c featureCase) test(t *testing.T) {
 		require.Nil(t, err)
 
 		res := client.EvalFeature(context.TODO(), c.FeatureName)
-		require.Equal(t, c.Expected, res)
+		var expected *FeatureResult
+		if c.Expected != nil {
+			expected = &c.Expected.FeatureResult
+		}
+		require.Equal(t, expected, res)
 	})
 }
 
@@ -336,7 +362,7 @@ func (c stickyBucketTestCase) test(t *testing.T) {
 
 		require.NotNil(t, result.ExperimentResult)
 		exp := result.ExperimentResult
-		expected := c.Expected
+		expected := &c.Expected.ExperimentResult
 
 		// Use a table of assertions
 		assertions := []struct {

--- a/cases_test.go
+++ b/cases_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -163,6 +164,11 @@ func TestCasesJson(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	data, err = stringifyHashValues(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var cases cases
 	if err := json.Unmarshal(data, &cases); err != nil {
 		t.Fatal(err)
@@ -179,6 +185,34 @@ func TestCasesJson(t *testing.T) {
 	cases.GetEqualWeights.run("getEqualWeights", t)
 	cases.Decrypt.run("decrypt", t)
 	cases.StickyBucket.run("stickyBucket", t)
+}
+
+// stringifyHashValues converts numeric hashValue fields in the corpus to
+// strings. The JS corpus stores hashValue with the raw attribute type, while
+// ExperimentResult.HashValue is a string.
+func stringifyHashValues(data []byte) ([]byte, error) {
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	var walk func(node any)
+	walk = func(node any) {
+		switch n := node.(type) {
+		case map[string]any:
+			if v, ok := n["hashValue"].(float64); ok {
+				n["hashValue"] = strconv.FormatFloat(v, 'f', -1, 64)
+			}
+			for _, v := range n {
+				walk(v)
+			}
+		case []any:
+			for _, v := range n {
+				walk(v)
+			}
+		}
+	}
+	walk(doc)
+	return json.Marshal(doc)
 }
 
 func (c evalConditionCase) test(t *testing.T) {

--- a/internal/condition/utils.go
+++ b/internal/condition/utils.go
@@ -6,15 +6,25 @@ import (
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
 
-// valueCompare mirrors the JS SDK's direct comparison
-// (JSON.stringify(actual) === JSON.stringify(expected)): a null condition
-// matches null or missing attributes, everything else requires strict
-// type-and-value equality.
+// valueCompare mirrors the JS SDK's direct comparison (mongrule.ts
+// evalConditionValue): string/number conditions coerce the attribute to the
+// condition's type (`value + ""`, `value * 1`), boolean conditions use
+// truthiness but never match null/missing, a null condition matches only
+// null/missing, and arrays/objects compare by deep equality.
 func valueCompare(actual, expected value.Value) bool {
-	if expected.Type() == value.NullType {
+	switch expected.Type() {
+	case value.StrType, value.NumType:
+		return value.Equal(expected, actual.Cast(expected.Type()))
+	case value.BoolType:
+		if value.IsNull(actual) {
+			return false
+		}
+		return value.Equal(expected, actual.Cast(value.BoolType))
+	case value.NullType:
 		return value.IsNull(actual)
+	default:
+		return value.Equal(actual, expected)
 	}
-	return value.Equal(actual, expected)
 }
 
 func isIn(fieldVal value.Value, expected value.ArrValue) bool {

--- a/internal/condition/utils.go
+++ b/internal/condition/utils.go
@@ -6,16 +6,15 @@ import (
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
 
+// valueCompare mirrors the JS SDK's direct comparison
+// (JSON.stringify(actual) === JSON.stringify(expected)): a null condition
+// matches null or missing attributes, everything else requires strict
+// type-and-value equality.
 func valueCompare(actual, expected value.Value) bool {
-	switch expected.Type() {
-	case value.StrType, value.NumType, value.BoolType:
-		casted := actual.Cast(expected.Type())
-		return value.Equal(expected, casted)
-	case value.NullType:
+	if expected.Type() == value.NullType {
 		return value.IsNull(actual)
-	default:
-		return value.Equal(actual, expected)
 	}
+	return value.Equal(actual, expected)
 }
 
 func isIn(fieldVal value.Value, expected value.ArrValue) bool {

--- a/internal/condition/value_cond.go
+++ b/internal/condition/value_cond.go
@@ -2,8 +2,8 @@ package condition
 
 import "github.com/growthbook/growthbook-golang/internal/value"
 
-// ValueCond used when field compared with another value directly, without any operator
-// Growthbook implementation casts field value to expected type in that case before comparison.
+// ValueCond used when field compared with another value directly, without any operator.
+// Matches JS SDK semantics: strict equality, with a null condition matching null or missing.
 type ValueCond struct {
 	expected value.Value
 }

--- a/internal/condition/value_cond.go
+++ b/internal/condition/value_cond.go
@@ -3,7 +3,8 @@ package condition
 import "github.com/growthbook/growthbook-golang/internal/value"
 
 // ValueCond used when field compared with another value directly, without any operator.
-// Matches JS SDK semantics: strict equality, with a null condition matching null or missing.
+// Matches JS SDK semantics: primitive conditions coerce the attribute to the
+// condition's type, except that boolean conditions never match null/missing.
 type ValueCond struct {
 	expected value.Value
 }

--- a/internal/condition/value_cond_test.go
+++ b/internal/condition/value_cond_test.go
@@ -13,18 +13,30 @@ func TestValueCond(t *testing.T) {
 		a any
 		r bool
 	}{
-		{"1", 1, false},
-		{"1", []any{1}, false},
+		// string condition: JS `value + "" === condition`
+		{"1", 1, true},
+		{"1", []any{1}, true},
 		{"1", "1", true},
 		{"1", true, false},
-		{0, "0", false},
+		{"null", nil, true},
+		// number condition: JS `value * 1 === condition`
+		{0, "0", true},
 		{0, 0, true},
-		{0, "", false},
-		{0, false, false},
+		{0, "", true},
+		{0, false, true},
+		{0, nil, true},
+		{1, "abc", false},
+		// boolean condition: JS `value !== null && !!value === condition`
 		{false, false, true},
+		{false, 0, true},
 		{false, nil, false},
+		{true, "0", true},
+		{true, nil, false},
+		// null condition: JS `value === null` (missing attributes read as null)
 		{nil, nil, true},
 		{nil, "1", false},
+		{nil, 0, false},
+		{nil, false, false},
 	}
 	for _, tt := range tests {
 		var c Condition = NewValueCond(tt.e)

--- a/internal/condition/value_cond_test.go
+++ b/internal/condition/value_cond_test.go
@@ -13,14 +13,18 @@ func TestValueCond(t *testing.T) {
 		a any
 		r bool
 	}{
-		{"1", 1, true},
-		{"1", []any{1}, true},
+		{"1", 1, false},
+		{"1", []any{1}, false},
 		{"1", "1", true},
 		{"1", true, false},
-		{0, "0", true},
+		{0, "0", false},
 		{0, 0, true},
-		{0, "", true},
-		{0, false, true},
+		{0, "", false},
+		{0, false, false},
+		{false, false, true},
+		{false, nil, false},
+		{nil, nil, true},
+		{nil, "1", false},
 	}
 	for _, tt := range tests {
 		var c Condition = NewValueCond(tt.e)

--- a/tests/scripts/check_corpus_freshness.py
+++ b/tests/scripts/check_corpus_freshness.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Check Go's cases.json against the JS SDK's cases.json.
+
+The two corpora are maintained by hand; `specVersion` is a label, not a
+contract. This script diffs the corpora and makes drift visible.
+
+Diff categories:
+
+  - "missing" — JS has a case name Go doesn't.
+                Fails CI unless the name is in skiplist["missing"][key].
+  - "drift"   — Both sides have the case name, but the bodies differ
+                (canonical-JSON SHA1 mismatch). Fails CI unless the name
+                is in skiplist["drift"][key]. Catches the silent
+                case-body update that pure name-matching misses.
+  - "extra"   — Go has a case name JS doesn't. Reported as
+                informational only — Go carries documented extensions
+                plus locally-authored regressions. Never fails CI.
+
+Source-of-truth URL is configurable via --js-source or env GB_JS_CASES_URL.
+Defaults to the JS SDK's main-branch raw URL.
+
+Exit codes:
+  0 — no actionable findings (or all on skiplist), OR the JS source could
+      not be fetched (network blip) — that is a warning, not a failure, so a
+      transient outage doesn't break unrelated builds
+  1 — at least one missing or drifted case isn't on the skiplist
+  2 — local IO/parse error (missing cases.json or bad skiplist)
+
+Run locally:
+  python3 tests/scripts/check_corpus_freshness.py
+  python3 tests/scripts/check_corpus_freshness.py --js-source /path/to/local/cases.json
+  GB_JS_CASES_URL=https://... python3 tests/scripts/check_corpus_freshness.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCAL_CASES = REPO_ROOT / "cases.json"
+SKIPLIST = REPO_ROOT / "tests" / "scripts" / "corpus_skiplist.json"
+
+DEFAULT_JS_URL = "https://raw.githubusercontent.com/growthbook/growthbook/main/packages/sdk-js/test/cases.json"
+
+# Top-level keys to diff. Other keys in cases.json (specVersion, decrypt
+# binary blobs, urlRedirect which Go doesn't yet wire, contextualBandit which
+# Go doesn't implement) are skipped either because they're scalar metadata or
+# because the divergence is tracked separately.
+KEYS_TO_DIFF = (
+    "evalCondition",
+    "feature",
+    "run",
+    "hash",
+    "getBucketRange",
+    "chooseVariation",
+    "getQueryStringOverride",
+    "inNamespace",
+    "getEqualWeights",
+    "stickyBucket",
+)
+
+
+def _fetch_js_cases(source: str) -> dict:
+    """Fetch JS cases.json from a URL or local path."""
+    if source.startswith(("http://", "https://")):
+        try:
+            req = urllib.request.Request(source, headers={"User-Agent": "growthbook-golang-corpus-check"})
+            with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"fetch failed: {source}: {e}") from e
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"JS source did not return valid JSON: {e}") from e
+    path = Path(source)
+    if not path.is_file():
+        raise RuntimeError(f"local source not found: {source}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"local source invalid JSON: {e}") from e
+
+
+def _load_local_cases() -> dict:
+    if not LOCAL_CASES.is_file():
+        raise RuntimeError(f"local cases.json not found: {LOCAL_CASES}")
+    return json.loads(LOCAL_CASES.read_text(encoding="utf-8"))
+
+
+def _load_skiplist() -> Dict[str, Dict[str, Set[str]]]:
+    """Load skiplist. File format:
+
+        {
+          "missing": { "<top_level_key>": ["case name", ...] },
+          "drift":   { "<top_level_key>": ["case name", ...] }
+        }
+
+    `missing` — case names JS has and Go deliberately doesn't carry yet.
+    `drift`   — case names where Go deliberately keeps a different body.
+
+    Extras (Go has, JS doesn't) are reported but never fail. The file is
+    optional.
+    """
+    if not SKIPLIST.is_file():
+        return {"missing": {}, "drift": {}}
+    try:
+        data = json.loads(SKIPLIST.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"skiplist invalid JSON: {e}") from e
+    return {
+        "missing": {k: set(v) for k, v in (data.get("missing") or {}).items()},
+        "drift": {k: set(v) for k, v in (data.get("drift") or {}).items()},
+    }
+
+
+def _case_signatures_grouped(cases: list) -> Dict[str, List[str]]:
+    """Return {case_name: [body_hash, ...]} preserving order.
+
+    Body = everything after the name (case[1:]), serialized via canonical
+    JSON (sorted keys + compact separators) so logically-equal cases hash
+    the same regardless of key order or whitespace. Same-named cases keep
+    every occurrence so drift in any duplicate is visible.
+    """
+    out: Dict[str, List[str]] = {}
+    for c in cases:
+        if not (isinstance(c, list) and c and isinstance(c[0], str)):
+            continue
+        name = c[0]
+        body = json.dumps(c[1:], sort_keys=True, separators=(",", ":"))
+        h = hashlib.sha1(body.encode("utf-8")).hexdigest()[:16]
+        out.setdefault(name, []).append(h)
+    return out
+
+
+def _diff(
+    js_cases: dict, local_cases: dict, skip: Dict[str, Set[str]]
+) -> Tuple[Dict[str, List[str]], Dict[str, List[str]], Dict[str, List[str]], Dict[str, List[str]], Dict[str, List[str]]]:
+    actionable_missing: Dict[str, List[str]] = {}
+    skipped_missing: Dict[str, List[str]] = {}
+    extras: Dict[str, List[str]] = {}
+    actionable_drift: Dict[str, List[str]] = {}
+    skipped_drift: Dict[str, List[str]] = {}
+
+    missing_skip = skip.get("missing", {})
+    drift_skip = skip.get("drift", {})
+
+    for key in KEYS_TO_DIFF:
+        js_list = js_cases.get(key, [])
+        local_list = local_cases.get(key, [])
+        if not isinstance(js_list, list) or not isinstance(local_list, list):
+            continue
+
+        js_grouped = _case_signatures_grouped(js_list)
+        local_grouped = _case_signatures_grouped(local_list)
+
+        js_names_ordered: List[str] = []
+        seen_js: Set[str] = set()
+        for c in js_list:
+            if isinstance(c, list) and c and isinstance(c[0], str) and c[0] not in seen_js:
+                js_names_ordered.append(c[0])
+                seen_js.add(c[0])
+
+        local_names_ordered: List[str] = []
+        seen_local: Set[str] = set()
+        for c in local_list:
+            if isinstance(c, list) and c and isinstance(c[0], str) and c[0] not in seen_local:
+                local_names_ordered.append(c[0])
+                seen_local.add(c[0])
+
+        missing = [n for n in js_names_ordered if n not in local_grouped]
+        extra = [n for n in local_names_ordered if n not in js_grouped]
+        drift = [n for n in js_names_ordered if n in local_grouped and Counter(js_grouped[n]) != Counter(local_grouped[n])]
+
+        key_missing_skip = missing_skip.get(key, set())
+        key_drift_skip = drift_skip.get(key, set())
+
+        actionable_missing[key] = [n for n in missing if n not in key_missing_skip]
+        skipped_missing[key] = [n for n in missing if n in key_missing_skip]
+        extras[key] = extra
+        actionable_drift[key] = [n for n in drift if n not in key_drift_skip]
+        skipped_drift[key] = [n for n in drift if n in key_drift_skip]
+
+    return actionable_missing, skipped_missing, extras, actionable_drift, skipped_drift
+
+
+def _spec_versions(js_cases: dict, local_cases: dict) -> Tuple[str, str]:
+    return (str(js_cases.get("specVersion", "<unset>")), str(local_cases.get("specVersion", "<unset>")))
+
+
+def _format_report(
+    js_spec: str,
+    local_spec: str,
+    actionable_missing: Dict[str, List[str]],
+    skipped_missing: Dict[str, List[str]],
+    extras: Dict[str, List[str]],
+    actionable_drift: Dict[str, List[str]],
+    skipped_drift: Dict[str, List[str]],
+) -> str:
+    lines = []
+    lines.append("=== Corpus freshness check (Go vs JS SDK) ===")
+    lines.append(f"  JS specVersion: {js_spec}")
+    lines.append(f"  Go specVersion: {local_spec}")
+    if js_spec != local_spec:
+        lines.append("  ⚠ specVersion mismatch — bump Go's value when you catch up to JS's.")
+    lines.append("")
+
+    n_missing = sum(len(v) for v in actionable_missing.values())
+    n_skip_missing = sum(len(v) for v in skipped_missing.values())
+    n_drift = sum(len(v) for v in actionable_drift.values())
+    n_skip_drift = sum(len(v) for v in skipped_drift.values())
+    n_extra = sum(len(v) for v in extras.values())
+
+    if n_missing + n_drift == 0:
+        lines.append(f"OK: no missing/drifted cases (skipped-missing: {n_skip_missing}, skipped-drift: {n_skip_drift}, extras: {n_extra})")
+    else:
+        lines.append(f"DRIFT: {n_missing} missing + {n_drift} body-drift (skipped: {n_skip_missing} missing, {n_skip_drift} drift; {n_extra} Go extras)")
+    lines.append("")
+
+    def _section(title: str, data: Dict[str, List[str]]) -> None:
+        if not any(data.values()):
+            return
+        lines.append(f"--- {title} ---")
+        for key, names in data.items():
+            if not names:
+                continue
+            lines.append(f"  [{key}] ({len(names)})")
+            for n in names:
+                lines.append(f"    - {n}")
+        lines.append("")
+
+    _section("Missing in Go (FAILS CI)", actionable_missing)
+    _section("Body-drift: same name, different case body (FAILS CI)", actionable_drift)
+    _section("Missing in Go — skipped via corpus_skiplist.json", skipped_missing)
+    _section("Body-drift — skipped via corpus_skiplist.json", skipped_drift)
+    _section("Extra in Go (informational; never fails)", extras)
+    return "\n".join(lines)
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--js-source",
+        default=os.environ.get("GB_JS_CASES_URL", DEFAULT_JS_URL),
+        help="URL or local path to JS cases.json (default: JS SDK main branch)",
+    )
+    parser.add_argument("--json", action="store_true", help="output machine-readable JSON instead of text")
+    args = parser.parse_args(argv)
+
+    # Local corpus / skiplist problems are real repo errors → hard fail.
+    try:
+        local_cases = _load_local_cases()
+        skip = _load_skiplist()
+    except RuntimeError as e:
+        print(f"corpus check infra error: {e}", file=sys.stderr)
+        return 2
+
+    # A failure to fetch the JS source (network blip, GitHub outage) must not
+    # break the build — the check is advisory drift detection, not a gate on
+    # the SDK itself. Warn and pass.
+    try:
+        js_cases = _fetch_js_cases(args.js_source)
+    except RuntimeError as e:
+        print(f"WARNING: corpus freshness check skipped — could not fetch JS cases: {e}", file=sys.stderr)
+        return 0
+
+    actionable_missing, skipped_missing, extras, actionable_drift, skipped_drift = _diff(js_cases, local_cases, skip)
+    js_spec, local_spec = _spec_versions(js_cases, local_cases)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "js_specVersion": js_spec,
+                    "go_specVersion": local_spec,
+                    "missing_actionable": actionable_missing,
+                    "missing_skipped": skipped_missing,
+                    "drift_actionable": actionable_drift,
+                    "drift_skipped": skipped_drift,
+                    "extras": extras,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(_format_report(js_spec, local_spec, actionable_missing, skipped_missing, extras, actionable_drift, skipped_drift))
+
+    fail = any(actionable_missing.values()) or any(actionable_drift.values())
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/check_corpus_freshness.py
+++ b/tests/scripts/check_corpus_freshness.py
@@ -22,9 +22,12 @@ Defaults to the JS SDK's main-branch raw URL.
 Exit codes:
   0 — no actionable findings (or all on skiplist), OR the JS source could
       not be fetched (network blip) — that is a warning, not a failure, so a
-      transient outage doesn't break unrelated builds
+      transient outage doesn't break unrelated builds; pass --strict-fetch
+      to make a failed fetch exit 2 instead (for scheduled audit runs,
+      where a silently skipped check is a missed alert)
   1 — at least one missing or drifted case isn't on the skiplist
-  2 — local IO/parse error (missing cases.json or bad skiplist)
+  2 — local IO/parse error (missing cases.json or bad skiplist), or a
+      failed fetch under --strict-fetch
 
 Run locally:
   python3 tests/scripts/check_corpus_freshness.py
@@ -252,6 +255,11 @@ def main(argv: List[str] | None = None) -> int:
         help="URL or local path to JS cases.json (default: JS SDK main branch)",
     )
     parser.add_argument("--json", action="store_true", help="output machine-readable JSON instead of text")
+    parser.add_argument(
+        "--strict-fetch",
+        action="store_true",
+        help="treat a failed fetch of the JS source as an error (exit 2) instead of warn-and-pass",
+    )
     args = parser.parse_args(argv)
 
     # Local corpus / skiplist problems are real repo errors → hard fail.
@@ -263,11 +271,15 @@ def main(argv: List[str] | None = None) -> int:
         return 2
 
     # A failure to fetch the JS source (network blip, GitHub outage) must not
-    # break the build — the check is advisory drift detection, not a gate on
-    # the SDK itself. Warn and pass.
+    # break a PR build — the check is advisory drift detection, not a gate on
+    # the SDK itself. Warn and pass, unless --strict-fetch (scheduled audit
+    # runs, where a silently skipped check is a missed alert).
     try:
         js_cases = _fetch_js_cases(args.js_source)
     except RuntimeError as e:
+        if args.strict_fetch:
+            print(f"corpus check fetch error: {e}", file=sys.stderr)
+            return 2
         print(f"WARNING: corpus freshness check skipped — could not fetch JS cases: {e}", file=sys.stderr)
         return 0
 

--- a/tests/scripts/corpus_skiplist.json
+++ b/tests/scripts/corpus_skiplist.json
@@ -1,0 +1,15 @@
+{
+  "_doc": "Skiplist for the corpus freshness check (tests/scripts/check_corpus_freshness.py). Two buckets:\n  * \"missing\" — case names JS has and Go deliberately doesn't carry yet. Use when JS adds a case for a feature Go doesn't (yet) support.\n  * \"drift\"   — case names where Go deliberately keeps a different body from JS. Use sparingly — body-drift on a shared case is usually a bug.\nExtras (Go has, JS doesn't) are reported but never fail CI, so they don't need an entry here.\nAdd a brief reason in `_reasons` whenever you add an entry so future maintainers know why.",
+  "missing": {
+    "feature": [
+      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
+      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
+      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
+      "CB rule with empty contexts is overridden by forced variation like a normal experiment"
+    ]
+  },
+  "drift": {},
+  "_reasons": {
+    "feature::CB rule *": "Contextual Bandit (multi-armed-bandit) rule support is not implemented in the Go SDK (spec 0.8.0: contextualBandits payload). The related non-CB cases (multi-armed-bandit/standard type treated as standard experiment, unknown bandit fields ignored) already pass in Go and are carried in cases.json; only the four cases that require CB bucketing are skiplisted. Tracked as a roadmap item; skiplisting keeps the freshness check green while still flagging future non-bandit drift."
+  }
+}


### PR DESCRIPTION
## Summary
Go counterpart of the Python/Rust conformance work: 
- fix the one corpus-pinned divergence from the JS SDK, 
- sync `cases.json` to the current JS corpus, 
- add a corpus-freshness CI check.

## Root cause
- `valueCompare` cast Null → `false` for boolean conditions, so `{"userId": false}`  matched a missing attribute. JS ([mongrule.ts#L81-L100](https://github.com/growthbook/growthbook/blob/9d5bcb6d1b8799313f395bc5e169f06614135265/packages/sdk-js/src/mongrule.ts#L81-L100))  evaluates booleans as `value !== null && !!value === condition`.
- Pinned by corpus case `false condition - missing attribute` (spec 0.7.1) — failed before the fix.
- Restores JS's primitive coercion (`value + ""`, `value * 1`). Net diff vs main is only the  bool-vs-null case.

## Behavioral change
- Boolean direct conditions vs missing/null attributes: match → no match. Nothing else —
  string/number coercion (`{"count": 0}` still matches `""`/`false`/missing) and `$eq`  strictness are unchanged.

## Corpus + CI
- `cases.json`: 0.7.0 → JS 0.8.0 bodies, spec label `0.7.1` (Python/Rust convention);  `432 → 482` executed cases;   4 contextual-bandit cases skiplisted; 8 rollout/fallback pinning cases carried from Rust.
- `ExperimentResult.HashValue` stays `string` (public API); numeric corpus `hashValue`s are stringified when decoding expected results in `cases_test.go` (never inputs).
- `tests/scripts/check_corpus_freshness.py` (ported from growthbook-rust): diffs case names + canonical-JSON body hashes vs the JS corpus; fails on unskiplisted missing/drift; 
- Own workflow (`corpus-freshness.yml`), `ci.yml` untouched: PR runs are deterministic  (pinned to the JS revision the corpus was synced from, path-filtered to corpus files);  weekly schedule + manual dispatch audit live JS `main` with `--strict-fetch` (a failed  fetch fails the audit; on PRs it warns and passes).

## Test plan
- [x] `go test -race -timeout=15m ./...` — green (482 corpus cases, was 432)
- [x] `TestValueCond`: 20-row truth table covering all four JS branches, cross-checked against Node
- [x] Checker vs pinned rev `05fe635c` → exit 0 (4 skiplisted, 8 extras); drift self-test with
  one flipped boolean → exit 1 naming the case; unreachable source → warn/exit 0, `--strict-fetch` → exit 2

## Follow-ups
- `getHashAttribute` truthiness for `0`/`false`/`""`; 
- rollout `fallbackAttribute` under active sticky bucketing; 
- double prerequisite evaluation via`experimentFromFeatureRule`; 
- sticky-bucket assignments map race (separate branch in flight).