### PR TITLE
Add LogEvent API for custom events

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,33 @@ Events tracked automatically:
 
 If plugin initialization fails (e.g., missing client key), the plugin silently becomes a no-op — it never interferes with SDK evaluation.
 
+#### Custom Events
+
+`client.LogEvent` logs a custom event with arbitrary properties — the Go
+equivalent of `logEvent` in the JS SDK and `log_event` in the Python SDK.
+With the tracking plugin configured, custom events are batched and sent to
+the ingestor alongside the automatic events:
+
+```go
+client.LogEvent(ctx, "button_clicked", gb.EventProperties{"button": "buy"})
+```
+
+You can also handle custom events yourself with `WithEventLogger` (with or
+without the tracking plugin — like callbacks, both fire independently):
+
+```go
+client, err := gb.NewClient(
+    context.Background(),
+    gb.WithEventLogger(func(ctx context.Context, eventName string, properties gb.EventProperties, userCtx *gb.EventUserContext) {
+        // Send to your analytics provider; userCtx carries the calling
+        // client's attributes and URL.
+    }),
+)
+```
+
+Custom plugins can receive these events too by implementing the optional
+`EventLoggerPlugin` interface (`OnEvent`).
+
 #### Custom Tracking via Callbacks
 
 For custom analytics integrations, you can set up two callbacks:

