### PR TITLE
feat: add remote evaluation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Added remote evaluation mode (`WithRemoteEval`): features are evaluated on
+  the GrowthBook endpoint (`POST {apiHost}/api/eval/{clientKey}`) for the
+  client's attributes instead of locally, matching the JS SDK's remote-eval
+  mode. Requires a client key and is incompatible with a decryption key or a
+  poll/SSE data source.
+- Remote-eval results are cached per distinct evaluation input (attributes,
+  forced variations, and URL) and reused within a TTL. `WithRemoteEvalTTL`
+  tunes the reuse window (0 disables expiry, default 60s), and
+  `WithCacheKeyAttributes` narrows the cache key to specific attributes so a
+  new request is made only when one of them changes.
+- The remote-eval cache is bounded (LRU, 1000 entries by default) via
+  `WithRemoteEvalCacheSize` so high-cardinality attributes cannot grow it
+  without limit, and concurrent fetches for the same key are coalesced into a
+  single request (single-flight).
+
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
 - **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`

--- a/client.go
+++ b/client.go
@@ -15,6 +15,10 @@ const defaultApiHost = "https://cdn.growthbook.io"
 
 var (
 	ErrNoDecryptionKey = errors.New("no decryption key provided")
+
+	ErrRemoteEvalNoClientKey    = errors.New("remote eval requires a client key")
+	ErrRemoteEvalDecryptionKey  = errors.New("remote eval is not compatible with a decryption key")
+	ErrRemoteEvalWithDataSource = errors.New("remote eval is not compatible with a poll/SSE data source")
 )
 
 // Client is a GrowthBook SDK client.
@@ -31,6 +35,13 @@ type Client struct {
 	eventLogger          EventLogger
 	logger               *slog.Logger
 	extraData            any
+
+	// remoteEval, when true, evaluates features on a remote endpoint
+	// (/api/eval/{clientKey}) instead of locally. cacheKeyAttributes limits
+	// which attributes trigger a new remote request.
+	remoteEval         bool
+	cacheKeyAttributes []string
+
 	// StickyBucketService for storing experiment assignments
 	stickyBucketService StickyBucketService
 
@@ -68,6 +79,12 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 	for _, opt := range opts {
 		err := opt(client)
 		if err != nil {
+			return nil, err
+		}
+	}
+
+	if client.remoteEval {
+		if err := client.validateRemoteEval(); err != nil {
 			return nil, err
 		}
 	}
@@ -219,6 +236,7 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 
 // EvalFeature evaluates feature based on attributes and features map
 func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResult {
+	client.maybeLoadRemoteEval(ctx)
 	e := client.evaluator(ctx)
 	res := e.evalFeature(key)
 	client.fireTracking(ctx, e)
@@ -226,6 +244,7 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 }
 
 func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *ExperimentResult {
+	client.maybeLoadRemoteEval(ctx)
 	e := client.evaluator(ctx)
 	res := e.runExperiment(exp, "")
 	client.fireTracking(ctx, e)
@@ -289,16 +308,29 @@ func (client *Client) Logger() *slog.Logger {
 // Internals
 func (client *Client) evaluator(ctx context.Context) *evaluator {
 	client.data.mu.RLock()
-	e := evaluator{
-		features:    client.data.features,
-		savedGroups: client.data.savedGroups,
+	features := client.data.features
+	savedGroups := client.data.savedGroups
+	client.data.mu.RUnlock()
+
+	// In remote-eval mode the features are the server-evaluated set cached for
+	// this client's attributes; fall back to none when not loaded yet.
+	if client.remoteEval {
+		features = nil
+		if key, err := client.remoteEvalCacheKey(); err == nil {
+			if f, ok := client.data.getRemoteEval(key); ok {
+				features = f
+			}
+		}
+	}
+
+	return &evaluator{
+		features:    features,
+		savedGroups: savedGroups,
 		client:      client,
 		ctx:         ctx,
 		recording: client.experimentCallback != nil || client.featureUsageCallback != nil ||
 			client.deferredTracks != nil || len(client.data.plugins) > 0,
 	}
-	client.data.mu.RUnlock()
-	return &e
 }
 
 func (client *Client) clone() *Client {

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
@@ -41,6 +42,7 @@ type Client struct {
 	// which attributes trigger a new remote request.
 	remoteEval         bool
 	cacheKeyAttributes []string
+	remoteEvalTTL      time.Duration
 
 	// StickyBucketService for storing experiment assignments
 	stickyBucketService StickyBucketService
@@ -135,6 +137,7 @@ func defaultClient() *Client {
 		logger:                  slog.Default(),
 		attributes:              value.ObjValue{},
 		stickyBucketAssignments: newStickyBucketCache(defaultStickyBucketCacheSize),
+		remoteEvalTTL:           defaultRemoteEvalTTL,
 	}
 }
 
@@ -317,8 +320,8 @@ func (client *Client) evaluator(ctx context.Context) *evaluator {
 	if client.remoteEval {
 		features = nil
 		if key, err := client.remoteEvalCacheKey(); err == nil {
-			if f, ok := client.data.getRemoteEval(key); ok {
-				features = f
+			if entry, ok := client.data.getRemoteEval(key); ok {
+				features = entry.features
 			}
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -40,9 +40,10 @@ type Client struct {
 	// remoteEval, when true, evaluates features on a remote endpoint
 	// (/api/eval/{clientKey}) instead of locally. cacheKeyAttributes limits
 	// which attributes trigger a new remote request.
-	remoteEval         bool
-	cacheKeyAttributes []string
-	remoteEvalTTL      time.Duration
+	remoteEval          bool
+	cacheKeyAttributes  []string
+	remoteEvalTTL       time.Duration
+	remoteEvalCacheSize int
 
 	// StickyBucketService for storing experiment assignments
 	stickyBucketService StickyBucketService
@@ -138,6 +139,7 @@ func defaultClient() *Client {
 		attributes:              value.ObjValue{},
 		stickyBucketAssignments: newStickyBucketCache(defaultStickyBucketCacheSize),
 		remoteEvalTTL:           defaultRemoteEvalTTL,
+		remoteEvalCacheSize:     defaultRemoteEvalCacheSize,
 	}
 }
 

--- a/client_data.go
+++ b/client_data.go
@@ -121,7 +121,6 @@ func (d *data) setRemoteEval(key string, features FeatureMap, maxSize int) {
 		evicted := back.Value.(*remoteEvalEntry)
 		d.remoteEvalOrder.Remove(back)
 		delete(d.remoteEvalCache, evicted.key)
-		d.remoteEvalFlight.delete(evicted.key)
 	}
 }
 

--- a/client_data.go
+++ b/client_data.go
@@ -27,7 +27,17 @@ type data struct {
 	// remoteEvalCache maps a remote-eval cache key (derived from the relevant
 	// attributes) to the server-evaluated feature set. Shared across child
 	// clients so requests with the same attributes reuse one remote fetch.
-	remoteEvalCache map[string]FeatureMap
+	remoteEvalCache map[string]*remoteEvalEntry
+	// remoteEvalFlight coalesces concurrent remote fetches for the same key.
+	remoteEvalFlight keyedMutex
+	// now returns the current time; overridable in tests for TTL checks.
+	now func() time.Time
+}
+
+// remoteEvalEntry is a cached server-evaluated feature set with its fetch time.
+type remoteEvalEntry struct {
+	features  FeatureMap
+	fetchedAt time.Time
 }
 
 func newData() *data {
@@ -35,6 +45,7 @@ func newData() *data {
 		dsStartWait: make(chan struct{}),
 		apiHost:     defaultApiHost,
 		httpClient:  http.DefaultClient,
+		now:         time.Now,
 	}
 }
 
@@ -68,20 +79,20 @@ func (d *data) getEvalUrl() string {
 	return d.apiHost + "/api/eval/" + d.clientKey
 }
 
-func (d *data) getRemoteEval(key string) (FeatureMap, bool) {
+func (d *data) getRemoteEval(key string) (*remoteEvalEntry, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	f, ok := d.remoteEvalCache[key]
-	return f, ok
+	e, ok := d.remoteEvalCache[key]
+	return e, ok
 }
 
 func (d *data) setRemoteEval(key string, features FeatureMap) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.remoteEvalCache == nil {
-		d.remoteEvalCache = make(map[string]FeatureMap)
+		d.remoteEvalCache = make(map[string]*remoteEvalEntry)
 	}
-	d.remoteEvalCache[key] = features
+	d.remoteEvalCache[key] = &remoteEvalEntry{features: features, fetchedAt: d.now()}
 }
 
 func (d *data) getDsStartErr() error {

--- a/client_data.go
+++ b/client_data.go
@@ -23,6 +23,11 @@ type data struct {
 	dsStartErr    error
 	plugins       []Plugin
 	subscribers   subscriberRegistry
+
+	// remoteEvalCache maps a remote-eval cache key (derived from the relevant
+	// attributes) to the server-evaluated feature set. Shared across child
+	// clients so requests with the same attributes reuse one remote fetch.
+	remoteEvalCache map[string]FeatureMap
 }
 
 func newData() *data {
@@ -55,6 +60,28 @@ func (d *data) getSseUrl() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.apiHost + "/sub/" + d.clientKey
+}
+
+func (d *data) getEvalUrl() string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.apiHost + "/api/eval/" + d.clientKey
+}
+
+func (d *data) getRemoteEval(key string) (FeatureMap, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	f, ok := d.remoteEvalCache[key]
+	return f, ok
+}
+
+func (d *data) setRemoteEval(key string, features FeatureMap) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.remoteEvalCache == nil {
+		d.remoteEvalCache = make(map[string]FeatureMap)
+	}
+	d.remoteEvalCache[key] = features
 }
 
 func (d *data) getDsStartErr() error {

--- a/client_data.go
+++ b/client_data.go
@@ -103,9 +103,10 @@ func (d *data) setRemoteEval(key string, features FeatureMap, maxSize int) {
 		d.remoteEvalOrder = list.New()
 	}
 	if elem, ok := d.remoteEvalCache[key]; ok {
-		entry := elem.Value.(*remoteEvalEntry)
-		entry.features = features
-		entry.fetchedAt = d.now()
+		// Replace the pointer instead of mutating in place: getRemoteEval hands
+		// the entry to callers that read it after releasing the RLock, so the
+		// entry must be an immutable snapshot.
+		elem.Value = &remoteEvalEntry{key: key, features: features, fetchedAt: d.now()}
 		d.remoteEvalOrder.MoveToFront(elem)
 		return
 	}

--- a/client_data.go
+++ b/client_data.go
@@ -1,6 +1,7 @@
 package growthbook
 
 import (
+	"container/list"
 	"net/http"
 	"sync"
 	"time"
@@ -25,9 +26,11 @@ type data struct {
 	subscribers   subscriberRegistry
 
 	// remoteEvalCache maps a remote-eval cache key (derived from the relevant
-	// attributes) to the server-evaluated feature set. Shared across child
-	// clients so requests with the same attributes reuse one remote fetch.
-	remoteEvalCache map[string]*remoteEvalEntry
+	// attributes) to its list element; remoteEvalOrder tracks recency so the
+	// cache can be bounded with LRU eviction. Shared across child clients so
+	// requests with the same attributes reuse one remote fetch.
+	remoteEvalCache map[string]*list.Element
+	remoteEvalOrder *list.List
 	// remoteEvalFlight coalesces concurrent remote fetches for the same key.
 	remoteEvalFlight keyedMutex
 	// now returns the current time; overridable in tests for TTL checks.
@@ -36,6 +39,7 @@ type data struct {
 
 // remoteEvalEntry is a cached server-evaluated feature set with its fetch time.
 type remoteEvalEntry struct {
+	key       string
 	features  FeatureMap
 	fetchedAt time.Time
 }
@@ -82,17 +86,42 @@ func (d *data) getEvalUrl() string {
 func (d *data) getRemoteEval(key string) (*remoteEvalEntry, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	e, ok := d.remoteEvalCache[key]
-	return e, ok
+	elem, ok := d.remoteEvalCache[key]
+	if !ok {
+		return nil, false
+	}
+	return elem.Value.(*remoteEvalEntry), true
 }
 
-func (d *data) setRemoteEval(key string, features FeatureMap) {
+// setRemoteEval stores features under key, refreshing recency. When maxSize > 0
+// the least-recently-used entries are evicted to keep the cache bounded.
+func (d *data) setRemoteEval(key string, features FeatureMap, maxSize int) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.remoteEvalCache == nil {
-		d.remoteEvalCache = make(map[string]*remoteEvalEntry)
+		d.remoteEvalCache = make(map[string]*list.Element)
+		d.remoteEvalOrder = list.New()
 	}
-	d.remoteEvalCache[key] = &remoteEvalEntry{features: features, fetchedAt: d.now()}
+	if elem, ok := d.remoteEvalCache[key]; ok {
+		entry := elem.Value.(*remoteEvalEntry)
+		entry.features = features
+		entry.fetchedAt = d.now()
+		d.remoteEvalOrder.MoveToFront(elem)
+		return
+	}
+	elem := d.remoteEvalOrder.PushFront(&remoteEvalEntry{key: key, features: features, fetchedAt: d.now()})
+	d.remoteEvalCache[key] = elem
+
+	for maxSize > 0 && len(d.remoteEvalCache) > maxSize {
+		back := d.remoteEvalOrder.Back()
+		if back == nil {
+			break
+		}
+		evicted := back.Value.(*remoteEvalEntry)
+		d.remoteEvalOrder.Remove(back)
+		delete(d.remoteEvalCache, evicted.key)
+		d.remoteEvalFlight.delete(evicted.key)
+	}
 }
 
 func (d *data) getDsStartErr() error {

--- a/datasource.go
+++ b/datasource.go
@@ -36,6 +36,11 @@ func (client *Client) startDataSource(ctx context.Context) {
 }
 
 func (client *Client) EnsureLoaded(ctx context.Context) error {
+	// In remote-eval mode there is no background data source; load the
+	// server-evaluated features for the client's current attributes instead.
+	if client.remoteEval {
+		return client.loadRemoteEval(ctx, false)
+	}
 	select {
 	case <-client.data.dsStartWait:
 		return client.data.getDsStartErr()

--- a/remote_eval.go
+++ b/remote_eval.go
@@ -93,12 +93,26 @@ func WithRemoteEvalCacheSize(size int) ClientOption {
 
 // WithRemoteEval creates a child client with remote evaluation toggled.
 func (c *Client) WithRemoteEval(enabled bool) (*Client, error) {
-	return c.cloneWith(WithRemoteEval(enabled))
+	return remoteEvalChild(c.cloneWith(WithRemoteEval(enabled)))
 }
 
 // WithCacheKeyAttributes creates a child client with updated cache-key attributes.
 func (c *Client) WithCacheKeyAttributes(attrs []string) (*Client, error) {
-	return c.cloneWith(WithCacheKeyAttributes(attrs))
+	return remoteEvalChild(c.cloneWith(WithCacheKeyAttributes(attrs)))
+}
+
+// remoteEvalChild validates the remote-eval configuration of a freshly cloned
+// child, so child clients enforce the same rules as NewClient.
+func remoteEvalChild(client *Client, err error) (*Client, error) {
+	if err != nil {
+		return nil, err
+	}
+	if client.remoteEval {
+		if err := client.validateRemoteEval(); err != nil {
+			return nil, err
+		}
+	}
+	return client, nil
 }
 
 func (client *Client) validateRemoteEval() error {
@@ -223,9 +237,15 @@ func (client *Client) callEvalApi(ctx context.Context) (*FeatureApiResponse, err
 	if client.url != nil {
 		pageURL = client.url.String()
 	}
+	// Send an empty object rather than null when no forced variations are set,
+	// matching the other SDKs' wire shape.
+	forcedVariations := client.forcedVariations
+	if forcedVariations == nil {
+		forcedVariations = ForcedVariationsMap{}
+	}
 	body, err := json.Marshal(remoteEvalPayload{
 		Attributes:       attrs,
-		ForcedVariations: client.forcedVariations,
+		ForcedVariations: forcedVariations,
 		ForcedFeatures:   [][]any{},
 		URL:              pageURL,
 	})

--- a/remote_eval.go
+++ b/remote_eval.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/growthbook/growthbook-golang/internal/value"
@@ -23,33 +22,9 @@ const defaultRemoteEvalTTL = 60 * time.Second
 // high-cardinality attributes does not grow the cache without limit.
 const defaultRemoteEvalCacheSize = 1000
 
-// keyedMutex serializes work per key, coalescing concurrent remote fetches for
-// the same attributes so they issue a single request (single-flight).
-type keyedMutex struct {
-	mu sync.Mutex
-	m  map[string]*sync.Mutex
-}
-
-func (k *keyedMutex) lock(key string) func() {
-	k.mu.Lock()
-	if k.m == nil {
-		k.m = make(map[string]*sync.Mutex)
-	}
-	mu, ok := k.m[key]
-	if !ok {
-		mu = &sync.Mutex{}
-		k.m[key] = mu
-	}
-	k.mu.Unlock()
-	mu.Lock()
-	return mu.Unlock
-}
-
-func (k *keyedMutex) delete(key string) {
-	k.mu.Lock()
-	delete(k.m, key)
-	k.mu.Unlock()
-}
+// The remote-eval single-flight uses the shared keyedMutex defined in
+// sticky_bucket.go, which serializes work per key and auto-releases a key's
+// entry once no goroutine holds or waits for it.
 
 // WithRemoteEval enables remote evaluation: features are evaluated on a remote
 // endpoint (POST {apiHost}/api/eval/{clientKey}) for the client's attributes

--- a/remote_eval.go
+++ b/remote_eval.go
@@ -7,9 +7,38 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/growthbook/growthbook-golang/internal/value"
 )
+
+// defaultRemoteEvalTTL is how long a cached remote-eval result is reused before
+// a new request is made, so feature changes on the server are eventually picked
+// up. A value of 0 disables expiry.
+const defaultRemoteEvalTTL = 60 * time.Second
+
+// keyedMutex serializes work per key, coalescing concurrent remote fetches for
+// the same attributes so they issue a single request (single-flight).
+type keyedMutex struct {
+	mu sync.Mutex
+	m  map[string]*sync.Mutex
+}
+
+func (k *keyedMutex) lock(key string) func() {
+	k.mu.Lock()
+	if k.m == nil {
+		k.m = make(map[string]*sync.Mutex)
+	}
+	mu, ok := k.m[key]
+	if !ok {
+		mu = &sync.Mutex{}
+		k.m[key] = mu
+	}
+	k.mu.Unlock()
+	mu.Lock()
+	return mu.Unlock
+}
 
 // WithRemoteEval enables remote evaluation: features are evaluated on a remote
 // endpoint (POST {apiHost}/api/eval/{clientKey}) for the client's attributes
@@ -28,6 +57,15 @@ func WithRemoteEval(enabled bool) ClientOption {
 func WithCacheKeyAttributes(attrs []string) ClientOption {
 	return func(c *Client) error {
 		c.cacheKeyAttributes = attrs
+		return nil
+	}
+}
+
+// WithRemoteEvalTTL sets how long a cached remote-eval result is reused before a
+// new request is made. A value of 0 disables expiry. Defaults to 60s.
+func WithRemoteEvalTTL(ttl time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.remoteEvalTTL = ttl
 		return nil
 	}
 }
@@ -90,18 +128,26 @@ func (client *Client) maybeLoadRemoteEval(ctx context.Context) {
 }
 
 // loadRemoteEval fetches server-evaluated features for the client's attributes
-// and caches them. When force is false and the attributes are already cached,
-// it is a no-op.
+// and caches them. When force is false and a fresh (non-expired) entry is
+// cached, it is a no-op. Concurrent loads for the same key are coalesced into a
+// single request. On fetch failure any previously cached entry is kept, so a
+// stale result is still served rather than nothing.
 func (client *Client) loadRemoteEval(ctx context.Context, force bool) error {
 	key, err := client.remoteEvalCacheKey()
 	if err != nil {
 		return err
 	}
-	if !force {
-		if _, ok := client.data.getRemoteEval(key); ok {
-			return nil
-		}
+	if !force && client.remoteEvalFresh(key) {
+		return nil
 	}
+
+	unlock := client.data.remoteEvalFlight.lock(key)
+	defer unlock()
+	// Another goroutine may have refreshed this key while we waited.
+	if !force && client.remoteEvalFresh(key) {
+		return nil
+	}
+
 	resp, err := client.callEvalApi(ctx)
 	if err != nil {
 		return err
@@ -113,6 +159,18 @@ func (client *Client) loadRemoteEval(ctx context.Context, force bool) error {
 	}
 	client.data.setRemoteEval(key, resp.Features)
 	return nil
+}
+
+// remoteEvalFresh reports whether a non-expired cache entry exists for key.
+func (client *Client) remoteEvalFresh(key string) bool {
+	entry, ok := client.data.getRemoteEval(key)
+	if !ok {
+		return false
+	}
+	if client.remoteEvalTTL <= 0 {
+		return true
+	}
+	return client.data.now().Sub(entry.fetchedAt) < client.remoteEvalTTL
 }
 
 type remoteEvalPayload struct {

--- a/remote_eval.go
+++ b/remote_eval.go
@@ -114,8 +114,11 @@ func (client *Client) validateRemoteEval() error {
 	return nil
 }
 
-// remoteEvalCacheKey returns a stable key for the client's current attributes.
-// When cacheKeyAttributes is set, only those attributes contribute to the key.
+// remoteEvalCacheKey returns a stable key covering every input sent to the
+// remote-eval endpoint: the attributes, forced variations and URL. Keying on all
+// of them ensures a change to any (not just attributes) triggers a fresh
+// evaluation instead of reusing a result computed for different inputs. When
+// cacheKeyAttributes is set, only those attributes contribute to the key.
 func (client *Client) remoteEvalCacheKey() (string, error) {
 	attrs := client.attributes
 	if len(client.cacheKeyAttributes) > 0 {
@@ -127,8 +130,16 @@ func (client *Client) remoteEvalCacheKey() (string, error) {
 		}
 		attrs = selected
 	}
+	pageURL := ""
+	if client.url != nil {
+		pageURL = client.url.String()
+	}
 	// json.Marshal sorts map keys, so the key is deterministic.
-	b, err := json.Marshal(attrs)
+	b, err := json.Marshal(struct {
+		Attributes       value.ObjValue      `json:"attributes"`
+		ForcedVariations ForcedVariationsMap `json:"forcedVariations"`
+		URL              string              `json:"url"`
+	}{attrs, client.forcedVariations, pageURL})
 	if err != nil {
 		return "", err
 	}

--- a/remote_eval.go
+++ b/remote_eval.go
@@ -18,6 +18,11 @@ import (
 // up. A value of 0 disables expiry.
 const defaultRemoteEvalTTL = 60 * time.Second
 
+// defaultRemoteEvalCacheSize bounds the number of cached remote-eval results
+// (one per distinct attribute set) so a long-running process with
+// high-cardinality attributes does not grow the cache without limit.
+const defaultRemoteEvalCacheSize = 1000
+
 // keyedMutex serializes work per key, coalescing concurrent remote fetches for
 // the same attributes so they issue a single request (single-flight).
 type keyedMutex struct {
@@ -38,6 +43,12 @@ func (k *keyedMutex) lock(key string) func() {
 	k.mu.Unlock()
 	mu.Lock()
 	return mu.Unlock
+}
+
+func (k *keyedMutex) delete(key string) {
+	k.mu.Lock()
+	delete(k.m, key)
+	k.mu.Unlock()
 }
 
 // WithRemoteEval enables remote evaluation: features are evaluated on a remote
@@ -66,6 +77,16 @@ func WithCacheKeyAttributes(attrs []string) ClientOption {
 func WithRemoteEvalTTL(ttl time.Duration) ClientOption {
 	return func(c *Client) error {
 		c.remoteEvalTTL = ttl
+		return nil
+	}
+}
+
+// WithRemoteEvalCacheSize bounds how many remote-eval results are cached (one
+// per distinct attribute set), evicting least-recently-used entries. A value of
+// 0 disables the bound. Defaults to 1000.
+func WithRemoteEvalCacheSize(size int) ClientOption {
+	return func(c *Client) error {
+		c.remoteEvalCacheSize = size
 		return nil
 	}
 }
@@ -157,7 +178,7 @@ func (client *Client) loadRemoteEval(ctx context.Context, force bool) error {
 		client.logger.WarnContext(ctx, "Remote eval response contains no features")
 		return nil
 	}
-	client.data.setRemoteEval(key, resp.Features)
+	client.data.setRemoteEval(key, resp.Features, client.remoteEvalCacheSize)
 	return nil
 }
 

--- a/remote_eval.go
+++ b/remote_eval.go
@@ -1,0 +1,173 @@
+package growthbook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/growthbook/growthbook-golang/internal/value"
+)
+
+// WithRemoteEval enables remote evaluation: features are evaluated on a remote
+// endpoint (POST {apiHost}/api/eval/{clientKey}) for the client's attributes
+// instead of locally. Requires a client key and is incompatible with a
+// decryption key or a poll/SSE data source. Default false.
+func WithRemoteEval(enabled bool) ClientOption {
+	return func(c *Client) error {
+		c.remoteEval = enabled
+		return nil
+	}
+}
+
+// WithCacheKeyAttributes limits which attributes are used to key the remote-eval
+// cache: a new remote request is made only when one of these attributes changes.
+// When empty, all attributes are used.
+func WithCacheKeyAttributes(attrs []string) ClientOption {
+	return func(c *Client) error {
+		c.cacheKeyAttributes = attrs
+		return nil
+	}
+}
+
+// WithRemoteEval creates a child client with remote evaluation toggled.
+func (c *Client) WithRemoteEval(enabled bool) (*Client, error) {
+	return c.cloneWith(WithRemoteEval(enabled))
+}
+
+// WithCacheKeyAttributes creates a child client with updated cache-key attributes.
+func (c *Client) WithCacheKeyAttributes(attrs []string) (*Client, error) {
+	return c.cloneWith(WithCacheKeyAttributes(attrs))
+}
+
+func (client *Client) validateRemoteEval() error {
+	if client.data.clientKey == "" {
+		return ErrRemoteEvalNoClientKey
+	}
+	if client.data.decryptionKey != "" {
+		return ErrRemoteEvalDecryptionKey
+	}
+	if client.data.dataSource != nil {
+		return ErrRemoteEvalWithDataSource
+	}
+	return nil
+}
+
+// remoteEvalCacheKey returns a stable key for the client's current attributes.
+// When cacheKeyAttributes is set, only those attributes contribute to the key.
+func (client *Client) remoteEvalCacheKey() (string, error) {
+	attrs := client.attributes
+	if len(client.cacheKeyAttributes) > 0 {
+		selected := value.ObjValue{}
+		for _, k := range client.cacheKeyAttributes {
+			if v, ok := attrs[k]; ok {
+				selected[k] = v
+			}
+		}
+		attrs = selected
+	}
+	// json.Marshal sorts map keys, so the key is deterministic.
+	b, err := json.Marshal(attrs)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// maybeLoadRemoteEval lazily loads the remote-eval features for the current
+// attributes when remote eval is enabled. Errors are logged, not returned, so
+// evaluation is never blocked (a failed load yields "unknownFeature", matching
+// the documented remote-eval fallback behavior).
+func (client *Client) maybeLoadRemoteEval(ctx context.Context) {
+	if !client.remoteEval {
+		return
+	}
+	if err := client.loadRemoteEval(ctx, false); err != nil {
+		client.logger.WarnContext(ctx, "Remote eval load failed", "error", err)
+	}
+}
+
+// loadRemoteEval fetches server-evaluated features for the client's attributes
+// and caches them. When force is false and the attributes are already cached,
+// it is a no-op.
+func (client *Client) loadRemoteEval(ctx context.Context, force bool) error {
+	key, err := client.remoteEvalCacheKey()
+	if err != nil {
+		return err
+	}
+	if !force {
+		if _, ok := client.data.getRemoteEval(key); ok {
+			return nil
+		}
+	}
+	resp, err := client.callEvalApi(ctx)
+	if err != nil {
+		return err
+	}
+	if resp.Features == nil {
+		// A missing "features" key is a malformed response; don't cache it.
+		client.logger.WarnContext(ctx, "Remote eval response contains no features")
+		return nil
+	}
+	client.data.setRemoteEval(key, resp.Features)
+	return nil
+}
+
+type remoteEvalPayload struct {
+	Attributes       json.RawMessage     `json:"attributes"`
+	ForcedVariations ForcedVariationsMap `json:"forcedVariations"`
+	ForcedFeatures   [][]any             `json:"forcedFeatures"`
+	URL              string              `json:"url"`
+}
+
+// callEvalApi POSTs the current attributes to the remote-eval endpoint and
+// returns the server-evaluated feature response.
+func (client *Client) callEvalApi(ctx context.Context) (*FeatureApiResponse, error) {
+	attrs, err := json.Marshal(client.attributes)
+	if err != nil {
+		return nil, err
+	}
+	pageURL := ""
+	if client.url != nil {
+		pageURL = client.url.String()
+	}
+	body, err := json.Marshal(remoteEvalPayload{
+		Attributes:       attrs,
+		ForcedVariations: client.forcedVariations,
+		ForcedFeatures:   [][]any{},
+		URL:              pageURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, client.data.getEvalUrl(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.data.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("remote eval failed, code: %d", resp.StatusCode)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	apiResp := FeatureApiResponse{}
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		client.logger.ErrorContext(ctx, "Error parsing remote eval response", "error", err)
+		return nil, err
+	}
+	return &apiResp, nil
+}

--- a/remote_eval_test.go
+++ b/remote_eval_test.go
@@ -173,6 +173,33 @@ func TestRemoteEvalServesStaleOnFailure(t *testing.T) {
 	require.Equal(t, "on", client.EvalFeature(ctx, "feat").Value)
 }
 
+func TestRemoteEvalCacheEviction(t *testing.T) {
+	ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+	defer ts.http.Close()
+
+	root := newRemoteEvalClient(t, ts, WithRemoteEvalCacheSize(2))
+
+	eval := func(id string) {
+		c, err := root.WithAttributes(Attributes{"id": id})
+		require.NoError(t, err)
+		c.EvalFeature(ctx, "feat")
+	}
+
+	eval("1") // cache: [1]
+	eval("2") // cache: [2,1]
+	eval("3") // cache: [3,2], evicts 1
+	require.Equal(t, int32(3), ts.count.Load())
+
+	// 2 and 3 are still cached (no new request).
+	eval("2")
+	eval("3")
+	require.Equal(t, int32(3), ts.count.Load())
+
+	// 1 was evicted, so it triggers a fresh request.
+	eval("1")
+	require.Equal(t, int32(4), ts.count.Load())
+}
+
 func TestRemoteEvalSingleFlight(t *testing.T) {
 	var count atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/remote_eval_test.go
+++ b/remote_eval_test.go
@@ -2,6 +2,7 @@ package growthbook
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -230,6 +231,63 @@ func TestRemoteEvalCacheEviction(t *testing.T) {
 	// 1 was evicted, so it triggers a fresh request.
 	eval("1")
 	require.Equal(t, int32(4), ts.count.Load())
+}
+
+func TestRemoteEvalChildValidation(t *testing.T) {
+	// A child that enables remote eval must enforce the same rules as NewClient.
+	withKey, err := NewClient(ctx, WithClientKey("k"), WithDecryptionKey("dk"))
+	require.NoError(t, err)
+	_, err = withKey.WithRemoteEval(true)
+	require.ErrorIs(t, err, ErrRemoteEvalDecryptionKey)
+
+	noKey, err := NewClient(ctx)
+	require.NoError(t, err)
+	_, err = noKey.WithRemoteEval(true)
+	require.ErrorIs(t, err, ErrRemoteEvalNoClientKey)
+}
+
+func TestRemoteEvalPayloadForcedVariationsNotNull(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"features":{}}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(ctx,
+		WithHttpClient(srv.Client()), WithApiHost(srv.URL), WithClientKey("k"),
+		WithRemoteEval(true), WithAttributes(Attributes{"id": "1"}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, client.EnsureLoaded(ctx))
+
+	require.Contains(t, string(body), `"forcedVariations":{}`)
+	require.NotContains(t, string(body), `"forcedVariations":null`)
+}
+
+func TestRemoteEvalConcurrentRefreshNoRace(t *testing.T) {
+	ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+	defer ts.http.Close()
+
+	// A tiny TTL forces frequent refreshes; run under -race to catch mutation of
+	// a shared cache entry concurrently with readers.
+	client := newRemoteEvalClient(t, ts,
+		WithAttributes(Attributes{"id": "1"}),
+		WithRemoteEvalTTL(time.Millisecond),
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				time.Sleep(time.Millisecond)
+				require.Equal(t, "on", client.EvalFeature(ctx, "feat").Value)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestRemoteEvalSingleFlight(t *testing.T) {

--- a/remote_eval_test.go
+++ b/remote_eval_test.go
@@ -3,7 +3,11 @@ package growthbook
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -113,4 +117,87 @@ func TestRemoteEvalIgnoresNilFeaturesResponse(t *testing.T) {
 	// A malformed (no "features") response is not cached and does not panic.
 	res := client.EvalFeature(ctx, "feat")
 	require.Equal(t, UnknownFeatureResultSource, res.Source)
+}
+
+func TestRemoteEvalRefetchesAfterTTL(t *testing.T) {
+	ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+	defer ts.http.Close()
+
+	client := newRemoteEvalClient(t, ts,
+		WithAttributes(Attributes{"id": "1"}),
+		WithRemoteEvalTTL(time.Minute),
+	)
+	base := time.Unix(1000, 0)
+	cur := base
+	client.data.now = func() time.Time { return cur }
+
+	client.EvalFeature(ctx, "feat")
+	require.Equal(t, int32(1), ts.count.Load())
+
+	// Within TTL: no new request.
+	cur = base.Add(30 * time.Second)
+	client.EvalFeature(ctx, "feat")
+	require.Equal(t, int32(1), ts.count.Load())
+
+	// Past TTL: a new request is made.
+	cur = base.Add(2 * time.Minute)
+	client.EvalFeature(ctx, "feat")
+	require.Equal(t, int32(2), ts.count.Load())
+}
+
+func TestRemoteEvalServesStaleOnFailure(t *testing.T) {
+	var fail atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(ctx,
+		WithHttpClient(srv.Client()), WithApiHost(srv.URL), WithClientKey("k"),
+		WithRemoteEval(true), WithAttributes(Attributes{"id": "1"}), WithRemoteEvalTTL(time.Minute),
+	)
+	require.NoError(t, err)
+	base := time.Unix(1000, 0)
+	cur := base
+	client.data.now = func() time.Time { return cur }
+
+	require.Equal(t, "on", client.EvalFeature(ctx, "feat").Value)
+
+	// Endpoint fails and the entry has expired: the stale value is still served.
+	fail.Store(true)
+	cur = base.Add(2 * time.Minute)
+	require.Equal(t, "on", client.EvalFeature(ctx, "feat").Value)
+}
+
+func TestRemoteEvalSingleFlight(t *testing.T) {
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		time.Sleep(20 * time.Millisecond) // hold the request so others overlap
+		_, _ = w.Write([]byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(ctx,
+		WithHttpClient(srv.Client()), WithApiHost(srv.URL), WithClientKey("k"),
+		WithRemoteEval(true), WithAttributes(Attributes{"id": "1"}),
+	)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			client.EvalFeature(ctx, "feat")
+		}()
+	}
+	wg.Wait()
+
+	// Concurrent evaluations for the same key coalesce into one remote request.
+	require.Equal(t, int32(1), count.Load())
 }

--- a/remote_eval_test.go
+++ b/remote_eval_test.go
@@ -1,0 +1,116 @@
+package growthbook
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newRemoteEvalClient(t *testing.T, ts *testServer, opts ...ClientOption) *Client {
+	t.Helper()
+	base := []ClientOption{
+		WithHttpClient(ts.http.Client()),
+		WithApiHost(ts.http.URL),
+		WithClientKey("k"),
+		WithRemoteEval(true),
+	}
+	client, err := NewClient(context.TODO(), append(base, opts...)...)
+	require.NoError(t, err)
+	return client
+}
+
+func TestRemoteEvalConfigValidation(t *testing.T) {
+	ctx := context.TODO()
+
+	_, err := NewClient(ctx, WithRemoteEval(true))
+	require.ErrorIs(t, err, ErrRemoteEvalNoClientKey)
+
+	_, err = NewClient(ctx, WithRemoteEval(true), WithClientKey("k"), WithDecryptionKey("key"))
+	require.ErrorIs(t, err, ErrRemoteEvalDecryptionKey)
+
+	_, err = NewClient(ctx, WithRemoteEval(true), WithClientKey("k"), WithSseDataSource())
+	require.ErrorIs(t, err, ErrRemoteEvalWithDataSource)
+}
+
+func TestRemoteEvalEvaluates(t *testing.T) {
+	ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+	defer ts.http.Close()
+
+	client := newRemoteEvalClient(t, ts, WithAttributes(Attributes{"id": "1"}))
+	require.NoError(t, client.EnsureLoaded(ctx))
+
+	res := client.EvalFeature(ctx, "feat")
+	require.Equal(t, "on", res.Value)
+	require.Equal(t, DefaultValueResultSource, res.Source)
+}
+
+func TestRemoteEvalCachesByAttributes(t *testing.T) {
+	ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+	defer ts.http.Close()
+
+	client := newRemoteEvalClient(t, ts, WithAttributes(Attributes{"id": "1"}))
+
+	// Repeated evaluations for the same attributes hit the cache: one request.
+	client.EvalFeature(ctx, "feat")
+	client.EvalFeature(ctx, "feat")
+	require.Equal(t, int32(1), ts.count.Load())
+
+	// A different attribute set triggers a new remote request.
+	child, err := client.WithAttributes(Attributes{"id": "2"})
+	require.NoError(t, err)
+	child.EvalFeature(ctx, "feat")
+	require.Equal(t, int32(2), ts.count.Load())
+}
+
+func TestRemoteEvalCacheKeyAttributes(t *testing.T) {
+	ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+	defer ts.http.Close()
+
+	client := newRemoteEvalClient(t, ts,
+		WithAttributes(Attributes{"id": "1", "page": "home"}),
+		WithCacheKeyAttributes([]string{"id"}),
+	)
+	client.EvalFeature(ctx, "feat")
+	require.Equal(t, int32(1), ts.count.Load())
+
+	// Changing a non-key attribute must NOT trigger a new request.
+	sameKey, err := client.WithAttributes(Attributes{"id": "1", "page": "pricing"})
+	require.NoError(t, err)
+	sameKey.EvalFeature(ctx, "feat")
+	require.Equal(t, int32(1), ts.count.Load())
+
+	// Changing the key attribute triggers a new request.
+	newKey, err := client.WithAttributes(Attributes{"id": "2", "page": "home"})
+	require.NoError(t, err)
+	newKey.EvalFeature(ctx, "feat")
+	require.Equal(t, int32(2), ts.count.Load())
+}
+
+func TestRemoteEvalFailureFallsBackToUnknown(t *testing.T) {
+	ts := startServer(http.StatusInternalServerError, []byte(""))
+	defer ts.http.Close()
+
+	client := newRemoteEvalClient(t, ts, WithAttributes(Attributes{"id": "1"}))
+
+	// EnsureLoaded surfaces the error.
+	require.Error(t, client.EnsureLoaded(ctx))
+
+	// Evaluation does not panic and reports the feature as unknown.
+	res := client.EvalFeature(ctx, "feat")
+	require.Equal(t, UnknownFeatureResultSource, res.Source)
+	require.False(t, res.On)
+}
+
+func TestRemoteEvalIgnoresNilFeaturesResponse(t *testing.T) {
+	ts := startServer(http.StatusOK, []byte(`{"dateUpdated":"2020-01-01T00:00:00Z"}`))
+	defer ts.http.Close()
+
+	client := newRemoteEvalClient(t, ts, WithAttributes(Attributes{"id": "1"}))
+	require.NoError(t, client.EnsureLoaded(ctx))
+
+	// A malformed (no "features") response is not cached and does not panic.
+	res := client.EvalFeature(ctx, "feat")
+	require.Equal(t, UnknownFeatureResultSource, res.Source)
+}

--- a/remote_eval_test.go
+++ b/remote_eval_test.go
@@ -173,6 +173,38 @@ func TestRemoteEvalServesStaleOnFailure(t *testing.T) {
 	require.Equal(t, "on", client.EvalFeature(ctx, "feat").Value)
 }
 
+func TestRemoteEvalCacheKeyIncludesAllInputs(t *testing.T) {
+	// Same attributes but different forced variations / URL must not reuse a
+	// cached result computed for different inputs.
+	t.Run("forced variations", func(t *testing.T) {
+		ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+		defer ts.http.Close()
+
+		client := newRemoteEvalClient(t, ts, WithAttributes(Attributes{"id": "1"}))
+		client.EvalFeature(ctx, "feat")
+		require.Equal(t, int32(1), ts.count.Load())
+
+		forced, err := client.WithForcedVariations(ForcedVariationsMap{"exp": 1})
+		require.NoError(t, err)
+		forced.EvalFeature(ctx, "feat")
+		require.Equal(t, int32(2), ts.count.Load())
+	})
+
+	t.Run("url", func(t *testing.T) {
+		ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
+		defer ts.http.Close()
+
+		client := newRemoteEvalClient(t, ts, WithAttributes(Attributes{"id": "1"}))
+		client.EvalFeature(ctx, "feat")
+		require.Equal(t, int32(1), ts.count.Load())
+
+		withURL, err := client.WithUrl("https://example.com/pricing")
+		require.NoError(t, err)
+		withURL.EvalFeature(ctx, "feat")
+		require.Equal(t, int32(2), ts.count.Load())
+	})
+}
+
 func TestRemoteEvalCacheEviction(t *testing.T) {
 	ts := startServer(http.StatusOK, []byte(`{"features":{"feat":{"defaultValue":"on"}}}`))
 	defer ts.http.Close()


### PR DESCRIPTION
## Summary
  
  Adds remote evaluation, matching the JS SDK's remote-eval mode. When enabled,
  features are evaluated on the GrowthBook endpoint (`POST {apiHost}/api/eval/{clientKey}`)
  for the client's attributes instead of locally.
  
  ## What's included
  
  - **`WithRemoteEval(bool)`** — opt into remote evaluation. Requires a client
    key; incompatible with a decryption key or a poll/SSE data source (validated
    at construction). 
  - **Attribute-keyed caching** — results are cached per distinct evaluation
    input (attributes, forced variations, URL) and reused within a TTL.
    - `WithRemoteEvalTTL(d)` — reuse window; `0` disables expiry (default 60s).
    - `WithCacheKeyAttributes([]string)` — narrow the cache key to specific
      attributes so a new request fires only when one of them changes.
  - **Bounded cache** — `WithRemoteEvalCacheSize(n)` caps cached results
    (LRU, default 1000) so high-cardinality attributes can't grow it without
    limit.
  - **Single-flight** — concurrent fetches for the same key are coalesced into
    one request, reusing the ref-counted `keyedMutex` introduced in v0.3.0.
    
  ## Notes
  
  - Cache entries are immutable snapshots (the pointer is replaced, never
    mutated in place) so readers that hold an entry after releasing the lock are
    safe.
  - Child clients created via `WithAttributes` re-validate remote-eval
    compatibility.
    
  ## Testing
  
  - `go test -race ./...`, `go vet`, `golangci-lint` — all clean.
  - Added unit tests covering caching, TTL expiry, cache keying, LRU eviction,
    single-flight, and child validation.
