### PR TITLE
Fix evaluator divergences vs JS: hash attribute truthiness, fallbackAttribute gating, inline experiment fields

### DIFF
--- a/cases.json
+++ b/cases.json
@@ -6851,6 +6851,271 @@
         "source": "defaultValue",
         "ruleId": ""
       }
+    ],
+    [
+      "experiment rules - parentConditions are not copied onto the experiment",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "features": {
+          "parent": {
+            "defaultValue": "on"
+          },
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1
+                ],
+                "parentConditions": [
+                  {
+                    "id": "parent",
+                    "condition": {
+                      "value": "on"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            0,
+            1
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": 1,
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "id",
+          "hashValue": "123",
+          "bucket": 0.863,
+          "key": "1",
+          "stickyBucketUsed": false
+        },
+        "source": "experiment",
+        "ruleId": ""
+      }
+    ],
+    [
+      "experiment rules - rule status is not copied onto the experiment (draft rule still runs)",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  "a",
+                  "b"
+                ],
+                "status": "draft"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "b",
+        "on": true,
+        "off": false,
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            "a",
+            "b"
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": "b",
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "id",
+          "hashValue": "123",
+          "bucket": 0.863,
+          "key": "1",
+          "stickyBucketUsed": false
+        },
+        "source": "experiment",
+        "ruleId": ""
+      }
+    ],
+    [
+      "experiment rules - urlPatterns are not copied onto the experiment",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "url": "http://example.com/",
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  "a",
+                  "b"
+                ],
+                "urlPatterns": [
+                  {
+                    "type": "simple",
+                    "pattern": "http://other.com",
+                    "include": true
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "b",
+        "on": true,
+        "off": false,
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            "a",
+            "b"
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": "b",
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "id",
+          "hashValue": "123",
+          "bucket": 0.863,
+          "key": "1",
+          "stickyBucketUsed": false
+        },
+        "source": "experiment",
+        "ruleId": ""
+      }
+    ],
+    [
+      "experiment rules - groups are not copied onto the experiment",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  "a",
+                  "b"
+                ],
+                "groups": [
+                  "internal"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "b",
+        "on": true,
+        "off": false,
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            "a",
+            "b"
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": "b",
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "id",
+          "hashValue": "123",
+          "bucket": 0.863,
+          "key": "1",
+          "stickyBucketUsed": false
+        },
+        "source": "experiment",
+        "ruleId": ""
+      }
+    ],
+    [
+      "experiment rules - legacy url is not copied onto the experiment",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "url": "http://example.com/",
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  "a",
+                  "b"
+                ],
+                "url": "^/pricing$"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "b",
+        "on": true,
+        "off": false,
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            "a",
+            "b"
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": "b",
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "id",
+          "hashValue": "123",
+          "bucket": 0.863,
+          "key": "1",
+          "stickyBucketUsed": false
+        },
+        "source": "experiment",
+        "ruleId": ""
+      }
     ]
   ],
   "run": [

--- a/cases.json
+++ b/cases.json
@@ -6766,6 +6766,91 @@
         "source": "defaultValue",
         "ruleId": ""
       }