--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ type Client struct {
 	qaMode               bool
 	experimentCallback   ExperimentCallback
 	featureUsageCallback FeatureUsageCallback
+	eventLogger          EventLogger
 	logger               *slog.Logger
 	extraData            any
 	// StickyBucketService for storing experiment assignments

--- a/client_option.go
+++ b/client_option.go
@@ -152,6 +152,15 @@ func WithExperimentCallback(cb ExperimentCallback) ClientOption {
 }
 
 // WithFeatureUsageCallback sets feature usage callback function.
+// WithEventLogger sets a callback invoked by [Client.LogEvent] for every
+// custom event.
+func WithEventLogger(cb EventLogger) ClientOption {
+	return func(c *Client) error {
+		c.eventLogger = cb
+		return nil
+	}
+}
+
 func WithFeatureUsageCallback(cb FeatureUsageCallback) ClientOption {
 	return func(c *Client) error {
 		c.featureUsageCallback = cb
@@ -267,6 +276,11 @@ func (c *Client) WithExperimentCallback(cb ExperimentCallback) (*Client, error) 
 // WithFeatureUsageCallback creates child client with udpated feature usage callback function.
 func (c *Client) WithFeatureUsageCallback(cb FeatureUsageCallback) (*Client, error) {
 	return c.cloneWith(WithFeatureUsageCallback(cb))
+}
+
+// WithEventLogger creates child client with updated event logger function.
+func (c *Client) WithEventLogger(cb EventLogger) (*Client, error) {
+	return c.cloneWith(WithEventLogger(cb))
 }
 
 func withValueAttributes(value value.ObjValue) ClientOption {

--- a/client_option.go
+++ b/client_option.go
@@ -152,18 +152,18 @@ func WithExperimentCallback(cb ExperimentCallback) ClientOption {
 }
 
 // WithFeatureUsageCallback sets feature usage callback function.
+func WithFeatureUsageCallback(cb FeatureUsageCallback) ClientOption {
+	return func(c *Client) error {
+		c.featureUsageCallback = cb
+		return nil
+	}
+}
+
 // WithEventLogger sets a callback invoked by [Client.LogEvent] for every
 // custom event.
 func WithEventLogger(cb EventLogger) ClientOption {
 	return func(c *Client) error {
 		c.eventLogger = cb
-		return nil
-	}
-}
-
-func WithFeatureUsageCallback(cb FeatureUsageCallback) ClientOption {
-	return func(c *Client) error {
-		c.featureUsageCallback = cb
 		return nil
 	}
 }

--- a/event_logger.go
+++ b/event_logger.go
@@ -1,0 +1,93 @@
+package growthbook
+
+import (
+	"context"
+
+	"github.com/growthbook/growthbook-golang/internal/value"
+)
+
+// EventProperties holds the custom properties attached to a logged event.
+type EventProperties map[string]any
+
+// EventUserContext carries the user context a custom event was logged
+// with: the calling client's attributes and URL. It is the Go equivalent
+// of the userContext argument the JS and Python SDKs pass to their event
+// loggers.
+type EventUserContext struct {
+	Attributes Attributes
+	URL        string
+}
+
+// EventLogger is invoked by [Client.LogEvent] for every custom event.
+// Implementations should return quickly (e.g. by enqueueing work);
+// panics are recovered by the caller.
+type EventLogger func(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext)
+
+// EventLoggerPlugin is an optional interface a [Plugin] can implement to
+// receive custom events from [Client.LogEvent]. [GrowthBookTrackingPlugin]
+// implements it, sending events to the GrowthBook ingestor through the
+// same batching pipeline as experiment and feature events.
+type EventLoggerPlugin interface {
+	OnEvent(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext)
+}
+
+// LogEvent logs a custom event, the Go equivalent of the JS SDK's
+// logEvent and the Python SDK's log_event. The event is delivered to the
+// event logger configured with [WithEventLogger] and to every plugin that
+// implements [EventLoggerPlugin]. If neither is configured a warning is
+// logged and the call is a no-op.
+func (client *Client) LogEvent(ctx context.Context, eventName string, properties EventProperties) {
+	clientURL := ""
+	if client.url != nil {
+		clientURL = client.url.String()
+	}
+	userCtx := &EventUserContext{
+		Attributes: attributesFromValue(client.attributes),
+		URL:        clientURL,
+	}
+
+	logged := false
+	if client.eventLogger != nil {
+		logged = true
+		client.safeEventLogger(ctx, eventName, properties, userCtx)
+	}
+	for _, p := range client.data.getPlugins() {
+		if ep, ok := p.(EventLoggerPlugin); ok {
+			logged = true
+			client.safePluginOnEvent(ctx, ep, eventName, properties, userCtx)
+		}
+	}
+	if !logged {
+		client.logger.WarnContext(ctx, "LogEvent called but no event logger is configured", "event", eventName)
+	}
+}
+
+// safeEventLogger calls the configured event logger, recovering panics.
+func (client *Client) safeEventLogger(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext) {
+	defer func() {
+		if r := recover(); r != nil {
+			client.logger.ErrorContext(ctx, "Event logger panicked", "error", r)
+		}
+	}()
+	client.eventLogger(ctx, eventName, properties, userCtx)
+}
+
+// safePluginOnEvent calls the plugin's OnEvent, recovering panics.
+func (client *Client) safePluginOnEvent(ctx context.Context, p EventLoggerPlugin, eventName string, properties EventProperties, userCtx *EventUserContext) {
+	defer func() {
+		if r := recover(); r != nil {
+			client.logger.ErrorContext(ctx, "Plugin panicked in OnEvent", "error", r)
+		}
+	}()
+	p.OnEvent(ctx, eventName, properties, userCtx)
+}
+
+// attributesFromValue converts the client's internal attribute
+// representation back to plain Attributes.
+func attributesFromValue(obj value.ObjValue) Attributes {
+	attrs := make(Attributes, len(obj))
+	for k, v := range obj {
+		attrs[k] = value.ToAny(v)
+	}
+	return attrs
+}

--- a/event_logger_test.go
+++ b/event_logger_test.go
@@ -1,0 +1,87 @@
+package growthbook
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogEventCallback(t *testing.T) {
+	ctx := context.TODO()
+	var gotName string
+	var gotProps EventProperties
+	var gotUserCtx *EventUserContext
+
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "123", "country": "US"}),
+		WithUrl("http://example.com/checkout"),
+		WithEventLogger(func(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext) {
+			gotName = eventName
+			gotProps = properties
+			gotUserCtx = userCtx
+		}),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	client.LogEvent(ctx, "button_clicked", EventProperties{"button": "buy"})
+
+	require.Equal(t, "button_clicked", gotName)
+	require.Equal(t, EventProperties{"button": "buy"}, gotProps)
+	require.Equal(t, Attributes{"id": "123", "country": "US"}, gotUserCtx.Attributes)
+	require.Equal(t, "http://example.com/checkout", gotUserCtx.URL)
+}
+
+func TestLogEventChildClientAttributes(t *testing.T) {
+	ctx := context.TODO()
+	var gotAttrs Attributes
+
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "123"}),
+		WithEventLogger(func(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext) {
+			gotAttrs = userCtx.Attributes
+		}),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	child, err := client.WithAttributes(Attributes{"id": "456"})
+	require.NoError(t, err)
+
+	child.LogEvent(ctx, "event", nil)
+	require.Equal(t, Attributes{"id": "456"}, gotAttrs)
+}
+
+func TestLogEventNoLoggerWarns(t *testing.T) {
+	ctx := context.TODO()
+	var buf bytes.Buffer
+	client, err := NewClient(ctx,
+		WithLogger(slog.New(slog.NewTextHandler(&buf, nil))),
+	)
+	require.NoError(t, err)
+
+	client.LogEvent(ctx, "orphan_event", nil)
+	require.Contains(t, buf.String(), "no event logger is configured")
+}
+
+func TestLogEventLoggerPanicRecovered(t *testing.T) {
+	ctx := context.TODO()
+	var calls atomic.Int32
+	client, err := NewClient(ctx,
+		WithEventLogger(func(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext) {
+			calls.Add(1)
+			panic("boom")
+		}),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		client.LogEvent(ctx, "event", nil)
+	})
+	require.Equal(t, int32(1), calls.Load())
+}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -38,6 +38,33 @@ func New(a any) Value {
 	}
 }
 
