### PR TITLE
Fix data race on shared sticky bucket assignments cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ All notable changes to this project will be documented in this file.
   without synchronization. The cache is now mutex-guarded, and assignment
   documents are no longer mutated in place once stored.
 - Concurrent sticky bucket saves for the same user now merge instead of
-  overwriting each other (saves are serialized per document key).
+  overwriting each other (saves are serialized per document key). The
+  guarantee is scoped to a client and its clones: independently constructed
+  clients or separate processes sharing one `StickyBucketService` can still
+  race at the service, whose `SaveAssignments` is last-write-wins.
+- Cache-miss reads of sticky bucket assignment docs run under the same
+  per-document lock as saves, so a read racing a save can no longer
+  re-install a stale doc after the save's fresher one was evicted from the
+  bounded cache.
 - The sticky bucket assignments cache is now bounded (LRU, 10000 entries by
   default) instead of growing with every attribute value evaluated. New
   `WithStickyBucketCacheSize` client option tunes or removes the bound.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fixed a data race on the sticky bucket assignments cache: it is shared by
+  reference between a client and its clones and was mutated during evaluation
+  without synchronization. The cache is now mutex-guarded, and assignment
+  documents are no longer mutated in place once stored.
+- Concurrent sticky bucket saves for the same user now merge instead of
+  overwriting each other (saves are serialized per document key).
+- The sticky bucket assignments cache is now bounded (LRU, 10000 entries by
+  default) instead of growing with every attribute value evaluated. New
+  `WithStickyBucketCacheSize` client option tunes or removes the bound.
 - Direct (no-operator) boolean condition comparison now matches the JS SDK
   exactly: a condition like `{"userId": false}` no longer matches a missing or
   null attribute (JS: `value !== null && !!value === condition`). String and

--- a/README.md
+++ b/README.md
@@ -226,9 +226,21 @@ Implement the `StickyBucketService` interface for custom storage:
 
 #### Concurrency & Caching
 