+    ],
+    [
+      "experiment rules - hashAttribute value of 0 is falsy, experiment skipped",
+      {
+        "attributes": {
+          "id": 0
+        },
+        "features": {
+          "feature": {
+            "defaultValue": "def",
+            "rules": [
+              {
+                "variations": [
+                  "a",
+                  "b"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "def",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "experiment rules - hashAttribute value of false is falsy, experiment skipped",
+      {
+        "attributes": {
+          "id": false
+        },
+        "features": {
+          "feature": {
+            "defaultValue": "def",
+            "rules": [
+              {
+                "variations": [
+                  "a",
+                  "b"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "def",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage rollout skipped when hashAttribute value is 0 (falsy)",
+      {
+        "attributes": {
+          "id": 0
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.99
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
     ]
   ],
   "run": [
@@ -9957,6 +10042,55 @@
           "assignments": {
             "feature-exp__0": "1"
           }
+        }
+      }
+    ],
+    [
+      "falsy hashAttribute value (0) falls through to fallbackAttribute",
+      {
+        "attributes": {
+          "id": 0,
+          "anonymousId": "123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "hashAttribute": "id",
+                "fallbackAttribute": "anonymousId"
+              }
+            ]
+          }
+        }
+      },
+      [],
+      "feature",
+      {
+        "bucket": 0.863,
+        "featureId": "feature",
+        "hashAttribute": "anonymousId",
+        "hashUsed": true,
+        "hashValue": "123",
+        "inExperiment": true,
+        "key": "3",
+        "stickyBucketUsed": false,
+        "value": 3,
+        "variationId": 3
+      },
+      {
+        "anonymousId||123": {
+          "assignments": {
+            "feature__0": "3"
+          },
+          "attributeName": "anonymousId",
+          "attributeValue": "123"
         }
       }
     ]

--- a/cases.json
+++ b/cases.json
@@ -7116,6 +7116,39 @@
         "source": "experiment",
         "ruleId": ""
       }
+    ],
+    [
+      "experiment rules - fallbackAttribute ignored without sticky bucket service",
+      {
+        "attributes": {
+          "anonymousId": "123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "hashAttribute": "id",
+                "fallbackAttribute": "anonymousId"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
     ]
   ],
   "run": [

--- a/evaluator.go
+++ b/evaluator.go
@@ -94,7 +94,7 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 	}
 
 	// 6. Get the user hash value and return if empty
-	hashAttribute, hashValue := e.getHashAttribute(exp.HashAttribute, exp.FallbackAttribute)
+	hashAttribute, hashValue := e.getHashAttribute(exp.HashAttribute, e.stickyFallbackAttribute(exp.FallbackAttribute, exp.DisableStickyBucketing))
 	if hashValue == "" {
 		e.client.logger.DebugContext(e.ctx, "Skip experiment because of missing hashAttribute", "id", exp.Key)
 		return e.experimentResult(exp, -1, false, featureId, nil, false)
@@ -304,7 +304,7 @@ func (e *evaluator) getExperimentResult(
 		inExperiment = false
 	}
 
-	hashAttribute, hashValue := e.getHashAttribute(exp.HashAttribute, exp.FallbackAttribute)
+	hashAttribute, hashValue := e.getHashAttribute(exp.HashAttribute, e.stickyFallbackAttribute(exp.FallbackAttribute, exp.DisableStickyBucketing))
 
 	var meta *VariationMeta
 	if variationId >= 0 && variationId < len(exp.Meta) {

--- a/evaluator.go
+++ b/evaluator.go
@@ -454,19 +454,22 @@ func hasMatchingGroup(expGroups []string, userGroups map[string]bool) bool {
 	return false
 }
 
+// getHashAttribute mirrors the JS SDK's getHashAttribute (sdk-js core.ts):
+// attribute values are checked for JS truthiness, so 0, false, "" and null
+// count as missing and trigger the fallback attribute (or skip the rule).
 func (e *evaluator) getHashAttribute(key string, fallback string) (string, string) {
 	if key == "" {
 		key = "id"
 	}
 
-	hashValue, ok := e.client.attributes[key]
-	if ok && !value.IsNull(hashValue) {
+	if hashValue, ok := e.client.attributes[key]; ok && value.Truthy(hashValue) {
 		return key, hashValue.String()
 	}
 
-	hashValue, ok = e.client.attributes[fallback]
-	if ok && !value.IsNull(hashValue) {
-		return fallback, hashValue.String()
+	if fallback != "" {
+		if hashValue, ok := e.client.attributes[fallback]; ok && value.Truthy(hashValue) {
+			return fallback, hashValue.String()
+		}
 	}
 
 	return key, ""

--- a/evaluator.go
+++ b/evaluator.go
@@ -402,7 +402,7 @@ func (e *evaluator) isIncludedInRollout(featureId string, rule *FeatureRule) boo
 		return false
 	}
 
-	_, hashValue := e.getHashAttribute(rule.HashAttribute, "")
+	_, hashValue := e.getHashAttribute(rule.HashAttribute, e.stickyFallbackAttribute(rule.FallbackAttribute, rule.DisableStickyBucketing))
 	if hashValue == "" {
 		return false
 	}
@@ -425,6 +425,17 @@ func (e *evaluator) isIncludedInRollout(featureId string, rule *FeatureRule) boo
 	}
 
 	return true
+}
+
+// stickyFallbackAttribute mirrors the JS SDK (sdk-js core.ts evalFeature /
+// runExperiment): a fallbackAttribute is only consulted when a sticky bucket
+// service is configured and sticky bucketing isn't disabled for the rule or
+// experiment.
+func (e *evaluator) stickyFallbackAttribute(fallback string, disableStickyBucketing bool) string {
+	if e.client.stickyBucketService != nil && !disableStickyBucketing {
+		return fallback
+	}
+	return ""
 }
 
 func (e *evaluator) isFilteredOut(filters []Filter) bool {

--- a/evaluator.go
+++ b/evaluator.go
@@ -110,9 +110,13 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 		attributes := make(map[string]string)
 		attributes[hashAttribute] = hashValue
 
-		// Also add any fallback if different
+		// Also add any fallback if different. Like getHashAttribute, falsy
+		// values count as missing — JS resolves the fallback through
+		// getHashAttribute and skips falsy values (sdk-js core.ts
+		// getStickyBucketAssignments), so no sticky doc is looked up under
+		// degenerate keys like "anonymousId||0".
 		if exp.FallbackAttribute != "" && exp.FallbackAttribute != exp.HashAttribute {
-			if fallbackValue, ok := e.client.attributes[exp.FallbackAttribute]; ok {
+			if fallbackValue, ok := e.client.attributes[exp.FallbackAttribute]; ok && value.Truthy(fallbackValue) {
 				attributes[exp.FallbackAttribute] = fallbackValue.String()
 			}
 		}

--- a/experiment.go
+++ b/experiment.go
@@ -81,6 +81,10 @@ func experimentFromFeatureRule(featureId string, rule *FeatureRule) *Experiment 
 		expKey = featureId
 	}
 
+	// Copy only the fields the JS SDK forwards when building the inline
+	// experiment (sdk-js core.ts evalFeature). ParentConditions are already
+	// evaluated by evalRule, so forwarding them would evaluate prerequisites
+	// twice; URLPatterns/URL/Groups/Status don't exist on JS feature rules.
 	exp := Experiment{
 		Key:                    expKey,
 		Variations:             rule.Variations,
@@ -97,14 +101,9 @@ func experimentFromFeatureRule(featureId string, rule *FeatureRule) *Experiment 
 		HashVersion:            rule.HashVersion,
 		Filters:                rule.Filters,
 		Condition:              rule.Condition,
-		ParentConditions:       rule.ParentConditions,
 		DisableStickyBucketing: rule.DisableStickyBucketing,
 		BucketVersion:          rule.BucketVersion,
 		MinBucketVersion:       rule.MinBucketVersion,
-		URLPatterns:            rule.URLPatterns,
-		URL:                    rule.URL,
-		Groups:                 rule.Groups,
-		Status:                 rule.Status,
 	}
 	return &exp
 }

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -48,12 +48,16 @@ type FeatureRule struct {
 	Name string `json:"name"`
 	// The phase id of the experiment
 	Phase string `json:"phase"`
-	// URL patterns to restrict where the rule's experiment runs. Empty means no URL restriction.
+	// Deprecated: ignored during evaluation. Feature rules never carried URL
+	// targeting in the JS SDK; use Experiment.URLPatterns with RunExperiment.
 	URLPatterns []URLTarget `json:"urlPatterns"`
-	// Legacy URL regex to restrict where the rule's experiment runs. Empty means no URL restriction.
+	// Deprecated: ignored during evaluation. Feature rules never carried URL
+	// targeting in the JS SDK; use Experiment.URL with RunExperiment.
 	URL string `json:"url"`
-	// Legacy group names — user must belong to at least one matching group (Client.WithGroups).
+	// Deprecated: ignored during evaluation. Feature rules never carried group
+	// targeting in the JS SDK; use Experiment.Groups with RunExperiment.
 	Groups []string `json:"groups"`
-	// Status — see Experiment.Status.
+	// Deprecated: ignored during evaluation. Feature rules never carried a
+	// status in the JS SDK; use Experiment.Status with RunExperiment.
 	Status ExperimentStatus `json:"status"`
 }

--- a/internal/value/truthy.go
+++ b/internal/value/truthy.go
@@ -1,0 +1,22 @@
+package value
+
+import "math"
+
+// Truthy reports whether v is truthy under JS coercion rules:
+// null, false, 0, NaN and "" are falsy; everything else (including
+// empty arrays and objects) is truthy.
+func Truthy(v Value) bool {
+	switch v.Type() {
+	case NullType:
+		return false
+	case BoolType:
+		return bool(v.(BoolValue))
+	case NumType:
+		n := float64(v.(NumValue))
+		return n != 0 && !math.IsNaN(n)
+	case StrType:
+		return v.(StrValue) != ""
+	default:
+		return true
+	}
+}

--- a/internal/value/value_test.go
+++ b/internal/value/value_test.go
@@ -1,8 +1,10 @@
 package value
 
 import (
-	"github.com/stretchr/testify/require"
+	"math"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestValueConstructor(t *testing.T) {
@@ -219,5 +221,28 @@ func TestValueString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		require.Equal(t, tt.s, New(tt.v).String())
+	}
+}
+
+func TestTruthy(t *testing.T) {
+	tests := []struct {
+		v Value
+		b bool
+	}{
+		{Null(), false},
+		{Bool(false), false},
+		{Bool(true), true},
+		{Num(0), false},
+		{Num(math.NaN()), false},
+		{Num(1), true},
+		{Num(-1), true},
+		{Str(""), false},
+		{Str("0"), true},
+		{Str("false"), true},
+		{ArrValue{}, true},
+		{ObjValue{}, true},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.b, Truthy(tt.v), "Truthy(%v)", tt.v)
 	}
 }

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -670,3 +670,58 @@ func (s *postReadGateService) GetAssignments(name, value string) (*StickyBucketA
 	}
 	return doc, err
 }
+
+func TestRolloutRuleFallbackAttribute(t *testing.T) {
+	// Mirrors JS evalFeature (sdk-js core.ts): rollout inclusion passes the
+	// rule's fallbackAttribute to getHashAttribute only when a sticky bucket
+	// service is configured and the rule doesn't disable sticky bucketing.
+	ctx := context.TODO()
+	coverage := 1.0
+	newFeatures := func(disableStickyBucketing bool) FeatureMap {
+		return FeatureMap{
+			"feature": {
+				DefaultValue: 0,
+				Rules: []FeatureRule{{
+					Force:                  1,
+					Coverage:               &coverage,
+					FallbackAttribute:      "deviceId",
+					DisableStickyBucketing: disableStickyBucketing,
+				}},
+			},
+		}
+	}
+	attrs := Attributes{"deviceId": "device123"} // no "id" attribute
+
+	t.Run("fallback used with sticky bucket service", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithAttributes(attrs),
+			WithFeatures(newFeatures(false)),
+			WithStickyBucketService(NewInMemoryStickyBucketService()),
+		)
+		require.NoError(t, err)
+		res := client.EvalFeature(ctx, "feature")
+		require.Equal(t, ForceResultSource, res.Source)
+		require.Equal(t, 1, res.Value)
+	})
+
+	t.Run("fallback ignored without sticky bucket service", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithAttributes(attrs),
+			WithFeatures(newFeatures(false)),
+		)
+		require.NoError(t, err)
+		res := client.EvalFeature(ctx, "feature")
+		require.Equal(t, DefaultValueResultSource, res.Source)
+	})
+
+	t.Run("fallback ignored when rule disables sticky bucketing", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithAttributes(attrs),
+			WithFeatures(newFeatures(true)),
+			WithStickyBucketService(NewInMemoryStickyBucketService()),
+		)
+		require.NoError(t, err)
+		res := client.EvalFeature(ctx, "feature")
+		require.Equal(t, DefaultValueResultSource, res.Source)
+	})
+}

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -725,3 +725,37 @@ func TestRolloutRuleFallbackAttribute(t *testing.T) {
 		require.Equal(t, DefaultValueResultSource, res.Source)
 	})
 }