+// ToAny converts a Value back to plain Go types: nil, bool, float64,
+// string, []any and map[string]any. Inverse of New.
+func ToAny(v Value) any {
+	switch t := v.(type) {
+	case BoolValue:
+		return bool(t)
+	case NumValue:
+		return float64(t)
+	case StrValue:
+		return string(t)
+	case ArrValue:
+		arr := make([]any, len(t))
+		for i, e := range t {
+			arr[i] = ToAny(e)
+		}
+		return arr
+	case ObjValue:
+		obj := make(map[string]any, len(t))
+		for k, e := range t {
+			obj[k] = ToAny(e)
+		}
+		return obj
+	default:
+		return nil
+	}
+}
+
 func Equal(v1, v2 Value) bool {
 	if v1.Type() != v2.Type() {
 		return false

--- a/internal/value/value_test.go
+++ b/internal/value/value_test.go
@@ -246,3 +246,21 @@ func TestTruthy(t *testing.T) {
 		require.Equal(t, tt.b, Truthy(tt.v), "Truthy(%v)", tt.v)
 	}
 }
+
+func TestToAny(t *testing.T) {
+	tests := []struct {
+		v Value
+		a any
+	}{
+		{Null(), nil},
+		{Bool(true), true},
+		{Num(1.5), 1.5},
+		{Num(2), 2.0},
+		{Str("x"), "x"},
+		{Arr(1, "y", true), []any{1.0, "y", true}},
+		{ObjValue{"n": Num(1), "o": ObjValue{"s": Str("z")}}, map[string]any{"n": 1.0, "o": map[string]any{"s": "z"}}},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.a, ToAny(tt.v), "ToAny(%v)", tt.v)
+	}
+}

--- a/tracking_plugin.go
+++ b/tracking_plugin.go
@@ -208,6 +208,94 @@ func (p *GrowthBookTrackingPlugin) OnFeatureEvaluated(ctx context.Context, featu
 	p.enqueue(event)
 }
 
