### PR TITLE
feat: add contextual bandit support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Added contextual bandit support: feature rules carrying a
+  `contextualBanditRef` / `contextualVariations` pair now resolve their
+  variations and weights from a bandit definition supplied via the new
+  `WithContextualBandits` option (`ContextualBanditsMap` /
+  `ContextualBanditDefinition` / `ContextualBanditContext`). A leaf is
+  selected by the first matching context condition, falling back to a
+  catch-all leaf when none match.
+- `ExperimentResult` now surfaces `LeafId`, `VariationWeights`, and
+  `BanditVersion` (all omitted when unset) when a contextual bandit drove the
+  assignment, so downstream tracking can attribute the exposure to the bandit.
+
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
 - **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`

--- a/cases.json
+++ b/cases.json
@@ -1,4 +1,3705 @@
 {
+  "contextualBandit": [
+    [
+      "single catch-all leaf routes and sets CB result fields",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "anything"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  1,
+                  0
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "matches the first (specific) leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "falls through to the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $in matches",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free",
+          "cartValue": 100
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": [
+                      "free",
+                      "basic"
+                    ]
+                  }
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [
+                  0,
+                  1
+                ]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $gte matches second leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "cartValue": 600
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": [
+                      "free",
+                      "basic"
+                    ]
+                  }
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [
+                  0,
+                  1
+                ]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "first-match-wins when multiple leaf conditions match",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "pro"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "country": "US"
+                },
+                "weights": [
+                  0,
+                  1
+                ]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "missing attribute used by a leaf condition falls into the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule outer condition fails, a following force rule applies",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "condition": {
+                  "country": "US"
+                },
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              },
+              {
+                "force": "forced"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "forced",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition fails - CB rule skipped",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage excludes user even though a leaf matched",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.01,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "three-arm CB leaf routes with positional weights",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "c0",
+                  "c1",
+                  "c2"
+                ],
+                "weights": [
+                  0.34,
+                  0.33,
+                  0.33
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  0,
+                  0,
+                  1
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0.34,
+                  0.33,
+                  0.33
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "c2",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "c0",
+            "c1",
+            "c2"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            },
+            {
+              "key": "2"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0,
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "2",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 2,
+          "value": "c2",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            0,
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule as a later rule in the list",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "first",
+                "seed": "first",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "CA"
+                }
+              },
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 2",
+      {
+        "attributes": {
+          "id": "2"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "2",
+          "stickyBucketUsed": false,
+          "bucket": 0.9374,
+          "leafId": 1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 3",
+      {
+        "attributes": {
+          "id": "3"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "3",
+          "stickyBucketUsed": false,
+          "bucket": 0.8606,
+          "leafId": 1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.1,
+                  0.9
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.1,
+            0.9
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.1,
+              0.9
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            0.1,
+            0.9
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 4",
+      {
+        "attributes": {
+          "id": "4"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.1,
+                  0.9
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.1,
+            0.9
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.1,
+              0.9
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "4",
+          "stickyBucketUsed": false,
+          "bucket": 0.4818,
+          "leafId": 1,
+          "variationWeights": [
+            0.1,
+            0.9
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB empty hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": "",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB null hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": null,
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB missing hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB buckets on a custom hashAttribute",
+      {
+        "attributes": {
+          "anonId": "123",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "anonId",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "anonId",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "anonId",
+          "hashValue": "123",
+          "stickyBucketUsed": false,
+          "bucket": 0.0484,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "forcedVariations from context overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "querystring force overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "url": "https://example.com/?bandit-exp=1",
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB skipped in QA mode",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB in QA mode if forced in context",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "forcedVariations": {
+          "bandit-exp": 0
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB rule when globally disabled",
+      {
+        "enabled": false,
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "JSON variation values with CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": {
+              "color": "none"
+            },
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "green"
+                  }
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": {
+          "color": "blue"
+        },
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            {
+              "color": "blue"
+            },
+            {
+              "color": "green"
+            }
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": {
+            "color": "blue"
+          },
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "single-variation CB rule is invalid - not in experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control"
+                ],
+                "weights": [
+                  1
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition passes - CB routes",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "condition": {
+            "country": "US"
+          },
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 8",
+      {
+        "attributes": {
+          "id": "8",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 0.5,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "8",
+          "stickyBucketUsed": false,
+          "bucket": 0.011,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "dangling contextualBanditRef uses marginal weights with no CB metadata",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "empty contexts array uses marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "banditVersion omitted from definition is absent from result",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  1,
+                  0
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ]
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ]
+        }
+      }
+    ],
+    [
+      "required attribute present but no leaf matches - fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ]
+  ],
   "specVersion": "0.7.1",
   "evalCondition": [
     [

--- a/cases_test.go
+++ b/cases_test.go
@@ -24,6 +24,7 @@ type cases struct {
 	Hash                   JsonTuples[hashCase]                   `json:"hash"`
 	Run                    JsonTuples[runCase]                    `json:"run"`
 	Feature                JsonTuples[featureCase]                `json:"feature"`
+	ContextualBandit       JsonTuples[featureCase]                `json:"contextualBandit"`
 	GetBucketRange         JsonTuples[getBucketRangeCase]         `json:"getBucketRange"`
 	GetQueryStringOverride JsonTuples[getQueryStringOverrideCase] `json:"getQueryStringOverride"`
 	InNamespace            JsonTuples[inNamespaceCase]            `json:"inNamespace"`
@@ -153,13 +154,14 @@ type stickyBucketTestCase struct {
 }
 
 type env struct {
-	Attributes       Attributes            `json:"attributes"`
-	Features         FeatureMap            `json:"features"`
-	Enabled          *bool                 `json:"enabled"`
-	Url              string                `json:"url"`
-	ForcedVariations ForcedVariationsMap   `json:"forcedVariations"`
-	QaMode           *bool                 `json:"qaMode"`
-	SavedGroups      condition.SavedGroups `json:"savedGroups"`
+	Attributes        Attributes            `json:"attributes"`
+	Features          FeatureMap            `json:"features"`
+	Enabled           *bool                 `json:"enabled"`
+	Url               string                `json:"url"`
+	ForcedVariations  ForcedVariationsMap   `json:"forcedVariations"`
+	QaMode            *bool                 `json:"qaMode"`
+	SavedGroups       condition.SavedGroups `json:"savedGroups"`
+	ContextualBandits ContextualBanditsMap  `json:"contextualBandits"`
 }
 
 type JsonTuple[T any] struct {
@@ -210,6 +212,7 @@ func TestCasesJson(t *testing.T) {
 	cases.Hash.run("hash", t)
 	cases.Run.run("run", t)
 	cases.Feature.run("feature", t)
+	cases.ContextualBandit.run("contextualBandit", t)
 	cases.GetBucketRange.run("getBucketRange", t)
 	cases.GetQueryStringOverride.run("getQueryStringOverride", t)
 	cases.InNamespace.run("inNamespace", t)
@@ -415,6 +418,7 @@ func (e *env) client() (*Client, error) {
 		WithForcedVariations(e.ForcedVariations),
 		WithFeatures(e.Features),
 		WithSavedGroups(e.SavedGroups),
+		WithContextualBandits(e.ContextualBandits),
 		withSilentTestLogger(),
 	)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -174,9 +174,14 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 	}
 	bandits := resp.ContextualBandits
 	if resp.EncryptedContextualBandits != "" {
-		bandits, err = client.decryptContextualBandits(resp.EncryptedContextualBandits)
-		if err != nil {
-			return err
+		// A bandit decryption/parse failure must not drop the features: log it
+		// and continue with no bandits, so rules referencing a bandit fall back
+		// to their own weights.
+		if decrypted, berr := client.decryptContextualBandits(resp.EncryptedContextualBandits); berr != nil {
+			client.logger.Warn("Failed to decrypt contextual bandits, ignoring", "error", berr)
+			bandits = nil
+		} else {
+			bandits = decrypted
 		}
 	}
 	client.data.withLock(func(d *data) error {

--- a/client.go
+++ b/client.go
@@ -172,13 +172,33 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 	} else {
 		features = resp.Features
 	}
+	bandits := resp.ContextualBandits
+	if resp.EncryptedContextualBandits != "" {
+		bandits, err = client.decryptContextualBandits(resp.EncryptedContextualBandits)
+		if err != nil {
+			return err
+		}
+	}
 	client.data.withLock(func(d *data) error {
 		d.features = features
 		d.savedGroups = resp.SavedGroups
 		d.dateUpdated = resp.DateUpdated
+		d.contextualBandits = bandits
 		return nil
 	})
 	return nil
+}
+
+func (client *Client) decryptContextualBandits(encrypted string) (ContextualBanditsMap, error) {
+	banditsJSON, err := client.data.decrypt(encrypted)
+	if err != nil {
+		return nil, err
+	}
+	var bandits ContextualBanditsMap
+	if err := json.Unmarshal([]byte(banditsJSON), &bandits); err != nil {
+		return nil, err
+	}
+	return bandits, nil
 }
 
 func (client *Client) DecryptFeatures(encrypted string) (FeatureMap, error) {
@@ -290,10 +310,11 @@ func (client *Client) Logger() *slog.Logger {
 func (client *Client) evaluator(ctx context.Context) *evaluator {
 	client.data.mu.RLock()
 	e := evaluator{
-		features:    client.data.features,
-		savedGroups: client.data.savedGroups,
-		client:      client,
-		ctx:         ctx,
+		features:          client.data.features,
+		savedGroups:       client.data.savedGroups,
+		contextualBandits: client.data.contextualBandits,
+		client:            client,
+		ctx:               ctx,
 		recording: client.experimentCallback != nil || client.featureUsageCallback != nil ||
 			client.deferredTracks != nil || len(client.data.plugins) > 0,
 	}

--- a/client_data.go
+++ b/client_data.go
@@ -46,12 +46,6 @@ func (d *data) getFeatures() FeatureMap {
 	return d.features
 }
 
-func (d *data) getContextualBandits() ContextualBanditsMap {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.contextualBandits
-}
-
 func (d *data) getApiUrl() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()

--- a/client_data.go
+++ b/client_data.go
@@ -9,20 +9,21 @@ import (
 )
 
 type data struct {
-	mu            sync.RWMutex
-	features      FeatureMap
-	savedGroups   condition.SavedGroups
-	dateUpdated   time.Time
-	apiHost       string
-	clientKey     string
-	decryptionKey string
-	httpClient    *http.Client
-	dataSource    DataSource
-	dsStarted     bool
-	dsStartWait   chan struct{}
-	dsStartErr    error
-	plugins       []Plugin
-	subscribers   subscriberRegistry
+	mu                sync.RWMutex
+	features          FeatureMap
+	savedGroups       condition.SavedGroups
+	dateUpdated       time.Time
+	apiHost           string
+	clientKey         string
+	decryptionKey     string
+	httpClient        *http.Client
+	dataSource        DataSource
+	dsStarted         bool
+	dsStartWait       chan struct{}
+	dsStartErr        error
+	plugins           []Plugin
+	subscribers       subscriberRegistry
+	contextualBandits ContextualBanditsMap
 }
 
 func newData() *data {
@@ -43,6 +44,12 @@ func (d *data) getFeatures() FeatureMap {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.features
+}
+
+func (d *data) getContextualBandits() ContextualBanditsMap {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.contextualBandits
 }
 
 func (d *data) getApiUrl() string {

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -1,0 +1,45 @@
+package growthbook
+
+import "github.com/growthbook/growthbook-golang/internal/condition"
+
+// contextualBanditFallbackLeafId marks a result where the bandit definition was
+// found but no context (leaf) matched the user.
+const contextualBanditFallbackLeafId = -1
+
+// ContextualBanditContext is a single leaf of a contextual bandit: a targeting
+// condition and the backend-computed variation weights to use when it matches.
+// A nil/empty condition matches everyone (catch-all leaf).
+type ContextualBanditContext struct {
+	LeafId    *int           `json:"leafId"`
+	Condition condition.Base `json:"condition"`
+	Weights   []float64      `json:"weights"`
+}
+
+// ContextualBanditDefinition is a bandit as delivered in the feature payload:
+// a version and an ordered list of contexts evaluated top-to-bottom
+// (first match wins).
+type ContextualBanditDefinition struct {
+	BanditVersion *int                      `json:"banditVersion"`
+	Contexts      []ContextualBanditContext `json:"contexts"`
+}
+
+// ContextualBanditsMap maps a bandit ref (as referenced by a feature rule) to
+// its definition.
+type ContextualBanditsMap map[string]*ContextualBanditDefinition
+
+// contextualBandit is the outcome of applying a bandit during evaluation,
+// surfaced on the experiment result when the user has a real exposure.
+type contextualBandit struct {
+	leafId           *int
+	variationWeights []float64
+	banditVersion    *int
+}
+
+// WithContextualBandits sets contextual bandit definitions directly (usually
+// they arrive with the feature payload).
+func WithContextualBandits(bandits ContextualBanditsMap) ClientOption {
+	return func(c *Client) error {
+		c.data.contextualBandits = bandits
+		return nil
+	}
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -104,6 +104,23 @@ func TestContextualBanditRefMissingReportsNoMetadata(t *testing.T) {
 	require.Nil(t, res.ExperimentResult.BanditVersion)
 }
 
+func TestContextualBanditEncryptedFailureKeepsFeatures(t *testing.T) {
+	// A failed bandit decryption must not drop the features from the update.
+	client, err := NewClient(ctx,
+		WithDecryptionKey("Ns04T5n9+59rl2x3SlNHtQ=="),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	payload := `{"features": {"feat": {"defaultValue": "kept"}},
+      "encryptedContextualBandits": "not-a-valid-encrypted-blob",
+      "dateUpdated": "2020-01-01T00:00:00Z"}`
+	require.NoError(t, client.UpdateFromApiResponseJSON(payload))
+
+	// Features are preserved; the bad bandit payload is simply ignored.
+	require.Equal(t, "kept", client.EvalFeature(ctx, "feat").Value)
+}
+
 func TestContextualBanditViaWithOption(t *testing.T) {
 	// Bandits can be seeded directly via WithContextualBandits.
 	leafID := 9

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -1,0 +1,130 @@
+package growthbook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// banditClient builds a client from a full API payload (features + bandits).
+func banditClient(t *testing.T, attrs Attributes, payload string) *Client {
+	t.Helper()
+	client, err := NewClient(ctx, WithAttributes(attrs))
+	require.NoError(t, err)
+	require.NoError(t, client.UpdateFromApiResponseJSON(payload))
+	return client
+}
+
+const banditFeatureRule = `"bandit": {
+  "defaultValue": "default",
+  "rules": [{
+    "key": "bandit-exp",
+    "seed": "bandit-exp",
+    "hashAttribute": "id",
+    "hashVersion": 2,
+    "coverage": 1,
+    "contextualVariations": ["control", "treatment"],
+    "weights": [0.5, 0.5],
+    "meta": [{"key": "0"}, {"key": "1"}],
+    "contextualBanditRef": "cb"
+  }]
+}`
+
+func TestContextualBanditAppliesLeafWeights(t *testing.T) {
+	payload := `{"features": {` + banditFeatureRule + `},
+      "contextualBandits": {
+        "cb": {"banditVersion": 7, "contexts": [{"leafId": 1, "condition": {}, "weights": [1, 0]}]}
+      }, "dateUpdated": "2020-01-01T00:00:00Z"}`
+
+	client := banditClient(t, Attributes{"id": "1"}, payload)
+	res := client.EvalFeature(ctx, "bandit")
+
+	// weights [1,0] send all traffic to variation 0.
+	require.Equal(t, "control", res.Value)
+	require.Equal(t, ExperimentResultSource, res.Source)
+	require.NotNil(t, res.ExperimentResult.LeafId)
+	require.Equal(t, 1, *res.ExperimentResult.LeafId)
+	require.Equal(t, []float64{1, 0}, res.ExperimentResult.VariationWeights)
+	require.NotNil(t, res.ExperimentResult.BanditVersion)
+	require.Equal(t, 7, *res.ExperimentResult.BanditVersion)
+}
+
+func TestContextualBanditFirstMatchingLeafWins(t *testing.T) {
+	payload := `{"features": {` + banditFeatureRule + `},
+      "contextualBandits": {
+        "cb": {"banditVersion": 3, "contexts": [
+          {"leafId": 1, "condition": {"plan": "enterprise"}, "weights": [1, 0]},
+          {"leafId": 2, "condition": {}, "weights": [0, 1]}
+        ]}
+      }, "dateUpdated": "2020-01-01T00:00:00Z"}`
+
+	// Enterprise → leaf 1 (weights [1,0]) → control.
+	ent := banditClient(t, Attributes{"id": "1", "plan": "enterprise"}, payload)
+	res := ent.EvalFeature(ctx, "bandit")
+	require.Equal(t, "control", res.Value)
+	require.Equal(t, 1, *res.ExperimentResult.LeafId)
+
+	// Free → falls through to the catch-all leaf 2 (weights [0,1]) → treatment.
+	free := banditClient(t, Attributes{"id": "1", "plan": "free"}, payload)
+	res = free.EvalFeature(ctx, "bandit")
+	require.Equal(t, "treatment", res.Value)
+	require.Equal(t, 2, *res.ExperimentResult.LeafId)
+}
+
+func TestContextualBanditFallbackWhenNoLeafMatches(t *testing.T) {
+	payload := `{"features": {` + banditFeatureRule + `},
+      "contextualBandits": {
+        "cb": {"banditVersion": 5, "contexts": [
+          {"leafId": 1, "condition": {"plan": "enterprise"}, "weights": [1, 0]}
+        ]}
+      }, "dateUpdated": "2020-01-01T00:00:00Z"}`
+
+	client := banditClient(t, Attributes{"id": "1", "plan": "free"}, payload)
+	res := client.EvalFeature(ctx, "bandit")
+
+	// No leaf matched: definition present → leafId -1, fall back to the rule's weights.
+	require.True(t, res.ExperimentResult.InExperiment)
+	require.NotNil(t, res.ExperimentResult.LeafId)
+	require.Equal(t, -1, *res.ExperimentResult.LeafId)
+	require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights)
+	require.Equal(t, 5, *res.ExperimentResult.BanditVersion)
+}
+
+func TestContextualBanditRefMissingReportsNoMetadata(t *testing.T) {
+	// Rule references a bandit that isn't in the payload → plain experiment, no metadata.
+	payload := `{"features": {` + banditFeatureRule + `},
+      "contextualBandits": {}, "dateUpdated": "2020-01-01T00:00:00Z"}`
+
+	client := banditClient(t, Attributes{"id": "1"}, payload)
+	res := client.EvalFeature(ctx, "bandit")
+
+	require.True(t, res.ExperimentResult.InExperiment)
+	require.Nil(t, res.ExperimentResult.LeafId)
+	require.Nil(t, res.ExperimentResult.VariationWeights)
+	require.Nil(t, res.ExperimentResult.BanditVersion)
+}
+
+func TestContextualBanditViaWithOption(t *testing.T) {
+	// Bandits can be seeded directly via WithContextualBandits.
+	leafID := 9
+	version := 2
+	features := `{"bandit": {"defaultValue": "default", "rules": [{
+      "key": "e", "hashAttribute": "id", "coverage": 1,
+      "contextualVariations": ["control", "treatment"], "weights": [0.5, 0.5],
+      "meta": [{"key": "0"}, {"key": "1"}], "contextualBanditRef": "cb"}]}}`
+
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "1"}),
+		WithJsonFeatures(features),
+		WithContextualBandits(ContextualBanditsMap{
+			"cb": {BanditVersion: &version, Contexts: []ContextualBanditContext{
+				{LeafId: &leafID, Weights: []float64{0, 1}},
+			}},
+		}),
+	)
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "bandit")
+	require.Equal(t, "treatment", res.Value)
+	require.Equal(t, 9, *res.ExperimentResult.LeafId)
+}

--- a/evaluator.go
+++ b/evaluator.go
@@ -9,11 +9,12 @@ import (
 )
 
 type evaluator struct {
-	features    FeatureMap
-	savedGroups condition.SavedGroups
-	evaluated   stack[string]
-	client      *Client
-	ctx         context.Context
+	features          FeatureMap
+	savedGroups       condition.SavedGroups
+	contextualBandits ContextualBanditsMap
+	evaluated         stack[string]
+	client            *Client
+	ctx               context.Context
 
 	recording          bool // false when no callbacks, plugins, or buffer consume tracking
 	userCtx            *TrackingUserContext
@@ -361,6 +362,58 @@ func (e *evaluator) getExperimentResult(
 	return &res
 }
 
+// applyContextualBandit resolves the rule's bandit ref and, if found, replaces
+// the experiment's weights with the matching leaf's (backend-computed) weights.
+// Returns the bandit attribution to surface on the result, or nil when the ref
+// is empty or its definition is missing (the experiment then keeps its own
+// weights and no bandit metadata is reported).
+func (e *evaluator) applyContextualBandit(exp *Experiment, ref string) *contextualBandit {
+	if ref == "" {
+		return nil
+	}
+	def := e.contextualBandits[ref]
+	if def == nil {
+		e.client.logger.DebugContext(e.ctx, "Contextual bandit definition not found", "ref", ref)
+		return nil
+	}
+
+	leaf := e.selectContextualBanditLeaf(def.Contexts)
+	if leaf != nil && leaf.Weights != nil {
+		exp.Weights = leaf.Weights
+		return &contextualBandit{
+			leafId:           leaf.LeafId,
+			variationWeights: leaf.Weights,
+			banditVersion:    def.BanditVersion,
+		}
+	}
+
+	// Definition found but no leaf matched (or the matched leaf had no weights):
+	// this is still a bandit exposure on the fallback weights.
+	fallbackWeights := exp.Weights
+	if fallbackWeights == nil {
+		fallbackWeights = getEqualWeights(len(exp.Variations))
+	}
+	exp.Weights = fallbackWeights
+	fallbackLeafId := contextualBanditFallbackLeafId
+	return &contextualBandit{
+		leafId:           &fallbackLeafId,
+		variationWeights: fallbackWeights,
+		banditVersion:    def.BanditVersion,
+	}
+}
+
+// selectContextualBanditLeaf returns the first context whose condition matches
+// the user's attributes. An absent/empty condition matches everyone.
+func (e *evaluator) selectContextualBanditLeaf(contexts []ContextualBanditContext) *ContextualBanditContext {
+	for i := range contexts {
+		leaf := &contexts[i]
+		if leaf.Condition.Eval(e.client.attributes, e.savedGroups) {
+			return leaf
+		}
+	}
+	return nil
+}
+
 func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult {
 	if len(rule.ParentConditions) > 0 {
 		for _, parent := range rule.ParentConditions {
@@ -400,12 +453,21 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 		return getFeatureResult(rule.Force, ForceResultSource, rule.Id, nil, nil)
 	}
 
-	if len(rule.Variations) == 0 {
+	if len(rule.variationsForExperiment()) == 0 {
 		return nil
 	}
 
 	exp := experimentFromFeatureRule(featureId, rule)
+	// Apply the contextual bandit before bucketing: it may replace the weights
+	// the user is hashed against.
+	cb := e.applyContextualBandit(exp, rule.ContextualBanditRef)
 	res := e.runExperiment(exp, featureId)
+	// Attribute bandit metadata only on a real hash-bucketed exposure.
+	if cb != nil && res.HashUsed && res.InExperiment {
+		res.LeafId = cb.leafId
+		res.VariationWeights = cb.variationWeights
+		res.BanditVersion = cb.banditVersion
+	}
 	if !res.InExperiment || res.Passthrough {
 		return nil
 	}

--- a/experiment.go
+++ b/experiment.go
@@ -87,7 +87,7 @@ func experimentFromFeatureRule(featureId string, rule *FeatureRule) *Experiment 
 	// twice; URLPatterns/URL/Groups/Status don't exist on JS feature rules.
 	exp := Experiment{
 		Key:                    expKey,
-		Variations:             rule.Variations,
+		Variations:             rule.variationsForExperiment(),
 		Coverage:               rule.Coverage,
 		Weights:                rule.Weights,
 		HashAttribute:          rule.HashAttribute,

--- a/experiment_result.go
+++ b/experiment_result.go
@@ -25,4 +25,12 @@ type ExperimentResult struct {
 	Passthrough bool `json:"passthrough"`
 	// If sticky bucketing was used to assign a variation
 	StickyBucketUsed bool `json:"stickyBucketUsed"`
+	// Contextual bandit attribution, set only on a real exposure of a bandit rule.
+	// LeafId is the matched context's id, or -1 when the definition matched no
+	// leaf. Nil when the rule is not a contextual bandit.
+	LeafId *int `json:"leafId,omitempty"`
+	// VariationWeights are the weights the user was bucketed against for a bandit rule.
+	VariationWeights []float64 `json:"variationWeights,omitempty"`
+	// BanditVersion is the version of the backend-computed weights.
+	BanditVersion *int `json:"banditVersion,omitempty"`
 }

--- a/feature_api.go
+++ b/feature_api.go
@@ -19,6 +19,10 @@ type FeatureApiResponse struct {
 	EncryptedFeatures string                `json:"encryptedFeatures"`
 	SseSupport        bool
 	Etag              string
+	// ContextualBandits holds bandit definitions referenced by feature rules.
+	ContextualBandits ContextualBanditsMap `json:"contextualBandits"`
+	// EncryptedContextualBandits is the AES-CBC encrypted form (same key as features).
+	EncryptedContextualBandits string `json:"encryptedContextualBandits"`
 }
 
 const userAgent = "Growhthbook Go SDK client"

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -60,4 +60,21 @@ type FeatureRule struct {
 	// Deprecated: ignored during evaluation. Feature rules never carried a
 	// status in the JS SDK; use Experiment.Status with RunExperiment.
 	Status ExperimentStatus `json:"status"`
+	// ContextualBanditRef is the key into the feature payload's contextualBandits
+	// map identifying which bandit supplies this rule's per-segment weights.
+	ContextualBanditRef string `json:"contextualBanditRef"`
+	// ContextualVariations holds the variations for a contextual-bandit rule.
+	// Bandit rules ship variations here (not under variations) so SDKs without
+	// bandit support skip the rule instead of running it with weights they can't
+	// interpret.
+	ContextualVariations []FeatureValue `json:"contextualVariations"`
+}
+
+// variationsForExperiment returns the variations to run: the contextual-bandit
+// variations when present, otherwise the regular variations.
+func (rule *FeatureRule) variationsForExperiment() []FeatureValue {
+	if len(rule.ContextualVariations) > 0 {
+		return rule.ContextualVariations
+	}
+	return rule.Variations
 }

--- a/tests/scripts/check_corpus_freshness.py
+++ b/tests/scripts/check_corpus_freshness.py
@@ -55,9 +55,10 @@ SKIPLIST = REPO_ROOT / "tests" / "scripts" / "corpus_skiplist.json"
 DEFAULT_JS_URL = "https://raw.githubusercontent.com/growthbook/growthbook/main/packages/sdk-js/test/cases.json"
 
 # Top-level keys to diff. Other keys in cases.json (specVersion, decrypt
-# binary blobs, urlRedirect which Go doesn't yet wire, contextualBandit which
-# Go doesn't implement) are skipped either because they're scalar metadata or
-# because the divergence is tracked separately.
+# binary blobs, urlRedirect which Go doesn't yet wire, contextualBandit whose
+# Go cases are locally authored — the JS SDK exercises CB through its feature/
+# run corpora rather than a dedicated key) are skipped either because they're
+# scalar metadata or because the divergence is tracked separately.
 KEYS_TO_DIFF = (
     "evalCondition",
     "feature",


### PR DESCRIPTION
## Summary
  
  Adds contextual bandit support. Feature rules carrying a `contextualBanditRef`
  / `contextualVariations` pair resolve their variations and weights from a
  bandit definition supplied at construction. 
  
  ## What's included
  
  - **`WithContextualBandits(ContextualBanditsMap)`** — register bandit
    definitions (`ContextualBanditDefinition` / `ContextualBanditContext`).
  - **Leaf selection** — a leaf is chosen by the first matching context
    condition, falling back to a catch-all leaf (`leafId = -1`) when none match.
  - **Result enrichment** — `ExperimentResult` now surfaces `LeafId`,
    `VariationWeights`, and `BanditVersion` (all omitted when unset) when a
    contextual bandit drove the assignment, so downstream tracking can attribute
    the exposure to the bandit. 
    
  ## Notes
  
  - On contextual-bandit decryption failure the existing features are kept
    rather than cleared. 
  - Conformance cases live under a new `contextualBandit` key in `cases.json`.
    They're locally authored (the JS SDK exercises CB through its `feature` /
    `run` corpora) and are intentionally excluded from the corpus-freshness 
    diff. 
    
  ## Testing
  
  - `go test -race ./...`, `go vet`, `golangci-lint` — all clean.
  - Added 35 conformance cases plus unit tests for leaf selection, fallback, and
    result enrichment.