+
+func TestStickyBucketFalsyFallbackAttributeIgnored(t *testing.T) {
+	// JS parity: a falsy fallback attribute value (0, "", false) must not be
+	// used to look up sticky bucket assignment docs (sdk-js core.ts
+	// getStickyBucketAssignments skips falsy fallback values).
+	ctx := context.TODO()
+	service := NewInMemoryStickyBucketService()
+	require.NoError(t, service.SaveAssignments(&StickyBucketAssignmentDoc{
+		AttributeName:  "anonymousId",
+		AttributeValue: "0",
+		Assignments:    map[string]string{"feature__0": "1"},
+	}))
+
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "u1", "anonymousId": 0}),
+		WithFeatures(FeatureMap{
+			"feature": {
+				DefaultValue: 0,
+				Rules: []FeatureRule{{
+					Variations:        []FeatureValue{0, 1},
+					Meta:              []VariationMeta{{Key: "0"}, {Key: "1"}},
+					FallbackAttribute: "anonymousId",
+				}},
+			},
+		}),
+		WithStickyBucketService(service),
+	)
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "feature")
+	require.NotNil(t, res.ExperimentResult)
+	require.False(t, res.ExperimentResult.StickyBucketUsed,
+		"sticky doc keyed by falsy fallback value must not be applied")
+}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -69,6 +69,7 @@ func TestSubscribe_FiresWhenAssignmentChanges(t *testing.T) {
 }
 
 func TestSubscribe_FiresForFeatureRuleMisses(t *testing.T) {
+	zeroCoverage := 0.0
 	c := newAttrClient(t, WithFeatures(FeatureMap{
 		"feature": {
 			DefaultValue: "default",
@@ -76,7 +77,7 @@ func TestSubscribe_FiresForFeatureRuleMisses(t *testing.T) {
 				{
 					Key:        "exp",
 					Variations: []FeatureValue{"off", "on"},
-					Status:     DraftStatus,
+					Coverage:   &zeroCoverage,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Fixes four evaluator divergences vs the JS SDK (source of truth: `sdk-js/src/core.ts`), each pinned by conformance cases or unit tests that fail without the fix. Follow-ups after the PR #77.

## Issues

- `getHashAttribute` treated `0`, `false`, `""` attribute values as present; JS uses truthiness (`core.ts` `getHashAttribute`), so they count as missing and trigger the fallback attribute or skip the rule.
- Rollout (force-rule coverage) inclusion never passed the rule's `fallbackAttribute`; JS passes it when a sticky bucket service is active and the rule doesn't disable sticky bucketing (`core.ts:274-282`).
- `experimentFromFeatureRule` copied `ParentConditions` into the inline experiment, so prerequisites already evaluated by `evalRule` were evaluated a second time in `runExperiment`. 
- `runExperiment`/`getExperimentResult` passed `exp.FallbackAttribute` unconditionally; JS gates it on the sticky bucket service (`core.ts:479-486`, `884-891`). Same rule as the rollout fix, found while cross-checking.

## Behavioral change

- Falsy hash attribute values (`0`, `false`, `""`, `null`) now skip rules / fall through to the fallback attribute, matching JS.
- `fallbackAttribute` (rollout and experiment paths) only applies when a sticky bucket service is configured and sticky bucketing isn't disabled.
- Rule-level `urlPatterns`/`url`/`groups`/`status` targeting (added in #65) is no longer applied to inline experiments — JS never had these on feature rules; they still work on `Experiment` via `RunExperiment`. The `FeatureRule` fields are now marked `Deprecated`.