+// OnEvent enqueues a custom event logged via [Client.LogEvent]. The
+// payload mirrors the EventPayload shape used by the JS and Python
+// tracking plugins (sdk-js plugins/growthbook-tracking.ts getEventPayload).
+// No-op if the plugin was not successfully initialized.
+func (p *GrowthBookTrackingPlugin) OnEvent(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext) {
+	if !p.initialized {
+		return
+	}
+	if properties == nil {
+		properties = EventProperties{}
+	}
+	event := trackingEvent{
+		"event_name":      eventName,
+		"properties_json": properties,
+		"sdk_language":    "go",
+		"sdk_version":     sdkVersion(),
+		"url":             userCtx.URL,
+	}
+	addEventAttributes(event, userCtx.Attributes)
+	p.enqueue(event)
+}
+
+// Attribute keys lifted to top-level EventPayload fields; everything else
+// goes into context_json. Mirrors parseAttributes in the JS tracking plugin.
+var (
+	eventIDAttrKeys = map[string]string{
+		"user_id":    "user_id",
+		"page_id":    "page_id",
+		"session_id": "session_id",
+	}
+	eventOptionalAttrKeys = map[string]string{
+		"utmCampaign": "utm_campaign",
+		"utmContent":  "utm_content",
+		"utmMedium":   "utm_medium",
+		"utmSource":   "utm_source",
+		"utmTerm":     "utm_term",
+		"pageTitle":   "page_title",
+	}
+	eventDeviceIDAttrKeys = []string{"device_id", "anonymous_id", "id"}
+)
+
+// addEventAttributes splits attributes into the top-level EventPayload
+// fields and the context_json object, like the JS plugin's parseAttributes:
+// id fields are always present (null when not a string), device_id falls
+// back to anonymous_id then id, and UTM/page_title fields are only set
+// when they hold a string.
+func addEventAttributes(event trackingEvent, attributes Attributes) {
+	nested := make(map[string]any, len(attributes))
+	for k, v := range attributes {
+		if _, ok := eventIDAttrKeys[k]; ok {
+			continue
+		}
+		if _, ok := eventOptionalAttrKeys[k]; ok {
+			continue
+		}
+		if k == "device_id" || k == "anonymous_id" || k == "id" {
+			continue
+		}
+		nested[k] = v
+	}
+	event["context_json"] = nested
+
+	for attrKey, field := range eventIDAttrKeys {
+		event[field] = stringOrNil(attributes[attrKey])
+	}
+	event["device_id"] = nil
+	for _, k := range eventDeviceIDAttrKeys {
+		if truthy(attributes[k]) {
+			event["device_id"] = stringOrNil(attributes[k])
+			break
+		}
+	}
+	for attrKey, field := range eventOptionalAttrKeys {
+		if s, ok := attributes[attrKey].(string); ok && s != "" {
+			event[field] = s
+		}
+	}
+}
+
+// stringOrNil returns the value if it is a string, otherwise nil —
+// like the JS plugin's parseString.
+func stringOrNil(v any) any {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return nil
+}
+
 // Close flushes any remaining events and releases resources. Safe to
 // call multiple times.
 func (p *GrowthBookTrackingPlugin) Close() error {

--- a/tracking_plugin.go
+++ b/tracking_plugin.go
@@ -84,10 +84,11 @@ type TrackingPluginConfig struct {
 // trackingEvent is the JSON payload for a single tracking event.
 type trackingEvent map[string]any
 
-// trackingRequest is the JSON body sent to the ingestor.
+// trackingRequest is the JSON body sent to the ingestor. Events are
+// pre-marshaled individually in enqueue.
 type trackingRequest struct {
-	Events    []trackingEvent `json:"events"`
-	ClientKey string          `json:"client_key"`
+	Events    []json.RawMessage `json:"events"`
+	ClientKey string            `json:"client_key"`
 }
 
 // GrowthBookTrackingPlugin sends experiment and feature evaluation
@@ -101,7 +102,7 @@ type GrowthBookTrackingPlugin struct {
 	initialized bool
 
 	mu     sync.Mutex
-	events []trackingEvent
+	events []json.RawMessage
 	timer  *time.Timer
 	closed bool
 	wg     sync.WaitGroup // tracks in-flight background sends
@@ -328,14 +329,23 @@ func (p *GrowthBookTrackingPlugin) Close() error {
 // enqueue adds an event to the batch. If the batch is full, it
 // triggers an immediate background flush. If this is the first event
 // in a new batch, it starts the timeout timer.
+// Events are marshaled here, one by one, so a single unmarshalable
+// value (e.g. NaN in LogEvent properties) drops only that event
+// instead of failing the whole batch at send time.
 func (p *GrowthBookTrackingPlugin) enqueue(event trackingEvent) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		p.logger.Error("Failed to marshal tracking event, dropping it", "error", err)
+		return
+	}
+
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
 		return
 	}
 
-	p.events = append(p.events, event)
+	p.events = append(p.events, data)
 
 	if len(p.events) >= p.config.BatchSize {
 		// Batch full — flush immediately.
@@ -391,7 +401,7 @@ func (p *GrowthBookTrackingPlugin) timerFlush() {
 // Delivery is best-effort: transient errors are logged and the batch
 // is dropped. No retry is attempted to keep the implementation simple
 // and avoid unbounded memory growth or complex retry state.
-func (p *GrowthBookTrackingPlugin) sendBatch(ctx context.Context, events []trackingEvent) {
+func (p *GrowthBookTrackingPlugin) sendBatch(ctx context.Context, events []json.RawMessage) {
 	body, err := json.Marshal(trackingRequest{
 		Events:    events,
 		ClientKey: p.clientKey,

--- a/tracking_plugin_test.go
+++ b/tracking_plugin_test.go
@@ -542,3 +542,82 @@ func (p *panickyPlugin) OnExperimentViewed(ctx context.Context, exp *Experiment,
 func (p *panickyPlugin) OnFeatureEvaluated(ctx context.Context, key string, res *FeatureResult) {
 	panic("feature evaluated panic")
 }
+
+func TestTrackingPluginLogEvent(t *testing.T) {
+	srv, reqs, mu := newTestIngestor(t)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithClientKey("sdk-test-key"),
+		WithAttributes(Attributes{
+			"id":         "user-123",
+			"user_id":    "u-9",
+			"utmSource":  "newsletter",
+			"utmContent": 42,   // non-string — omitted
+			"pageTitle":  "",   // empty string — omitted
+			"country":    "US", // nested
+		}),
+		WithGrowthBookTracking(TrackingPluginConfig{
+			IngestorHost: srv.URL,
+			BatchSize:    1, // flush on every event for test
+		}),
+	)
+	require.NoError(t, err)
+
+	client.LogEvent(ctx, "button_clicked", EventProperties{"button": "buy"})
+	require.NoError(t, client.Close())
+
+	captured := getRequests(reqs, mu)
+	require.Len(t, captured, 1)
+	require.Equal(t, "sdk-test-key", captured[0].ClientKey)
+	require.Len(t, captured[0].Events, 1)
+
+	event := captured[0].Events[0]
+	require.Equal(t, "button_clicked", event["event_name"])
+	require.Equal(t, map[string]any{"button": "buy"}, event["properties_json"])
+	require.Equal(t, "go", event["sdk_language"])
+	require.Equal(t, "", event["url"])
+
+	// Top-level id fields: user_id from attributes, device_id falls back
+	// to id, page_id/session_id null when absent.
+	require.Equal(t, "u-9", event["user_id"])
+	require.Equal(t, "user-123", event["device_id"])
+	require.Contains(t, event, "page_id")
+	require.Nil(t, event["page_id"])
+	require.Contains(t, event, "session_id")
+	require.Nil(t, event["session_id"])
+
+	// UTM fields: string values pass through, non-string and empty
+	// string values are omitted.
+	require.Equal(t, "newsletter", event["utm_source"])
+	require.NotContains(t, event, "utm_content")
+	require.NotContains(t, event, "page_title")
+
+	// Remaining attributes land in context_json; lifted keys don't.
+	require.Equal(t, map[string]any{"country": "US"}, event["context_json"])
+}
+
+func TestTrackingPluginLogEventNilProperties(t *testing.T) {
+	srv, reqs, mu := newTestIngestor(t)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithClientKey("sdk-test-key"),
+		WithGrowthBookTracking(TrackingPluginConfig{
+			IngestorHost: srv.URL,
+			BatchSize:    1,
+		}),
+	)
+	require.NoError(t, err)
+
+	client.LogEvent(ctx, "bare_event", nil)
+	require.NoError(t, client.Close())
+
+	captured := getRequests(reqs, mu)
+	require.Len(t, captured, 1)
+	event := captured[0].Events[0]
+	require.Equal(t, "bare_event", event["event_name"])
+	require.Equal(t, map[string]any{}, event["properties_json"])
+}

--- a/tracking_plugin_test.go
+++ b/tracking_plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -620,4 +621,31 @@ func TestTrackingPluginLogEventNilProperties(t *testing.T) {
 	event := captured[0].Events[0]
 	require.Equal(t, "bare_event", event["event_name"])
 	require.Equal(t, map[string]any{}, event["properties_json"])
+}
+
+func TestTrackingPluginBadPropertyDropsOnlyThatEvent(t *testing.T) {
+	srv, reqs, mu := newTestIngestor(t)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithClientKey("sdk-test-key"),
+		WithGrowthBookTracking(TrackingPluginConfig{
+			IngestorHost: srv.URL,
+			BatchSize:    10, // keep both events in one batch
+		}),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	// NaN is rejected by json.Marshal; the event must be dropped at
+	// enqueue time without poisoning the rest of the batch.
+	client.LogEvent(ctx, "bad_event", EventProperties{"score": math.NaN()})
+	client.LogEvent(ctx, "good_event", EventProperties{"ok": true})
+	require.NoError(t, client.Close())
+
+	captured := getRequests(reqs, mu)
+	require.Len(t, captured, 1)
+	require.Len(t, captured[0].Events, 1)
+	require.Equal(t, "good_event", captured[0].Events[0]["event_name"])
 }


### PR DESCRIPTION
## Summary

Adds a custom-event logging API — the Go equivalent of `logEvent` in the JS SDK

## How it works

1) one call to log a custom event with arbitrary properties.

```go
client.LogEvent(ctx, "button_clicked", gb.EventProperties{"button": "buy"})
```

2) `WithEventLogger(fn)` client option (plus child-client variant) for custom handling; the logger receives the calling client's attributes and URL, mirroring the `userContext` argument in JS/Python.
3) `GrowthBookTrackingPlugin` implements a new optional `EventLoggerPlugin` interface, so custom events flow through the existing batching pipeline (batch size/timeout, wg-tracked sends, flush on `Close`) to the ingestor.
4) Callback and plugins fire independently — same model the SDK already uses for `ExperimentCallback` vs plugin hooks.
5) The batch envelope stays Go's existing `POST /events` with `{client_key, events}`. 

## Things to Note

- The ingestor payload for custom events mirrors the JS/Python plugins' `EventPayload` shape.
- `EventLoggerPlugin` is an optional interface rather than a new `Plugin` method, so existing third-party `Plugin` implementations keep compiling.
- No logger configured → warn and no-op, matching JS ("No event logger configured") and Python.
- Adds `value.ToAny` (inverse of `value.New`) to hand plain Go types to the logger.