-- The in-memory implementation is thread-safe using `sync.RWMutex`
-- Assignments are cached in memory to reduce storage calls
-- Cache is shared across all clients using the same service instance
+- The in-memory service implementation is thread-safe using `sync.RWMutex`
+- Assignments are cached per client to reduce storage calls; the cache is
+  shared between a client and its child clients (created via `With*` methods)
+  and is bounded (LRU, 10,000 docs by default — tune or remove the bound with
+  `WithStickyBucketCacheSize`)
+- Within a client and its children, concurrent reads and saves of the same
+  user's assignment doc are serialized, so parallel evaluations merge
+  assignments instead of overwriting each other
+- **Scope of the guarantee:** independently constructed clients — or separate
+  processes — sharing one `StickyBucketService` are not serialized against
+  each other. `SaveAssignments` writes whole documents last-write-wins, so
+  truly concurrent saves for the same user from different clients can drop
+  an assignment. If that matters for your deployment, make your service's
+  `SaveAssignments` merge atomically in the backend (e.g. a Redis hash or a
+  transactional upsert)
 
 For more details, see the [official documentation](https://docs.growthbook.io/app/sticky-bucketing).
 

--- a/cases_test.go
+++ b/cases_test.go
@@ -352,7 +352,7 @@ func (c stickyBucketTestCase) test(t *testing.T) {
 		client, err := c.Env.client()
 		require.NoError(t, err)
 		client.stickyBucketService = service
-		client.stickyBucketAssignments = newStickyBucketCache()
+		client.stickyBucketAssignments = newStickyBucketCache(defaultStickyBucketCacheSize)
 
 		// Evaluate feature
 		result := client.EvalFeature(context.TODO(), c.FeatureName)

--- a/cases_test.go
+++ b/cases_test.go
@@ -289,7 +289,7 @@ func (c stickyBucketTestCase) test(t *testing.T) {
 		client, err := c.Env.client()
 		require.NoError(t, err)
 		client.stickyBucketService = service
-		client.stickyBucketAssignments = make(StickyBucketAssignments)
+		client.stickyBucketAssignments = newStickyBucketCache()
 
 		// Evaluate feature
 		result := client.EvalFeature(context.TODO(), c.FeatureName)

--- a/client.go
+++ b/client.go
@@ -111,7 +111,7 @@ func defaultClient() *Client {
 		qaMode:                  false,
 		logger:                  slog.Default(),
 		attributes:              value.ObjValue{},
-		stickyBucketAssignments: newStickyBucketCache(),
+		stickyBucketAssignments: newStickyBucketCache(defaultStickyBucketCacheSize),
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -36,8 +36,9 @@ type Client struct {
 	// StickyBucketAttributes for identifying users
 	stickyBucketAttributes StickyBucketAttributes
 
-	// StickyBucketAssignments caches assignments
-	stickyBucketAssignments StickyBucketAssignments
+	// stickyBucketAssignments caches assignments. Shared by reference with
+	// cloned clients and mutated during evaluation, hence mutex-guarded.
+	stickyBucketAssignments *lockedStickyBucketCache
 }
 
 // ForcedVariationsMap is a map that forces an Experiment to always assign a specific variation. Useful for QA.
@@ -110,7 +111,7 @@ func defaultClient() *Client {
 		qaMode:                  false,
 		logger:                  slog.Default(),
 		attributes:              value.ObjValue{},
-		stickyBucketAssignments: make(StickyBucketAssignments),
+		stickyBucketAssignments: newStickyBucketCache(),
 	}
 }
 

--- a/client_option.go
+++ b/client_option.go
@@ -170,6 +170,19 @@ func WithStickyBucketService(service StickyBucketService) ClientOption {
 	}
 }
 
+// WithStickyBucketCacheSize bounds the client's in-memory sticky bucket
+// assignments cache to size entries with LRU eviction. The cache holds one
+// entry per attribute value evaluated, so a long-lived multi-user client
+// grows it with every new user; evicting an entry only costs a re-fetch
+// from the StickyBucketService. size <= 0 removes the bound. The default
+// is 10000 entries.
+func WithStickyBucketCacheSize(size int) ClientOption {
+	return func(c *Client) error {
+		c.stickyBucketAssignments = newStickyBucketCache(size)
+		return nil
+	}
+}
+
 // WithStickyBucketAttributes sets sticky bucket attributes for the client
 func WithStickyBucketAttributes(attributes StickyBucketAttributes) ClientOption {
 	return func(c *Client) error {

--- a/evaluator.go
+++ b/evaluator.go
@@ -127,7 +127,7 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 			}
 		}
 
-		stickyResult, err := GetStickyBucketVariation(
+		stickyResult, err := getStickyBucketVariation(
 			exp.Key,
 			exp.BucketVersion,
 			exp.MinBucketVersion,
@@ -259,7 +259,7 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 	// 13.5 Save sticky bucket assignment if in experiment and sticky bucketing is enabled
 	if e.client.stickyBucketService != nil && !exp.DisableStickyBucketing && result.InExperiment {
 		// Create the sticky bucket assignment and save it
-		SaveStickyBucketAssignment(
+		saveStickyBucketAssignment(
 			exp.Key,
 			exp.BucketVersion,
 			result.VariationId,

--- a/sticky_bucket.go
+++ b/sticky_bucket.go
@@ -22,8 +22,8 @@ type StickyBucketAssignments map[string]*StickyBucketAssignmentDoc
 type stickyBucketCache interface {
 	get(key string) (*StickyBucketAssignmentDoc, bool)
 	set(key string, doc *StickyBucketAssignmentDoc)
-	setIfAbsent(key string, doc *StickyBucketAssignmentDoc)
-	// lockDoc serializes read-modify-write save cycles for one document key.
+	// lockDoc serializes service read-modify-write cycles (saves and
+	// cache-miss reads) for one document key.
 	lockDoc(key string) (unlock func())
 }
 
@@ -34,12 +34,6 @@ func (a StickyBucketAssignments) get(key string) (*StickyBucketAssignmentDoc, bo
 
 func (a StickyBucketAssignments) set(key string, doc *StickyBucketAssignmentDoc) {
 	a[key] = doc
-}
-
-func (a StickyBucketAssignments) setIfAbsent(key string, doc *StickyBucketAssignmentDoc) {
-	if _, ok := a[key]; !ok {
-		a[key] = doc
-	}
 }
 
 // lockDoc is a no-op: the exported helpers taking a plain map remain
@@ -70,9 +64,13 @@ type lockedStickyBucketCache struct {
 	maxSize int // <= 0 disables eviction
 	docs    map[string]*list.Element
 	order   *list.List // front = most recently used
-	// docLocks serializes save cycles per document key so concurrent saves
-	// for the same user merge instead of overwriting each other. Key-scoped
-	// so a save's backend I/O never blocks work on other documents.
+	// docLocks serializes service read-modify-write cycles per document key:
+	// concurrent saves for the same user merge instead of overwriting each
+	// other, and cache-miss reads can't re-install a stale doc over a save's
+	// fresher one after eviction. Key-scoped so backend I/O never blocks work
+	// on other documents. The guarantee is scoped to this cache, i.e. one
+	// client and its clones — independently constructed Clients (or separate
+	// processes) sharing a StickyBucketService still race at the service.
 	docLocks keyedMutex
 }
 
@@ -104,14 +102,6 @@ func (c *lockedStickyBucketCache) set(key string, doc *StickyBucketAssignmentDoc
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.insert(key, doc)
-}
-
-func (c *lockedStickyBucketCache) setIfAbsent(key string, doc *StickyBucketAssignmentDoc) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if _, ok := c.docs[key]; !ok {
-		c.insert(key, doc)
-	}
 }
 
 // insert adds or updates an entry and evicts the least recently used one
@@ -417,7 +407,7 @@ func getStickyBucketAssignments(
 	// If we need to fetch anything from the service
 	if len(attributesToFetch) > 0 {
 		for attrName, attrValue := range attributesToFetch {
-			doc, err := service.GetAssignments(attrName, attrValue)
+			doc, err := fetchAssignmentsDoc(service, cache, attrName, attrValue)
 			if err != nil {
 				return merged, err
 			}
@@ -436,19 +426,42 @@ func getStickyBucketAssignments(
 						merged[k] = v
 					}
 				}
-
-				// Update the cache if provided. setIfAbsent: a concurrent
-				// save may have already cached a doc merged from fresher
-				// service state; don't clobber it with this earlier read.
-				if cache != nil {
-					key := getKey(attrName, attrValue)
-					cache.setIfAbsent(key, doc)
-				}
 			}
 		}
 	}
 
 	return merged, nil
+}
+
+// fetchAssignmentsDoc reads one assignment doc from the service and caches
+// it, under the same per-document lock that serializes saves. Without the
+// lock, a read that fetched the doc before a concurrent save could
+// re-install the stale version after LRU eviction removed the save's
+// fresher one — and cache hits never re-consult the service, so the stale
+// doc would stick until its own eviction.
+func fetchAssignmentsDoc(service StickyBucketService, cache stickyBucketCache, attrName, attrValue string) (*StickyBucketAssignmentDoc, error) {
+	if cache == nil {
+		return service.GetAssignments(attrName, attrValue)
+	}
+
+	key := getKey(attrName, attrValue)
+	unlock := cache.lockDoc(key)
+	defer unlock()
+
+	// Re-check under the lock: a save that finished while we waited may
+	// have cached a doc merged from fresher service state.
+	if doc, ok := cache.get(key); ok {
+		return doc, nil
+	}
+
+	doc, err := service.GetAssignments(attrName, attrValue)
+	if err != nil || doc == nil {
+		return doc, err
+	}
+	// Holding the doc lock means no save for this key is mid-flight, so a
+	// plain set cannot clobber anything fresher.
+	cache.set(key, doc)
+	return doc, nil
 }
 
 // SaveStickyBucketAssignment saves a sticky bucket assignment

--- a/sticky_bucket.go
+++ b/sticky_bucket.go
@@ -21,6 +21,9 @@ type StickyBucketAssignments map[string]*StickyBucketAssignmentDoc
 type stickyBucketCache interface {
 	get(key string) (*StickyBucketAssignmentDoc, bool)
 	set(key string, doc *StickyBucketAssignmentDoc)
+	setIfAbsent(key string, doc *StickyBucketAssignmentDoc)
+	// lockDoc serializes read-modify-write save cycles for one document key.
+	lockDoc(key string) (unlock func())
 }
 
 func (a StickyBucketAssignments) get(key string) (*StickyBucketAssignmentDoc, bool) {
@@ -30,6 +33,18 @@ func (a StickyBucketAssignments) get(key string) (*StickyBucketAssignmentDoc, bo
 
 func (a StickyBucketAssignments) set(key string, doc *StickyBucketAssignmentDoc) {
 	a[key] = doc
+}
+
+func (a StickyBucketAssignments) setIfAbsent(key string, doc *StickyBucketAssignmentDoc) {
+	if _, ok := a[key]; !ok {
+		a[key] = doc
+	}
+}
+
+// lockDoc is a no-op: the exported helpers taking a plain map remain
+// unsynchronized, as they always were.
+func (a StickyBucketAssignments) lockDoc(string) func() {
+	return func() {}
 }
 
 // asStickyBucketCache converts a possibly-nil assignments map to a cache,
@@ -46,6 +61,10 @@ func asStickyBucketCache(assignments StickyBucketAssignments) stickyBucketCache 
 type lockedStickyBucketCache struct {
 	mu   sync.RWMutex
 	docs StickyBucketAssignments
+	// docLocks serializes save cycles per document key so concurrent saves
+	// for the same user merge instead of overwriting each other. Key-scoped
+	// so a save's backend I/O never blocks work on other documents.
+	docLocks keyedMutex
 }
 
 func newStickyBucketCache() *lockedStickyBucketCache {
@@ -63,6 +82,56 @@ func (c *lockedStickyBucketCache) set(key string, doc *StickyBucketAssignmentDoc
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.docs[key] = doc
+}
+
+func (c *lockedStickyBucketCache) setIfAbsent(key string, doc *StickyBucketAssignmentDoc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.docs[key]; !ok {
+		c.docs[key] = doc
+	}
+}
+
+func (c *lockedStickyBucketCache) lockDoc(key string) func() {
+	return c.docLocks.lock(key)
+}
+
+// keyedMutex provides a mutex per string key. A key's entry is removed once
+// no goroutine holds or waits for it, so memory does not grow with the
+// number of keys ever locked.
+type keyedMutex struct {
+	mu    sync.Mutex
+	locks map[string]*keyedLock
+}
+
+type keyedLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func (k *keyedMutex) lock(key string) (unlock func()) {
+	k.mu.Lock()
+	if k.locks == nil {
+		k.locks = make(map[string]*keyedLock)
+	}
+	l := k.locks[key]
+	if l == nil {
+		l = &keyedLock{}
+		k.locks[key] = l
+	}
+	l.refs++
+	k.mu.Unlock()
+
+	l.mu.Lock()
+	return func() {
+		l.mu.Unlock()
+		k.mu.Lock()
+		l.refs--
+		if l.refs == 0 {
+			delete(k.locks, key)
+		}
+		k.mu.Unlock()
+	}
 }
 
 // StickyBucketService defines operations for storing and retrieving sticky bucket assignments
@@ -330,10 +399,12 @@ func getStickyBucketAssignments(
 					}
 				}
 
-				// Update the cache if provided
+				// Update the cache if provided. setIfAbsent: a concurrent
+				// save may have already cached a doc merged from fresher
+				// service state; don't clobber it with this earlier read.
 				if cache != nil {
 					key := getKey(attrName, attrValue)
-					cache.set(key, doc)
+					cache.setIfAbsent(key, doc)
 				}
 			}
 		}
@@ -370,6 +441,14 @@ func saveStickyBucketAssignment(
 ) error {
 	if service == nil || attributeName == "" || attributeValue == "" {
 		return nil
+	}
+
+	// Saving is a read-modify-write cycle: serialize it per document so
+	// concurrent saves for the same user merge instead of the last write
+	// dropping the other's assignment.
+	if cache != nil {
+		unlock := cache.lockDoc(getKey(attributeName, attributeValue))
+		defer unlock()
 	}
 
 	// Create assignment map with the experiment key and variation key
@@ -412,7 +491,7 @@ func GenerateStickyBucketAssignmentDoc(
 	service StickyBucketService,
 ) *StickyBucketAssignmentData {
 	result := &StickyBucketAssignmentData{
-		Key:     attributeName + "||" + attributeValue,
+		Key:     getKey(attributeName, attributeValue),
 		Changed: false,
 	}
 

--- a/sticky_bucket.go
+++ b/sticky_bucket.go
@@ -1,6 +1,7 @@
 package growthbook
 
 import (
+	"container/list"
 	"fmt"
 	"sync"
 )
@@ -56,39 +57,76 @@ func asStickyBucketCache(assignments StickyBucketAssignments) stickyBucketCache 
 	return assignments
 }
 
-// lockedStickyBucketCache is the client's assignments cache. It is shared by
-// reference between a client and its clones, so access is mutex-guarded.
+// defaultStickyBucketCacheSize bounds the client's assignments cache. The
+// cache holds one entry per attribute value evaluated, so a long-lived
+// multi-user client would otherwise grow it forever. Evicting an entry only
+// costs a re-fetch from the StickyBucketService.
+const defaultStickyBucketCacheSize = 10_000
+
+// lockedStickyBucketCache is the client's assignments cache: an LRU shared
+// by reference between a client and its clones, so access is mutex-guarded.
 type lockedStickyBucketCache struct {
-	mu   sync.RWMutex
-	docs StickyBucketAssignments
+	mu      sync.Mutex
+	maxSize int // <= 0 disables eviction
+	docs    map[string]*list.Element
+	order   *list.List // front = most recently used
 	// docLocks serializes save cycles per document key so concurrent saves
 	// for the same user merge instead of overwriting each other. Key-scoped
 	// so a save's backend I/O never blocks work on other documents.
 	docLocks keyedMutex
 }
 
-func newStickyBucketCache() *lockedStickyBucketCache {
-	return &lockedStickyBucketCache{docs: make(StickyBucketAssignments)}
+type stickyBucketCacheEntry struct {
+	key string
+	doc *StickyBucketAssignmentDoc
+}
+
+func newStickyBucketCache(maxSize int) *lockedStickyBucketCache {
+	return &lockedStickyBucketCache{
+		maxSize: maxSize,
+		docs:    make(map[string]*list.Element),
+		order:   list.New(),
+	}
 }
 
 func (c *lockedStickyBucketCache) get(key string) (*StickyBucketAssignmentDoc, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	doc, ok := c.docs[key]
-	return doc, ok
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	elem, ok := c.docs[key]
+	if !ok {
+		return nil, false
+	}
+	c.order.MoveToFront(elem)
+	return elem.Value.(*stickyBucketCacheEntry).doc, true
 }
 
 func (c *lockedStickyBucketCache) set(key string, doc *StickyBucketAssignmentDoc) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.docs[key] = doc
+	c.insert(key, doc)
 }
 
 func (c *lockedStickyBucketCache) setIfAbsent(key string, doc *StickyBucketAssignmentDoc) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if _, ok := c.docs[key]; !ok {
-		c.docs[key] = doc
+		c.insert(key, doc)
+	}
+}
+
+// insert adds or updates an entry and evicts the least recently used one
+// when over capacity. Callers must hold c.mu.
+func (c *lockedStickyBucketCache) insert(key string, doc *StickyBucketAssignmentDoc) {
+	if elem, ok := c.docs[key]; ok {
+		elem.Value.(*stickyBucketCacheEntry).doc = doc
+		c.order.MoveToFront(elem)
+		return
+	}
+	c.docs[key] = c.order.PushFront(&stickyBucketCacheEntry{key: key, doc: doc})
+	if c.maxSize > 0 && c.order.Len() > c.maxSize {
+		oldest := c.order.Back()
+		c.order.Remove(oldest)
+		delete(c.docs, oldest.Value.(*stickyBucketCacheEntry).key)
 	}
 }
 

--- a/sticky_bucket.go
+++ b/sticky_bucket.go
@@ -15,6 +15,56 @@ type StickyBucketAssignmentDoc struct {
 // StickyBucketAssignments is a map of keys to assignment documents
 type StickyBucketAssignments map[string]*StickyBucketAssignmentDoc
 
+// stickyBucketCache abstracts the assignments cache so the client can guard
+// its shared cache with a mutex while the exported helpers keep accepting a
+// plain StickyBucketAssignments map.
+type stickyBucketCache interface {
+	get(key string) (*StickyBucketAssignmentDoc, bool)
+	set(key string, doc *StickyBucketAssignmentDoc)
+}
+
+func (a StickyBucketAssignments) get(key string) (*StickyBucketAssignmentDoc, bool) {
+	doc, ok := a[key]
+	return doc, ok
+}
+
+func (a StickyBucketAssignments) set(key string, doc *StickyBucketAssignmentDoc) {
+	a[key] = doc
+}
+
+// asStickyBucketCache converts a possibly-nil assignments map to a cache,
+// keeping a nil map as a nil interface so cache presence checks work.
+func asStickyBucketCache(assignments StickyBucketAssignments) stickyBucketCache {
+	if assignments == nil {
+		return nil
+	}
+	return assignments
+}
+
+// lockedStickyBucketCache is the client's assignments cache. It is shared by
+// reference between a client and its clones, so access is mutex-guarded.
+type lockedStickyBucketCache struct {
+	mu   sync.RWMutex
+	docs StickyBucketAssignments
+}
+
+func newStickyBucketCache() *lockedStickyBucketCache {
+	return &lockedStickyBucketCache{docs: make(StickyBucketAssignments)}
+}
+
+func (c *lockedStickyBucketCache) get(key string) (*StickyBucketAssignmentDoc, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	doc, ok := c.docs[key]
+	return doc, ok
+}
+
+func (c *lockedStickyBucketCache) set(key string, doc *StickyBucketAssignmentDoc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.docs[key] = doc
+}
+
 // StickyBucketService defines operations for storing and retrieving sticky bucket assignments
 type StickyBucketService interface {
 	GetAssignments(attributeName string, attributeValue string) (*StickyBucketAssignmentDoc, error)
@@ -132,6 +182,22 @@ func GetStickyBucketVariation(
 	attributes map[string]string,
 	cachedAssignments StickyBucketAssignments,
 ) (*StickyBucketResult, error) {
+	return getStickyBucketVariation(experimentKey, bucketVersion, minBucketVersion,
+		meta, service, hashAttribute, fallbackAttribute, attributes,
+		asStickyBucketCache(cachedAssignments))
+}
+
+func getStickyBucketVariation(
+	experimentKey string,
+	bucketVersion int,
+	minBucketVersion int,
+	meta []VariationMeta,
+	service StickyBucketService,
+	hashAttribute string,
+	fallbackAttribute string,
+	attributes map[string]string,
+	cache stickyBucketCache,
+) (*StickyBucketResult, error) {
 	result := &StickyBucketResult{
 		Variation:        -1,
 		VersionIsBlocked: false,
@@ -149,7 +215,7 @@ func GetStickyBucketVariation(
 	experimentVersionKey := getStickyBucketExperimentKey(experimentKey, bucketVersion)
 
 	// Get assignments from both primary and fallback attributes
-	assignments, err := getStickyBucketAssignments(service, hashAttribute, fallbackAttribute, attributes, cachedAssignments)
+	assignments, err := getStickyBucketAssignments(service, hashAttribute, fallbackAttribute, attributes, cache)
 	if err != nil {
 		return result, err
 	}
@@ -184,7 +250,7 @@ func getStickyBucketAssignments(
 	hashAttribute string,
 	fallbackAttribute string,
 	attributes map[string]string,
-	cachedAssignments StickyBucketAssignments,
+	cache stickyBucketCache,
 ) (map[string]string, error) {
 	merged := make(map[string]string)
 
@@ -200,8 +266,8 @@ func getStickyBucketAssignments(
 	if hasHash {
 		// Check if we have this in the cache first
 		hashKey := getKey(hashAttribute, hashValue)
-		if cachedAssignments != nil {
-			if doc, ok := cachedAssignments[hashKey]; ok && doc != nil {
+		if cache != nil {
+			if doc, ok := cache.get(hashKey); ok && doc != nil {
 				// Use cached assignments
 				for k, v := range doc.Assignments {
 					merged[k] = v
@@ -222,8 +288,8 @@ func getStickyBucketAssignments(
 		if hasFallback {
 			// Check if we have this in the cache first
 			fallbackKey := getKey(fallbackAttribute, fallbackValue)
-			if cachedAssignments != nil {
-				if doc, ok := cachedAssignments[fallbackKey]; ok && doc != nil {
+			if cache != nil {
+				if doc, ok := cache.get(fallbackKey); ok && doc != nil {
 					// Use cached assignments, but don't overwrite existing ones
 					for k, v := range doc.Assignments {
 						if _, exists := merged[k]; !exists {
@@ -265,9 +331,9 @@ func getStickyBucketAssignments(
 				}
 
 				// Update the cache if provided
-				if cachedAssignments != nil {
+				if cache != nil {
 					key := getKey(attrName, attrValue)
-					cachedAssignments[key] = doc
+					cache.set(key, doc)
 				}
 			}
 		}
@@ -286,6 +352,21 @@ func SaveStickyBucketAssignment(
 	attributeName string,
 	attributeValue string,
 	cachedAssignments StickyBucketAssignments,
+) error {
+	return saveStickyBucketAssignment(experimentKey, bucketVersion, variationID,
+		variationKey, service, attributeName, attributeValue,
+		asStickyBucketCache(cachedAssignments))
+}
+
+func saveStickyBucketAssignment(
+	experimentKey string,
+	bucketVersion int,
+	variationID int,
+	variationKey string,
+	service StickyBucketService,
+	attributeName string,
+	attributeValue string,
+	cache stickyBucketCache,
 ) error {
 	if service == nil || attributeName == "" || attributeValue == "" {
 		return nil
@@ -307,8 +388,8 @@ func SaveStickyBucketAssignment(
 	// Only save if a change was detected
 	if data.Doc != nil && data.Changed {
 		// Update cache if provided
-		if cachedAssignments != nil {
-			cachedAssignments[data.Key] = data.Doc
+		if cache != nil {
+			cache.set(data.Key, data.Doc)
 		}
 		return service.SaveAssignments(data.Doc)
 	}
@@ -364,20 +445,23 @@ func GenerateStickyBucketAssignmentDoc(
 		}
 	}
 
-	// If changes detected, create merged assignments
+	// If changes detected, build a new doc with merged assignments instead of
+	// mutating the existing one: docs held by the service or the client cache
+	// may be read concurrently by other evaluations.
 	if result.Changed {
-		// Create a copy of existing assignments
-		mergedAssignments := make(map[string]string)
+		mergedAssignments := make(map[string]string, len(doc.Assignments)+len(assignments))
 		for k, v := range doc.Assignments {
 			mergedAssignments[k] = v
 		}
-
-		// Add or update with new assignments
 		for k, v := range assignments {
 			mergedAssignments[k] = v
 		}
 
-		doc.Assignments = mergedAssignments
+		doc = &StickyBucketAssignmentDoc{
+			AttributeName:  attributeName,
+			AttributeValue: attributeValue,
+			Assignments:    mergedAssignments,
+		}
 	}
 
 	result.Doc = doc

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -407,6 +408,71 @@ func TestStickyBucketConcurrentEvaluation(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+// Concurrent saves for the same user must merge rather than overwrite each
+// other: saving is a read-modify-write cycle against the service, and without
+// per-document serialization the last write drops the other's assignment.
+//
+// The gate in GetAssignments holds save-path reads open, so when saves are
+// NOT serialized both deterministically read the same document version and
+// the lost update reproduces. Once saves ARE serialized the second save
+// cannot reach the read, so the timeout releases the gate and the saves run
+// back to back — which is exactly the fixed behavior being asserted.
+func TestStickyBucketOverlappingSavesMerge(t *testing.T) {
+	inner := NewInMemoryStickyBucketService()
+	readerArrived := make(chan struct{}, 2)
+	release := make(chan struct{})
+	svc := &mockStickyBucketService{
+		InMemoryStickyBucketService: inner,
+		onGetAssignments: func(_, _ string) {
+			select {
+			case readerArrived <- struct{}{}:
+			default:
+			}
+			<-release
+		},
+	}
+	go func() {
+		timeout := time.After(200 * time.Millisecond)
+		for i := 0; i < 2; i++ {
+			select {
+			case <-readerArrived:
+			case <-timeout:
+				close(release)
+				return
+			}
+		}
+		close(release)
+	}()
+
+	cache := newStickyBucketCache()
+	var wg sync.WaitGroup
+	for _, save := range []struct{ expKey, variation string }{
+		{"exp-a", "control"},
+		{"exp-b", "treatment"},
+	} {
+		wg.Add(1)
+		go func(expKey, variation string) {
+			defer wg.Done()
+			if err := saveStickyBucketAssignment(expKey, 0, 0, variation, svc, "id", "u1", cache); err != nil {
+				t.Error(err)
+			}
+		}(save.expKey, save.variation)
+	}
+	wg.Wait()
+
+	doc, err := inner.GetAssignments("id", "u1")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Equal(t, "control", doc.Assignments["exp-a__0"], "assignment for exp-a was lost")
+	require.Equal(t, "treatment", doc.Assignments["exp-b__0"], "assignment for exp-b was lost")
+
+	// The shared cache must hold the merged document too.
+	cached, ok := cache.get(getKey("id", "u1"))
+	require.True(t, ok)
+	require.Equal(t, "control", cached.Assignments["exp-a__0"])
+	require.Equal(t, "treatment", cached.Assignments["exp-b__0"])
 }
 
 // mockStickyBucketService is a wrapper around InMemoryStickyBucketService that allows tracking calls

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -440,15 +441,10 @@ func TestStickyBucketCacheLRUEviction(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "a2", got.AttributeValue)
 
-	// setIfAbsent keeps the existing doc.
-	cache.setIfAbsent("a", doc("a3"))
-	got, _ = cache.get("a")
-	require.Equal(t, "a2", got.AttributeValue)
-
 	// size <= 0 means unbounded.
 	unbounded := newStickyBucketCache(0)
 	for i := 0; i < 100; i++ {
-		unbounded.setIfAbsent(fmt.Sprintf("k%d", i), doc("v"))
+		unbounded.set(fmt.Sprintf("k%d", i), doc("v"))
 	}
 	for i := 0; i < 100; i++ {
 		_, ok := unbounded.get(fmt.Sprintf("k%d", i))
@@ -584,4 +580,93 @@ func (m *mockStickyBucketService) SaveAssignments(doc *StickyBucketAssignmentDoc
 
 func (m *mockStickyBucketService) GetAllAssignments(attributes map[string]string) (StickyBucketAssignments, error) {
 	return m.InMemoryStickyBucketService.GetAllAssignments(attributes)
+}
+
+// A cache-miss read that raced with a save must not re-install its stale
+// service snapshot after the save's fresher doc was evicted from the LRU —
+// cache hits never re-consult the service, so a stale doc would stick and
+// the user would be re-hashed (and the flip persisted by the next save).
+func TestStickyBucketReadDoesNotReinstallStaleDoc(t *testing.T) {
+	inner := NewInMemoryStickyBucketService()
+	require.NoError(t, inner.SaveAssignments(&StickyBucketAssignmentDoc{
+		AttributeName:  "id",
+		AttributeValue: "u1",
+		Assignments:    map[string]string{"other__0": "0"},
+	}))
+
+	// Gate the reader AFTER its service fetch, so it holds a stale snapshot
+	// of the doc while a save merges and persists a fresher one. Only the
+	// first caller parks (CAS), so the save's own service read passes.
+	svc := &postReadGateService{
+		InMemoryStickyBucketService: inner,
+		entered:                     make(chan struct{}),
+		release:                     make(chan struct{}),
+	}
+	svc.gate.Store(true)
+	entered, release := svc.entered, svc.release
+
+	cache := newStickyBucketCache(1)
+
+	// Reader: cache miss -> service fetch, parked at the gate.
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := getStickyBucketAssignments(svc, "id", "", map[string]string{"id": "u1"}, cache)
+		readErr <- err
+	}()
+	<-entered
+
+	// Concurrent save merges a new assignment for the same user. With the
+	// read-path doc lock it waits for the reader; without it, it completes
+	// now and its cached doc is about to be evicted.
+	saveErr := make(chan error, 1)
+	go func() {
+		saveErr <- saveStickyBucketAssignment("exp", 0, 1, "1", svc, "id", "u1", cache)
+	}()
+	savedEarly := false
+	select {
+	case err := <-saveErr:
+		require.NoError(t, err)
+		savedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Evict whatever the size-1 cache holds for u1.
+	cache.set(getKey("id", "other"), &StickyBucketAssignmentDoc{
+		AttributeName:  "id",
+		AttributeValue: "other",
+		Assignments:    map[string]string{},
+	})
+
+	close(release)
+	require.NoError(t, <-readErr)
+	if !savedEarly {
+		require.NoError(t, <-saveErr)
+	}
+
+	// However the read and save interleave, a cached doc for u1 must not
+	// hide the saved assignment: it either holds the merged doc or was
+	// evicted (forcing a service re-fetch on the next evaluation).
+	if cached, ok := cache.get(getKey("id", "u1")); ok {
+		require.Equal(t, "1", cached.Assignments["exp__0"],
+			"stale doc without the saved assignment was re-installed into the cache")
+	}
+}
+
+// postReadGateService parks the first GetAssignments call for id||u1 after
+// the read completes, simulating a reader stalled between its service fetch
+// and its cache install.
+type postReadGateService struct {
+	*InMemoryStickyBucketService
+	gate    atomic.Bool
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *postReadGateService) GetAssignments(name, value string) (*StickyBucketAssignmentDoc, error) {
+	doc, err := s.InMemoryStickyBucketService.GetAssignments(name, value)
+	if name == "id" && value == "u1" && s.gate.CompareAndSwap(true, false) {
+		close(s.entered)
+		<-s.release
+	}
+	return doc, err
 }

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -410,6 +410,96 @@ func TestStickyBucketConcurrentEvaluation(t *testing.T) {
 	wg.Wait()
 }
 
+func TestStickyBucketCacheLRUEviction(t *testing.T) {
+	doc := func(val string) *StickyBucketAssignmentDoc {
+		return &StickyBucketAssignmentDoc{AttributeName: "id", AttributeValue: val}
+	}
+
+	cache := newStickyBucketCache(2)
+	cache.set("a", doc("a"))
+	cache.set("b", doc("b"))
+
+	// Touch "a" so "b" becomes the least recently used entry.
+	_, ok := cache.get("a")
+	require.True(t, ok)
+
+	cache.set("c", doc("c"))
+	_, ok = cache.get("b")
+	require.False(t, ok, "least recently used entry should be evicted")
+	_, ok = cache.get("a")
+	require.True(t, ok)
+	_, ok = cache.get("c")
+	require.True(t, ok)
+
+	// Updating an existing key must not evict anything.
+	cache.set("a", doc("a2"))
+	got, ok := cache.get("c")
+	require.True(t, ok)
+	require.Equal(t, "c", got.AttributeValue)
+	got, ok = cache.get("a")
+	require.True(t, ok)
+	require.Equal(t, "a2", got.AttributeValue)
+
+	// setIfAbsent keeps the existing doc.
+	cache.setIfAbsent("a", doc("a3"))
+	got, _ = cache.get("a")
+	require.Equal(t, "a2", got.AttributeValue)
+
+	// size <= 0 means unbounded.
+	unbounded := newStickyBucketCache(0)
+	for i := 0; i < 100; i++ {
+		unbounded.setIfAbsent(fmt.Sprintf("k%d", i), doc("v"))
+	}
+	for i := 0; i < 100; i++ {
+		_, ok := unbounded.get(fmt.Sprintf("k%d", i))
+		require.True(t, ok)
+	}
+}
+
+// Eviction must be transparent: an evicted user's next evaluation re-fetches
+// the assignment doc from the service and keeps the sticky variation.
+func TestStickyBucketCacheEvictionRefetches(t *testing.T) {
+	featuresJSON := `{
+		"feat": {
+			"defaultValue": "off",
+			"rules": [{
+				"key": "exp",
+				"variations": ["control", "treatment"],
+				"meta": [{"key": "0"}, {"key": "1"}],
+				"hashAttribute": "id"
+			}]
+		}
+	}`
+
+	service := NewInMemoryStickyBucketService()
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJSON),
+		WithStickyBucketService(service),
+		WithStickyBucketCacheSize(1),
+	)
+	require.NoError(t, err)
+
+	c1, err := client.WithAttributes(Attributes{"id": "u1"})
+	require.NoError(t, err)
+	res1 := c1.EvalFeature(ctx, "feat")
+	require.True(t, res1.ExperimentResult.InExperiment)
+
+	// Evaluating a second user evicts u1 from the size-1 cache.
+	c2, err := client.WithAttributes(Attributes{"id": "u2"})
+	require.NoError(t, err)
+	c2.EvalFeature(ctx, "feat")
+	_, cached := client.stickyBucketAssignments.get(getKey("id", "u1"))
+	require.False(t, cached, "u1 should be evicted from the size-1 cache")
+
+	// u1's next evaluation re-fetches from the service: same variation,
+	// via the stored sticky bucket rather than a fresh hash.
+	res2 := c1.EvalFeature(ctx, "feat")
+	require.True(t, res2.ExperimentResult.InExperiment)
+	require.Equal(t, res1.ExperimentResult.VariationId, res2.ExperimentResult.VariationId)
+	require.True(t, res2.ExperimentResult.StickyBucketUsed)
+}
+
 // Concurrent saves for the same user must merge rather than overwrite each
 // other: saving is a read-modify-write cycle against the service, and without
 // per-document serialization the last write drops the other's assignment.
@@ -446,7 +536,7 @@ func TestStickyBucketOverlappingSavesMerge(t *testing.T) {
 		close(release)
 	}()
 
-	cache := newStickyBucketCache()
+	cache := newStickyBucketCache(defaultStickyBucketCacheSize)
 	var wg sync.WaitGroup
 	for _, save := range []struct{ expKey, variation string }{
 		{"exp-a", "control"},

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -2,8 +2,10 @@ package growthbook
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -349,8 +351,62 @@ func TestStickyBucketCaching(t *testing.T) {
 
 	// Verify cache contains both experiments
 	cacheKey := getKey("id", "123")
-	cache := client.stickyBucketAssignments[cacheKey]
+	cache, ok := client.stickyBucketAssignments.get(cacheKey)
+	require.True(t, ok)
 	require.Len(t, cache.Assignments, 2, "Cache should contain both experiments")
+}
+
+// The assignments cache is shared between a client and all clients cloned
+// from it, so concurrent EvalFeature calls must not race on it. Run with
+// -race to catch regressions.
+func TestStickyBucketConcurrentEvaluation(t *testing.T) {
+	featuresJSON := `{
+		"feat-a": {
+			"defaultValue": "off",
+			"rules": [{
+				"key": "exp-a",
+				"variations": ["control", "treatment"],
+				"meta": [{"key": "0"}, {"key": "1"}],
+				"hashAttribute": "id"
+			}]
+		},
+		"feat-b": {
+			"defaultValue": "off",
+			"rules": [{
+				"key": "exp-b",
+				"variations": ["control", "treatment"],
+				"meta": [{"key": "0"}, {"key": "1"}],
+				"hashAttribute": "id"
+			}]
+		}
+	}`
+
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJSON),
+		WithStickyBucketService(NewInMemoryStickyBucketService()),
+	)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// A small pool of user ids so goroutines both write fresh cache
+			// entries and hit the same entries concurrently.
+			child, err := client.WithAttributes(Attributes{"id": fmt.Sprintf("user-%d", i%4)})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			for j := 0; j < 20; j++ {
+				child.EvalFeature(ctx, "feat-a")
+				child.EvalFeature(ctx, "feat-b")
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 // mockStickyBucketService is a wrapper around InMemoryStickyBucketService that allows tracking calls


### PR DESCRIPTION
## Summary

Data race on the shared sticky bucket assignments cache - saves serialized per document within a client and its clones.

## Root Cause

`client.stickyBucketAssignments` is mutated during evaluation without any synchronization, and `client.clone()` shallow-copies the map reference into every child client.  Concurrent `EvalFeature`/`RunExperiment` calls on a shared or cloned client are a data race. 

On top of the race, saving was a non-atomic read-modify-write (concurrent saves for the same user could drop each other's assignment), and the cache grew unboundedly with every attribute value evaluated.

## What's NOT changed
- No behavior change to sticky bucket semantics or spec conformance 
- Reads are not batched via `GetAllAssignments`. not worth the churn. 