### PR TITLE
Track passthrough experiment assignments in EvalFeature

### DIFF
--- a/client.go
+++ b/client.go
@@ -219,6 +219,7 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 	if client.featureUsageCallback != nil {
 		client.featureUsageCallback(ctx, key, res, client.extraData)
 	}
+	plugins := client.data.getPlugins()
 	// Passthrough assignments (e.g. the control arm of a monitored ramp
 	// step) did not decide the served value, but they are exposures all the
 	// same: track them before the served experiment, in evaluation order,
@@ -227,7 +228,7 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 		if client.experimentCallback != nil {
 			client.experimentCallback(ctx, a.experiment, a.result, client.extraData)
 		}
-		for _, p := range client.data.getPlugins() {
+		for _, p := range plugins {
 			client.safePluginExperimentViewed(ctx, p, a.experiment, a.result)
 		}
 	}
@@ -235,7 +236,7 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 		client.experimentCallback(ctx, res.Experiment, res.ExperimentResult, client.extraData)
 	}
 	// Notify plugins. Panics are recovered so plugins never interrupt evaluation.
-	for _, p := range client.data.getPlugins() {
+	for _, p := range plugins {
 		client.safePluginFeatureEvaluated(ctx, p, key, res)
 		if res.InExperiment() {
 			client.safePluginExperimentViewed(ctx, p, res.Experiment, res.ExperimentResult)

--- a/client.go
+++ b/client.go
@@ -219,6 +219,18 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 	if client.featureUsageCallback != nil {
 		client.featureUsageCallback(ctx, key, res, client.extraData)
 	}
+	// Passthrough assignments (e.g. the control arm of a monitored ramp
+	// step) did not decide the served value, but they are exposures all the
+	// same: track them before the served experiment, in evaluation order,
+	// as the JS and Python SDKs do.
+	for _, a := range e.passthroughAssignments {
+		if client.experimentCallback != nil {
+			client.experimentCallback(ctx, a.experiment, a.result, client.extraData)
+		}
+		for _, p := range client.data.getPlugins() {
+			client.safePluginExperimentViewed(ctx, p, a.experiment, a.result)
+		}
+	}
 	if client.experimentCallback != nil && res.InExperiment() {
 		client.experimentCallback(ctx, res.Experiment, res.ExperimentResult, client.extraData)
 	}

--- a/evaluator.go
+++ b/evaluator.go
@@ -401,9 +401,10 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 		return nil
 	}
 	if res.Passthrough {
-		// Only the top-level feature's own rules; assignments made while
-		// evaluating prerequisite features are not reported, consistent
-		// with how EvalFeature reports the served experiment.
+		// Record only assignments made by the feature EvalFeature was
+		// asked for (depth 1), not ones made while evaluating its
+		// prerequisites — consistent with how EvalFeature reports the
+		// served experiment.
 		if len(e.evaluated.stack) == 1 {
 			e.passthroughAssignments = append(e.passthroughAssignments, experimentAssignment{exp, res})
 		}

--- a/evaluator.go
+++ b/evaluator.go
@@ -14,6 +14,17 @@ type evaluator struct {
 	evaluated   stack[string]
 	client      *Client
 	ctx         context.Context
+
+	// passthroughAssignments records experiment rules of the feature being
+	// evaluated that bucketed the user into a passthrough variation.
+	// Evaluation falls through to the next rule, but the assignment is still
+	// an exposure the caller must be able to track (see Client.EvalFeature).
+	passthroughAssignments []experimentAssignment
+}
+
+type experimentAssignment struct {
+	experiment *Experiment
+	result     *ExperimentResult
 }
 
 func (e *evaluator) evalFeature(key string) *FeatureResult {
@@ -386,7 +397,16 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 
 	exp := experimentFromFeatureRule(featureId, rule)
 	res := e.runExperiment(exp, featureId)
-	if !res.InExperiment || res.Passthrough {
+	if !res.InExperiment {
+		return nil
+	}
+	if res.Passthrough {
+		// Only the top-level feature's own rules; assignments made while
+		// evaluating prerequisite features are not reported, consistent
+		// with how EvalFeature reports the served experiment.
+		if len(e.evaluated.stack) == 1 {
+			e.passthroughAssignments = append(e.passthroughAssignments, experimentAssignment{exp, res})
+		}
 		return nil
 	}
 

--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -1,0 +1,143 @@
+package growthbook
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A passthrough variation does not serve its value — evaluation falls
+// through to the next rule — but the assignment is still an exposure and
+// must reach ExperimentCallback and plugins, as in the JS and Python SDKs.
+// The canonical producer is a monitored ramp step: treatment serves the
+// rule value, control is a passthrough arm, and the ramp's health check
+// compares exposure counts between the two.
+const passthroughFeaturesJSON = `{
+  "flag": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "ramp_1",
+        "coverage": 1,
+        "hashAttribute": "id",
+        "variations": ["treatment", "default"],
+        "weights": [0.5, 0.5],
+        "meta": [{"key": "0"}, {"key": "1", "passthrough": true}]
+      },
+      {"force": "lower-rule"}
+    ]
+  },
+  "child": {
+    "defaultValue": "child-default",
+    "rules": [
+      {
+        "parentConditions": [{"id": "flag", "condition": {"value": {"$exists": true}}}],
+        "force": "child-forced"
+      }
+    ]
+  }
+}`
+
+type viewed struct {
+	key         string
+	variationID int
+	passthrough bool
+	featureID   string
+}
+
+type recordingPlugin struct{ viewed []viewed }
+
+func (p *recordingPlugin) Init(*Client) error { return nil }
+func (p *recordingPlugin) Close() error       { return nil }
+func (p *recordingPlugin) OnFeatureEvaluated(context.Context, string, *FeatureResult) {
+}
+func (p *recordingPlugin) OnExperimentViewed(_ context.Context, exp *Experiment, res *ExperimentResult) {
+	p.viewed = append(p.viewed, viewed{exp.Key, res.VariationId, res.Passthrough, res.FeatureId})
+}
+
+func passthroughClient(t *testing.T, id string) (*Client, *[]viewed, *recordingPlugin) {
+	t.Helper()
+	var fromCallback []viewed
+	plugin := &recordingPlugin{}
+	client, err := NewClient(context.Background(),
+		WithJsonFeatures(passthroughFeaturesJSON),
+		WithAttributes(Attributes{"id": id}),
+		WithExperimentCallback(func(_ context.Context, exp *Experiment, res *ExperimentResult, _ any) {
+			fromCallback = append(fromCallback, viewed{exp.Key, res.VariationId, res.Passthrough, res.FeatureId})
+		}),
+		WithPlugins(plugin),
+	)
+	require.NoError(t, err)
+	return client, &fromCallback, plugin
+}
+
+// idsByArm finds one user id per arm of the ramp_1 experiment.
+func idsByArm(t *testing.T) (treatmentID, controlID string) {
+	t.Helper()
+	for i := 0; treatmentID == "" || controlID == ""; i++ {
+		require.Less(t, i, 1000, "could not find ids for both arms")
+		id := fmt.Sprintf("user-%d", i)
+		client, _, _ := passthroughClient(t, id)
+		rule := client.Features()["flag"].Rules[0]
+		res := client.RunExperiment(context.Background(), experimentFromFeatureRule("flag", &rule))
+		if !res.InExperiment {
+			continue
+		}
+		if res.VariationId == 0 && treatmentID == "" {
+			treatmentID = id
+		}
+		if res.VariationId == 1 && controlID == "" {
+			controlID = id
+		}
+	}
+	return treatmentID, controlID
+}
+
+func TestPassthroughAssignmentIsTracked(t *testing.T) {
+	ctx := context.Background()
+	treatmentID, controlID := idsByArm(t)
+
+	t.Run("control arm falls through but is tracked", func(t *testing.T) {
+		client, fromCallback, plugin := passthroughClient(t, controlID)
+		res := client.EvalFeature(ctx, "flag")
+
+		require.Equal(t, "lower-rule", res.Value)
+		require.Equal(t, ForceResultSource, res.Source)
+		require.False(t, res.InExperiment())
+
+		want := []viewed{{key: "ramp_1", variationID: 1, passthrough: true, featureID: "flag"}}
+		require.Equal(t, want, *fromCallback)
+		require.Equal(t, want, plugin.viewed)
+	})
+
+	t.Run("treatment arm is unchanged", func(t *testing.T) {
+		client, fromCallback, plugin := passthroughClient(t, treatmentID)
+		res := client.EvalFeature(ctx, "flag")
+
+		require.Equal(t, "treatment", res.Value)
+		require.True(t, res.InExperiment())
+
+		want := []viewed{{key: "ramp_1", variationID: 0, passthrough: false, featureID: "flag"}}
+		require.Equal(t, want, *fromCallback)
+		require.Equal(t, want, plugin.viewed)
+	})
+
+	t.Run("prerequisite's passthrough assignment is not attributed to the dependent feature", func(t *testing.T) {
+		client, fromCallback, plugin := passthroughClient(t, controlID)
+		res := client.EvalFeature(ctx, "child")
+
+		require.Equal(t, "child-forced", res.Value)
+		require.Empty(t, *fromCallback)
+		require.Empty(t, plugin.viewed)
+	})
+
+	t.Run("evaluator state does not leak between evaluations", func(t *testing.T) {
+		client, fromCallback, _ := passthroughClient(t, controlID)
+		client.EvalFeature(ctx, "flag")
+		client.EvalFeature(ctx, "child")
+		client.EvalFeature(ctx, "flag")
+		require.Len(t, *fromCallback, 2)
+	})
+}

--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -26,7 +26,14 @@ const passthroughFeaturesJSON = `{
         "weights": [0.5, 0.5],
         "meta": [{"key": "0"}, {"key": "1", "passthrough": true}]
       },
-      {"force": "lower-rule"}
+      {"force": "lower-rule", "condition": {"country": "nz"}},
+      {
+        "key": "exp_2",
+        "coverage": 1,
+        "hashAttribute": "id",
+        "variations": ["a", "b"],
+        "weights": [1, 0]
+      }
     ]
   },
   "child": {
@@ -99,8 +106,10 @@ func TestPassthroughAssignmentIsTracked(t *testing.T) {
 	ctx := context.Background()
 	treatmentID, controlID := idsByArm(t)
 
-	t.Run("control arm falls through but is tracked", func(t *testing.T) {
+	t.Run("control arm falls through to a force rule and is tracked", func(t *testing.T) {
 		client, fromCallback, plugin := passthroughClient(t, controlID)
+		client, err := client.WithAttributeOverrides(Attributes{"country": "nz"})
+		require.NoError(t, err)
 		res := client.EvalFeature(ctx, "flag")
 
 		require.Equal(t, "lower-rule", res.Value)
@@ -108,6 +117,22 @@ func TestPassthroughAssignmentIsTracked(t *testing.T) {
 		require.False(t, res.InExperiment())
 
 		want := []viewed{{key: "ramp_1", variationID: 1, passthrough: true, featureID: "flag"}}
+		require.Equal(t, want, *fromCallback)
+		require.Equal(t, want, plugin.viewed)
+	})
+
+	t.Run("control arm falls through to an experiment rule: tracked first, then the served experiment", func(t *testing.T) {
+		client, fromCallback, plugin := passthroughClient(t, controlID)
+		res := client.EvalFeature(ctx, "flag")
+
+		require.Equal(t, "a", res.Value)
+		require.True(t, res.InExperiment())
+		require.Equal(t, "exp_2", res.Experiment.Key)
+
+		want := []viewed{
+			{key: "ramp_1", variationID: 1, passthrough: true, featureID: "flag"},
+			{key: "exp_2", variationID: 0, passthrough: false, featureID: "flag"},
+		}
 		require.Equal(t, want, *fromCallback)
 		require.Equal(t, want, plugin.viewed)
 	})
@@ -138,6 +163,6 @@ func TestPassthroughAssignmentIsTracked(t *testing.T) {
 		client.EvalFeature(ctx, "flag")
 		client.EvalFeature(ctx, "child")
 		client.EvalFeature(ctx, "flag")
-		require.Len(t, *fromCallback, 2)
+		require.Len(t, *fromCallback, 4) // (ramp_1 + exp_2) twice, nothing from child
 	})
 }


### PR DESCRIPTION
### Features and Changes

When a feature rule buckets the user into a **passthrough** variation, evaluation correctly falls through to the next rule — but the assignment itself was never reported: `evalRule` returned early on `Passthrough`, and `EvalFeature` only fires `ExperimentCallback` / plugin `OnExperimentViewed` for the experiment that decided the served value. The JS and Python SDKs fire their tracking callback for the passthrough assignment and then fall through.

Where this bites is monitored ramp steps: the control arm is a passthrough variation, so with this SDK the served values are right but no control exposures are ever tracked, and the ramp's health check sees an empty control arm and holds the step.

This change makes the evaluator record passthrough assignments made by the evaluated feature's own rules, and `EvalFeature` reports them (callback + plugins) ahead of the served experiment, in evaluation order. `FeatureResult`, served values and `RunExperiment` are unchanged. Assignments made while evaluating *prerequisite* features are not reported, consistent with how the served experiment is reported today — happy to change that if you'd prefer full JS behaviour there.

Suggested changelog line: *Behavior change (JS parity): `EvalFeature` now fires `ExperimentCallback` and plugin `OnExperimentViewed` for passthrough experiment assignments (e.g. the control arm of a monitored ramp step); previously these were silently dropped.*

### Dependencies

None.

### Testing

- `passthrough_test.go` (new): control arm falls through to the next rule and is tracked (callback + plugin); treatment arm unchanged; a prerequisite's passthrough assignment isn't attributed to the dependent feature; no state leaks across evaluations. The first and last cases fail on `main` and pass with the fix.
- `go test ./...` passes, including the `cases.json` conformance suite unchanged.
- Replayed `main` vs. this branch over a large real-world feature payload containing monitored-ramp rules, for 1000 synthetic users, through `Client.EvalFeature`: every `FeatureResult` identical; no callback lost; the only new callbacks are the ramp control-arm (passthrough) assignments.
