### PR TITLE
Track passthrough and prerequisite exposures; deferred tracking; user context on ExperimentCallback (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- **Behavior change (JS parity):** `EvalFeature` now fires `ExperimentCallback`
+  and plugin `OnExperimentViewed` for every experiment assignment made during
+  evaluation, in evaluation order — including passthrough assignments (e.g.
+  the control arm of a monitored ramp step) and assignments made while
+  evaluating prerequisite features. Previously only the experiment that
+  decided the served value was reported, so those exposures were silently
+  dropped.
+- **Behavior change (JS parity):** `FeatureUsageCallback` and plugin
+  `OnFeatureEvaluated` now also fire for prerequisite features evaluated
+  along the way, not just the requested feature. A feature is reported once
+  per evaluation unless its value changed.
+- **Behavior change (JS parity):** `RunExperiment` no longer fires tracking
+  callbacks for forced variations (`force`, forced variations set on the
+  client, querystring overrides) — these are not randomized exposures and the
+  JS SDK has never tracked them.
+- Added `EvalFeatureWithTracking` and `RunExperimentWithTracking`, which also
+  return an `EvalTracking`: every feature evaluated and every experiment
+  assignment made by that call, complete when the call returns. Intended for
+  servers that forward exposures to client SDKs (e.g. remote evaluation)
+  instead of tracking via callbacks. `TrackingData` serializes to the JS
+  SDK's `TrackingData` shape (compatible with `setDeferredTrackingCalls`),
+  and `TrackingData.DedupeKey` matches the JS SDK's dedupe key so callers
+  batching several evaluations for one user can deduplicate across calls.
+  Within a call, assignments are deduplicated automatically; there is
+  deliberately no cross-call deduplication (analysis dedupes exposures at
+  the query level).
+
 ## [v0.3.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.3.0) - 2026-08-26
 
 - **Behavior change (JS parity):** attribute values that are falsy in JS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,18 @@ All notable changes to this project will be documented in this file.
   callbacks for forced variations (`force`, forced variations set on the
   client, querystring overrides) — these are not randomized exposures and the
   JS SDK has never tracked them.
-- Added `EvalFeatureWithTracking` and `RunExperimentWithTracking`, which also
-  return the experiment exposures the call produced as `[]TrackingData`,
-  complete when the call returns. Intended for servers that forward exposures
-  to client SDKs (e.g. remote evaluation) instead of tracking via callbacks.
-  `TrackingData` serializes to the JS SDK's `TrackingData` shape (compatible
-  with `setDeferredTrackingCalls`), and `TrackingData.DedupeKey` matches the
-  JS SDK's dedupe key so callers batching several evaluations for one user
-  can deduplicate across calls. Within a call, exposures are deduplicated
-  automatically; there is deliberately no cross-call deduplication (analysis
-  dedupes exposures at the query level).
+- Added deferred tracking, the Go equivalent of the JS SDK's deferred
+  tracking queue, for servers that forward exposures to client SDKs (e.g.
+  remote evaluation) instead of tracking via callbacks. Enable it with the
+  `WithDeferredTracking` option — typically on a per-request child client,
+  which acts as the user context — and every experiment exposure produced by
+  the standard evaluation methods is buffered: read it with
+  `Client.DeferredTrackingCalls` and empty it with
+  `Client.ClearDeferredTrackingCalls`. The buffer deduplicates by
+  `TrackingData.DedupeKey` (the JS SDK's dedupe key) over its lifetime and
+  keeps first-seen order; `TrackingData` serializes to the JS SDK's
+  `TrackingData` shape, compatible with `setDeferredTrackingCalls`.
+  Callbacks and plugins are unaffected and keep firing per evaluation.
 
 ## [v0.3.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.3.0) - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,15 @@ All notable changes to this project will be documented in this file.
   client, querystring overrides) — these are not randomized exposures and the
   JS SDK has never tracked them.
 - Added `EvalFeatureWithTracking` and `RunExperimentWithTracking`, which also
-  return an `EvalTracking`: every feature evaluated and every experiment
-  assignment made by that call, complete when the call returns. Intended for
-  servers that forward exposures to client SDKs (e.g. remote evaluation)
-  instead of tracking via callbacks. `TrackingData` serializes to the JS
-  SDK's `TrackingData` shape (compatible with `setDeferredTrackingCalls`),
-  and `TrackingData.DedupeKey` matches the JS SDK's dedupe key so callers
-  batching several evaluations for one user can deduplicate across calls.
-  Within a call, assignments are deduplicated automatically; there is
-  deliberately no cross-call deduplication (analysis dedupes exposures at
-  the query level).
+  return the experiment exposures the call produced as `[]TrackingData`,
+  complete when the call returns. Intended for servers that forward exposures
+  to client SDKs (e.g. remote evaluation) instead of tracking via callbacks.
+  `TrackingData` serializes to the JS SDK's `TrackingData` shape (compatible
+  with `setDeferredTrackingCalls`), and `TrackingData.DedupeKey` matches the
+  JS SDK's dedupe key so callers batching several evaluations for one user
+  can deduplicate across calls. Within a call, exposures are deduplicated
+  automatically; there is deliberately no cross-call deduplication (analysis
+  dedupes exposures at the query level).
 
 ## [v0.3.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.3.0) - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
+- **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`
+  parameter — the evaluating client's attributes and URL, the JS SDK
+  `trackingCallback`'s user argument — before the extra-data parameter:
+  `func(ctx, experiment, result, userCtx, extraData)`. Existing callbacks
+  need the one added parameter to compile. The same user context is stamped
+  on each buffered `TrackingData` as its `user` field, snapshotted at
+  evaluation time. `EventUserContext` is now an alias of the new
+  `TrackingUserContext` type; event logger code is unaffected.
 - **Behavior change (JS parity):** `EvalFeature` now fires `ExperimentCallback`
   and plugin `OnExperimentViewed` for every experiment assignment made during
   evaluation, in evaluation order — including passthrough assignments (e.g.
@@ -36,14 +44,6 @@ All notable changes to this project will be documented in this file.
   its lifetime and keeps first-seen order; `TrackingData` serializes to the
   JS SDK's `TrackingData` shape, compatible with `setDeferredTrackingCalls`.
   Callbacks and plugins are unaffected and keep firing per evaluation.
-- **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`
-  parameter — the evaluating client's attributes and URL, the JS SDK
-  `trackingCallback`'s user argument — before the extra-data parameter:
-  `func(ctx, experiment, result, userCtx, extraData)`. Existing callbacks
-  need the one added parameter to compile. The same user context is stamped
-  on each buffered `TrackingData` as its `user` field, snapshotted at
-  evaluation time. `EventUserContext` is now an alias of the new
-  `TrackingUserContext` type; event logger code is unaffected.
 
 ## [v0.3.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.3.0) - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@ All notable changes to this project will be documented in this file.
   the standard evaluation methods is buffered: read it with
   `Client.DeferredTrackingCalls` (which returns detached copies, safe to
   retain or mutate) and empty it with `Client.ClearDeferredTrackingCalls`.
-  The buffer deduplicates by
-  `TrackingData.DedupeKey` (the same fields as the JS SDK's dedupe key) over
-  its lifetime and keeps first-seen order; `TrackingData` serializes to the
+  The buffer deduplicates by `TrackingData.DedupeKey` (the same fields as
+  the JS SDK's dedupe key) over its lifetime and keeps first-seen order;
+  `TrackingData` serializes to the
   JS SDK's `TrackingData` shape, compatible with `setDeferredTrackingCalls`.
   Callbacks and plugins are unaffected and keep firing per evaluation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ All notable changes to this project will be documented in this file.
   its lifetime and keeps first-seen order; `TrackingData` serializes to the
   JS SDK's `TrackingData` shape, compatible with `setDeferredTrackingCalls`.
   Callbacks and plugins are unaffected and keep firing per evaluation.
+- **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`
+  parameter — the evaluating client's attributes and URL, the JS SDK
+  `trackingCallback`'s user argument — before the extra-data parameter:
+  `func(ctx, experiment, result, userCtx, extraData)`. Existing callbacks
+  need the one added parameter to compile. The same user context is stamped
+  on each buffered `TrackingData` as its `user` field, snapshotted at
+  evaluation time. `EventUserContext` is now an alias of the new
+  `TrackingUserContext` type; event logger code is unaffected.
 
 ## [v0.3.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.3.0) - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,11 @@ All notable changes to this project will be documented in this file.
   `Client.DeferredTrackingCalls` (which returns detached copies, safe to
   retain or mutate) and empty it with `Client.ClearDeferredTrackingCalls`.
   The buffer deduplicates by `TrackingData.DedupeKey` (the same fields as
-  the JS SDK's dedupe key) over its lifetime and keeps first-seen order;
-  `TrackingData` serializes to the
+  the JS SDK's dedupe key) over its lifetime and keeps first-seen order.
+  `Namespace` and `BucketRange` now marshal to their payload tuple forms
+  (`[id, start, end]` and `[min, max]`) so experiment JSON round-trips and
+  matches what other SDKs emit; previously they marshaled as structs that
+  could not be re-parsed. `TrackingData` serializes to the
   JS SDK's `TrackingData` shape, compatible with `setDeferredTrackingCalls`.
   Callbacks and plugins are unaffected and keep firing per evaluation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ All notable changes to this project will be documented in this file.
   `WithDeferredTracking` option — typically on a per-request child client,
   which acts as the user context — and every experiment exposure produced by
   the standard evaluation methods is buffered: read it with
-  `Client.DeferredTrackingCalls` and empty it with
-  `Client.ClearDeferredTrackingCalls`. The buffer deduplicates by
+  `Client.DeferredTrackingCalls` (which returns detached copies, safe to
+  retain or mutate) and empty it with `Client.ClearDeferredTrackingCalls`.
+  The buffer deduplicates by
   `TrackingData.DedupeKey` (the same fields as the JS SDK's dedupe key) over
   its lifetime and keeps first-seen order; `TrackingData` serializes to the
   JS SDK's `TrackingData` shape, compatible with `setDeferredTrackingCalls`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,16 @@ All notable changes to this project will be documented in this file.
   the control arm of a monitored ramp step) and assignments made while
   evaluating prerequisite features. Previously only the experiment that
   decided the served value was reported, so those exposures were silently
-  dropped.
+  dropped. Feature-usage callbacks fire before experiment callbacks.
 - **Behavior change (JS parity):** `FeatureUsageCallback` and plugin
   `OnFeatureEvaluated` now also fire for prerequisite features evaluated
   along the way, not just the requested feature. A feature is reported once
   per evaluation unless its value changed.
-- **Behavior change (JS parity):** `RunExperiment` no longer fires tracking
-  callbacks for forced variations (`force`, forced variations set on the
-  client, querystring overrides) — these are not randomized exposures and the
-  JS SDK has never tracked them.
+- **Behavior change (JS parity):** forced variations (`force`, forced
+  variations set on the client, querystring overrides) no longer fire
+  tracking callbacks — from `RunExperiment` or from a feature's experiment
+  rules in `EvalFeature`. These are not randomized exposures and the JS SDK
+  has never tracked them.
 - Added deferred tracking, the Go equivalent of the JS SDK's deferred
   tracking queue, for servers that forward exposures to client SDKs (e.g.
   remote evaluation) instead of tracking via callbacks. Enable it with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,15 @@ All notable changes to this project will be documented in this file.
   retain or mutate) and empty it with `Client.ClearDeferredTrackingCalls`.
   The buffer deduplicates by `TrackingData.DedupeKey` (the same fields as
   the JS SDK's dedupe key) over its lifetime and keeps first-seen order.
-  `Namespace` and `BucketRange` now marshal to their payload tuple forms
-  (`[id, start, end]` and `[min, max]`) so experiment JSON round-trips and
-  matches what other SDKs emit; previously they marshaled as structs that
-  could not be re-parsed. `TrackingData` serializes to the
+  `TrackingData` serializes to the
   JS SDK's `TrackingData` shape, compatible with `setDeferredTrackingCalls`.
   Callbacks and plugins are unaffected and keep firing per evaluation.
+- **Behavior change:** `Namespace` and `BucketRange` now marshal to their
+  payload tuple forms (`[id, start, end]` and `[min, max]`), matching what
+  they unmarshal from and what other SDKs emit. Previously they marshaled as
+  structs that could not be re-parsed, which broke JSON round-trips of
+  experiments (including deferred-tracking deep copies) for any experiment
+  carrying a namespace, ranges, or filters.
 
 ## [v0.3.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.3.0) - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ All notable changes to this project will be documented in this file.
   the control arm of a monitored ramp step) and assignments made while
   evaluating prerequisite features. Previously only the experiment that
   decided the served value was reported, so those exposures were silently
-  dropped. Feature-usage callbacks fire before experiment callbacks.
+  dropped. Feature-usage callbacks fire before experiment callbacks. Unlike
+  the JS SDK, callbacks are deduplicated per evaluation, not per client
+  lifetime — repeat evaluations fire them again (the deferred tracking
+  buffer dedupes for its lifetime, and analysis dedupes exposures at query
+  time).
 - **Behavior change (JS parity):** `FeatureUsageCallback` and plugin
   `OnFeatureEvaluated` now also fire for prerequisite features evaluated
   along the way, not just the requested feature. A feature is reported once

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
 - **Behavior change (JS parity):** `EvalFeature` now fires `ExperimentCallback`
   and plugin `OnExperimentViewed` for every experiment assignment made during
@@ -32,9 +32,9 @@ All notable changes to this project will be documented in this file.
   the standard evaluation methods is buffered: read it with
   `Client.DeferredTrackingCalls` and empty it with
   `Client.ClearDeferredTrackingCalls`. The buffer deduplicates by
-  `TrackingData.DedupeKey` (the JS SDK's dedupe key) over its lifetime and
-  keeps first-seen order; `TrackingData` serializes to the JS SDK's
-  `TrackingData` shape, compatible with `setDeferredTrackingCalls`.
+  `TrackingData.DedupeKey` (the same fields as the JS SDK's dedupe key) over
+  its lifetime and keeps first-seen order; `TrackingData` serializes to the
+  JS SDK's `TrackingData` shape, compatible with `setDeferredTrackingCalls`.
   Callbacks and plugins are unaffected and keep firing per evaluation.
 
 ## [v0.3.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.3.0) - 2026-08-26

--- a/README.md
+++ b/README.md
@@ -188,6 +188,50 @@ client, err := gb.NewClient(
 
 Callbacks and the tracking plugin can be used together — they operate independently.
 
+#### Deferred Tracking
+
+Sometimes the process evaluating features isn't the right place to send
+analytics from. A common example is a remote-evaluation server: it evaluates
+features on behalf of client SDKs, and each client should report its own
+exposures. Deferred tracking buffers every experiment exposure an evaluation
+produces — including passthrough assignments and experiments inside
+prerequisite features — so you can read the buffer and forward it, instead of
+intercepting callbacks.
+
+Enable it with `WithDeferredTracking`. The usual pattern is one child client
+per user request; the child acts as the user context, so every request gets
+its own buffer:
+
+```go
+child, _ := client.WithAttributes(gb.Attributes{"id": userID})
+child, _ = child.WithDeferredTracking()
+
+child.EvalFeature(ctx, "feature-a")
+child.EvalFeature(ctx, "feature-b")
+
+exposures := child.DeferredTrackingCalls() // []gb.TrackingData
+```
+
+Good to know:
+
+- The buffer keeps one entry per unique assignment (same user, experiment,
+  and variation), in the order they were first seen.
+  `ClearDeferredTrackingCalls` empties it.
+- `TrackingData` marshals to the same JSON shape as the JS SDK's tracking
+  data, so a forwarded list can be passed directly to a JS client's
+  `setDeferredTrackingCalls`.
+- Child clients cloned from an armed client share its buffer. Calling
+  `WithDeferredTracking` again gives the new client a fresh, separate buffer.
+- Arming a shared client also works — the buffer is safe for concurrent use
+  and entries carry their user identity — but you lose the per-request
+  boundary, so prefer arming per-request children.
+- Callbacks and plugins are unaffected and keep firing. If you both forward
+  the buffer and track via callbacks, you'll report exposures twice — pick
+  one channel.
+- Feature usage is not buffered, only experiment exposures. Usage events
+  describe where evaluation happened, and remote-evaluation clients report
+  their own; on the server they still reach callbacks and plugins.
+
 #### Custom Plugins
 
 You can implement the `Plugin` interface to create custom tracking or other plugins:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ Custom plugins can receive these events too by implementing the optional
 
 For custom analytics integrations, you can set up two callbacks:
 
-1. **`ExperimentCallback`**: Triggered when a user is included in an experiment.
+1. **`ExperimentCallback`**: Triggered when a user is included in an
+   experiment, with the user context (attributes and URL) the evaluation ran
+   with — the equivalent of the JS SDK's `trackingCallback`.
 2. **`FeatureUsageCallback`**: Triggered on each feature evaluation.
 
 You can also attach extra data that will be sent with each callback. These callbacks can be set globally via the `NewClient` function using the `WithExperimentCallback` and `WithFeatureUsageCallback` options. Alternatively, you can set them locally when creating child clients using similar methods like `client.WithExperimentCallback`. Extra data is set via the `WithExtraData` option.
@@ -176,7 +178,7 @@ You can also attach extra data that will be sent with each callback. These callb
 client, err := gb.NewClient(
     context.Background(),
     gb.WithClientKey("sdk-XXXX"),
-    gb.WithExperimentCallback(func(ctx context.Context, exp *gb.Experiment, result *gb.ExperimentResult, extraData any) {
+    gb.WithExperimentCallback(func(ctx context.Context, exp *gb.Experiment, result *gb.ExperimentResult, userCtx *gb.TrackingUserContext, extraData any) {
         // Send to your analytics provider
     }),
     gb.WithFeatureUsageCallback(func(ctx context.Context, key string, result *gb.FeatureResult, extraData any) {
@@ -218,7 +220,8 @@ Good to know:
   and variation), in the order they were first seen.
   `ClearDeferredTrackingCalls` empties it.
 - `TrackingData` marshals to the same JSON shape as the JS SDK's tracking
-  data, so a forwarded list can be passed directly to a JS client's
+  data — including the `user` context the evaluation ran with — so a
+  forwarded list can be passed directly to a JS client's
   `setDeferredTrackingCalls`.
 - Child clients cloned from an armed client share its buffer. Calling
   `WithDeferredTracking` again gives the new client a fresh, separate buffer.

--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ exposures := child.DeferredTrackingCalls() // []gb.TrackingData
 Good to know:
 
 - The buffer keeps one entry per unique assignment (same user, experiment,
-  and variation), in the order they were first seen.
-  `ClearDeferredTrackingCalls` empties it.
+  and variation), in the order they were first seen. Reads return detached
+  copies, safe to retain or mutate; `ClearDeferredTrackingCalls` empties the
+  buffer.
 - `TrackingData` marshals to the same JSON shape as the JS SDK's tracking
   data — including the `user` context the evaluation ran with — so a
   forwarded list can be passed directly to a JS client's

--- a/bucket_range.go
+++ b/bucket_range.go
@@ -88,3 +88,7 @@ func (br *BucketRange) UnmarshalJSON(data []byte) error {
 	br.Max = float64(pair[1])
 	return nil
 }
+
+func (br BucketRange) MarshalJSON() ([]byte, error) {
+	return json.Marshal([2]float64{br.Min, br.Max})
+}

--- a/client.go
+++ b/client.go
@@ -40,6 +40,10 @@ type Client struct {
 	// stickyBucketAssignments caches assignments. Shared by reference with
 	// cloned clients and mutated during evaluation, hence mutex-guarded.
 	stickyBucketAssignments *lockedStickyBucketCache
+
+	// deferredTracks buffers experiment exposures when deferred tracking is
+	// enabled. Shared by reference with cloned clients, hence mutex-guarded.
+	deferredTracks *trackingBuffer
 }
 
 // ForcedVariationsMap is a map that forces an Experiment to always assign a specific variation. Useful for QA.
@@ -214,43 +218,25 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 
 // EvalFeature evaluates feature based on attributes and features map
 func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResult {
-	res, _ := client.EvalFeatureWithTracking(ctx, key)
-	return res
-}
-
-// EvalFeatureWithTracking evaluates a feature and also returns every
-// experiment exposure the evaluation produced — passthrough and prerequisite
-// assignments included, in evaluation order — for callers that forward
-// exposures elsewhere (e.g. remote-evaluation servers). The list is complete
-// when the call returns, and callbacks and plugins fire as usual,
-// synchronously, before it does.
-func (client *Client) EvalFeatureWithTracking(ctx context.Context, key string) (*FeatureResult, []TrackingData) {
 	e := client.evaluator(ctx)
 	res := e.evalFeature(key)
 	client.fireTracking(ctx, e)
-	return res, e.experiments
-}
-
-func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *ExperimentResult {
-	res, _ := client.RunExperimentWithTracking(ctx, exp)
 	return res
 }
 
-// RunExperimentWithTracking is EvalFeatureWithTracking for a directly-run
-// experiment.
-func (client *Client) RunExperimentWithTracking(ctx context.Context, exp *Experiment) (*ExperimentResult, []TrackingData) {
+func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *ExperimentResult {
 	e := client.evaluator(ctx)
 	res := e.runExperiment(exp, "")
 	client.fireTracking(ctx, e)
 	if client.data.subscribers.hasSubscribers() {
 		client.notifySubscribers(ctx, exp, res)
 	}
-	return res, e.experiments
+	return res
 }
 
 // fireTracking reports one evaluation's tracking data to the configured
-// callbacks and plugins. Plugin panics are recovered so plugins never
-// interrupt evaluation.
+// callbacks and plugins, and to the deferred tracking buffer when enabled.
+// Plugin panics are recovered so plugins never interrupt evaluation.
 func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 	plugins := client.data.getPlugins()
 	for _, u := range e.featureUsage {
@@ -268,6 +254,9 @@ func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 		for _, p := range plugins {
 			client.safePluginExperimentViewed(ctx, p, d.Experiment, d.Result)
 		}
+	}
+	if client.deferredTracks != nil {
+		client.deferredTracks.add(e.experiments)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -242,7 +242,14 @@ func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *Exper
 // evaluation.
 func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 	if client.deferredTracks != nil {
-		client.deferredTracks.add(e.experiments)
+		// Detach before buffering: this runs on the evaluating goroutine, so
+		// nothing the caller later mutates can reach the buffer.
+		data, err := detachTrackingData(e.experiments)
+		if err != nil {
+			client.logger.Warn("Buffering aliased tracking data, deep copy failed", "error", err)
+			data = e.experiments
+		}
+		client.deferredTracks.add(data)
 	}
 	plugins := client.data.getPlugins()
 	for _, u := range e.featureUsage {

--- a/client.go
+++ b/client.go
@@ -234,10 +234,15 @@ func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *Exper
 	return res
 }
 
-// fireTracking reports one evaluation's tracking data to the configured
-// callbacks and plugins, and to the deferred tracking buffer when enabled.
-// Plugin panics are recovered so plugins never interrupt evaluation.
+// fireTracking reports one evaluation's tracking data to the deferred
+// tracking buffer when enabled, then to the configured callbacks and
+// plugins. The buffer is written first so a panicking callback cannot lose
+// exposures. Plugin panics are recovered so plugins never interrupt
+// evaluation.
 func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
+	if client.deferredTracks != nil {
+		client.deferredTracks.add(e.experiments)
+	}
 	plugins := client.data.getPlugins()
 	for _, u := range e.featureUsage {
 		if client.featureUsageCallback != nil {
@@ -254,9 +259,6 @@ func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 		for _, p := range plugins {
 			client.safePluginExperimentViewed(ctx, p, d.Experiment, d.Result)
 		}
-	}
-	if client.deferredTracks != nil {
-		client.deferredTracks.add(e.experiments)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -244,12 +244,7 @@ func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 	if client.deferredTracks != nil {
 		// Detach before buffering: this runs on the evaluating goroutine, so
 		// nothing the caller later mutates can reach the buffer.
-		data, err := detachTrackingData(e.experiments)
-		if err != nil {
-			client.logger.Warn("Buffering aliased tracking data, deep copy failed", "error", err)
-			data = e.experiments
-		}
-		client.deferredTracks.add(data)
+		client.deferredTracks.add(client.detachTrackingData(e.experiments))
 	}
 	plugins := client.data.getPlugins()
 	for _, u := range e.featureUsage {

--- a/client.go
+++ b/client.go
@@ -291,6 +291,8 @@ func (client *Client) evaluator(ctx context.Context) *evaluator {
 		savedGroups: client.data.savedGroups,
 		client:      client,
 		ctx:         ctx,
+		recording: client.experimentCallback != nil || client.featureUsageCallback != nil ||
+			client.deferredTracks != nil || len(client.data.plugins) > 0,
 	}
 	client.data.mu.RUnlock()
 	return &e

--- a/client.go
+++ b/client.go
@@ -49,8 +49,9 @@ type Client struct {
 // ForcedVariationsMap is a map that forces an Experiment to always assign a specific variation. Useful for QA.
 type ForcedVariationsMap map[string]int
 
-// ExperimentCallback function that is executed every time a user is included in an Experiment.
-type ExperimentCallback func(context.Context, *Experiment, *ExperimentResult, any)
+// ExperimentCallback function that is executed every time a user is included
+// in an Experiment, with the user context the evaluation ran with.
+type ExperimentCallback func(context.Context, *Experiment, *ExperimentResult, *TrackingUserContext, any)
 
 // FeatureUsageCallback funcion is executed every time feature is evaluated
 type FeatureUsageCallback func(context.Context, string, *FeatureResult, any)
@@ -254,7 +255,7 @@ func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 	}
 	for _, d := range e.experiments {
 		if client.experimentCallback != nil {
-			client.experimentCallback(ctx, d.Experiment, d.Result, client.extraData)
+			client.experimentCallback(ctx, d.Experiment, d.Result, d.User, client.extraData)
 		}
 		for _, p := range plugins {
 			client.safePluginExperimentViewed(ctx, p, d.Experiment, d.Result)

--- a/client.go
+++ b/client.go
@@ -219,13 +219,9 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 }
 
 // EvalFeatureWithTracking evaluates a feature and also returns everything
-// the evaluation reported through callbacks and plugins: every feature
-// evaluated (including prerequisites) and every experiment assignment made
-// along the way (including passthrough assignments). Callbacks and plugins
-// fire as usual, synchronously, before this returns; the returned data is
-// for callers that forward exposures elsewhere — e.g. remote-evaluation
-// servers — which typically configure no callbacks and serialize the data
-// into their response instead.
+// the evaluation reported through callbacks and plugins, for callers that
+// forward exposures elsewhere (e.g. remote-evaluation servers). Callbacks
+// and plugins fire as usual, synchronously, before this returns.
 func (client *Client) EvalFeatureWithTracking(ctx context.Context, key string) (*FeatureResult, *EvalTracking) {
 	e := client.evaluator(ctx)
 	res := e.evalFeature(key)
@@ -239,8 +235,7 @@ func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *Exper
 }
 
 // RunExperimentWithTracking is EvalFeatureWithTracking for a directly-run
-// experiment: the returned data includes the experiment's own assignment and
-// any made while evaluating its prerequisites.
+// experiment.
 func (client *Client) RunExperimentWithTracking(ctx context.Context, exp *Experiment) (*ExperimentResult, *EvalTracking) {
 	e := client.evaluator(ctx)
 	res := e.runExperiment(exp, "")
@@ -251,9 +246,9 @@ func (client *Client) RunExperimentWithTracking(ctx context.Context, exp *Experi
 	return res, &e.tracking
 }
 
-// fireTracking reports one evaluation's feature usage and experiment
-// assignments to the configured callbacks and plugins, in evaluation order.
-// Plugin panics are recovered so plugins never interrupt evaluation.
+// fireTracking reports one evaluation's tracking data to the configured
+// callbacks and plugins. Plugin panics are recovered so plugins never
+// interrupt evaluation.
 func (client *Client) fireTracking(ctx context.Context, t *EvalTracking) {
 	plugins := client.data.getPlugins()
 	for _, u := range t.FeatureUsage {

--- a/client.go
+++ b/client.go
@@ -214,40 +214,64 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 
 // EvalFeature evaluates feature based on attributes and features map
 func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResult {
-	e := client.evaluator(ctx)
-	res := e.evalFeature(key)
-	if client.featureUsageCallback != nil {
-		client.featureUsageCallback(ctx, key, res, client.extraData)
-	}
-	if client.experimentCallback != nil && res.InExperiment() {
-		client.experimentCallback(ctx, res.Experiment, res.ExperimentResult, client.extraData)
-	}
-	// Notify plugins. Panics are recovered so plugins never interrupt evaluation.
-	for _, p := range client.data.getPlugins() {
-		client.safePluginFeatureEvaluated(ctx, p, key, res)
-		if res.InExperiment() {
-			client.safePluginExperimentViewed(ctx, p, res.Experiment, res.ExperimentResult)
-		}
-	}
+	res, _ := client.EvalFeatureWithTracking(ctx, key)
 	return res
 }
 
+// EvalFeatureWithTracking evaluates a feature and also returns everything
+// the evaluation reported through callbacks and plugins: every feature
+// evaluated (including prerequisites) and every experiment assignment made
+// along the way (including passthrough assignments). Callbacks and plugins
+// fire as usual, synchronously, before this returns; the returned data is
+// for callers that forward exposures elsewhere — e.g. remote-evaluation
+// servers — which typically configure no callbacks and serialize the data
+// into their response instead.
+func (client *Client) EvalFeatureWithTracking(ctx context.Context, key string) (*FeatureResult, *EvalTracking) {
+	e := client.evaluator(ctx)
+	res := e.evalFeature(key)
+	client.fireTracking(ctx, &e.tracking)
+	return res, &e.tracking
+}
+
 func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *ExperimentResult {
+	res, _ := client.RunExperimentWithTracking(ctx, exp)
+	return res
+}
+
+// RunExperimentWithTracking is EvalFeatureWithTracking for a directly-run
+// experiment: the returned data includes the experiment's own assignment and
+// any made while evaluating its prerequisites.
+func (client *Client) RunExperimentWithTracking(ctx context.Context, exp *Experiment) (*ExperimentResult, *EvalTracking) {
 	e := client.evaluator(ctx)
 	res := e.runExperiment(exp, "")
-	if client.experimentCallback != nil && res.InExperiment {
-		client.experimentCallback(ctx, exp, res, client.extraData)
-	}
-	// Notify plugins.
-	for _, p := range client.data.getPlugins() {
-		if res.InExperiment {
-			client.safePluginExperimentViewed(ctx, p, exp, res)
-		}
-	}
+	client.fireTracking(ctx, &e.tracking)
 	if client.data.subscribers.hasSubscribers() {
 		client.notifySubscribers(ctx, exp, res)
 	}
-	return res
+	return res, &e.tracking
+}
+
+// fireTracking reports one evaluation's feature usage and experiment
+// assignments to the configured callbacks and plugins, in evaluation order.
+// Plugin panics are recovered so plugins never interrupt evaluation.
+func (client *Client) fireTracking(ctx context.Context, t *EvalTracking) {
+	plugins := client.data.getPlugins()
+	for _, u := range t.FeatureUsage {
+		if client.featureUsageCallback != nil {
+			client.featureUsageCallback(ctx, u.Key, u.Result, client.extraData)
+		}
+		for _, p := range plugins {
+			client.safePluginFeatureEvaluated(ctx, p, u.Key, u.Result)
+		}
+	}
+	for _, d := range t.Experiments {
+		if client.experimentCallback != nil {
+			client.experimentCallback(ctx, d.Experiment, d.Result, client.extraData)
+		}
+		for _, p := range plugins {
+			client.safePluginExperimentViewed(ctx, p, d.Experiment, d.Result)
+		}
+	}
 }
 
 func (client *Client) Features() FeatureMap {

--- a/client.go
+++ b/client.go
@@ -218,15 +218,17 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 	return res
 }
 
-// EvalFeatureWithTracking evaluates a feature and also returns everything
-// the evaluation reported through callbacks and plugins, for callers that
-// forward exposures elsewhere (e.g. remote-evaluation servers). Callbacks
-// and plugins fire as usual, synchronously, before this returns.
-func (client *Client) EvalFeatureWithTracking(ctx context.Context, key string) (*FeatureResult, *EvalTracking) {
+// EvalFeatureWithTracking evaluates a feature and also returns every
+// experiment exposure the evaluation produced — passthrough and prerequisite
+// assignments included, in evaluation order — for callers that forward
+// exposures elsewhere (e.g. remote-evaluation servers). The list is complete
+// when the call returns, and callbacks and plugins fire as usual,
+// synchronously, before it does.
+func (client *Client) EvalFeatureWithTracking(ctx context.Context, key string) (*FeatureResult, []TrackingData) {
 	e := client.evaluator(ctx)
 	res := e.evalFeature(key)
-	client.fireTracking(ctx, &e.tracking)
-	return res, &e.tracking
+	client.fireTracking(ctx, e)
+	return res, e.experiments
 }
 
 func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *ExperimentResult {
@@ -236,30 +238,30 @@ func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *Exper
 
 // RunExperimentWithTracking is EvalFeatureWithTracking for a directly-run
 // experiment.
-func (client *Client) RunExperimentWithTracking(ctx context.Context, exp *Experiment) (*ExperimentResult, *EvalTracking) {
+func (client *Client) RunExperimentWithTracking(ctx context.Context, exp *Experiment) (*ExperimentResult, []TrackingData) {
 	e := client.evaluator(ctx)
 	res := e.runExperiment(exp, "")
-	client.fireTracking(ctx, &e.tracking)
+	client.fireTracking(ctx, e)
 	if client.data.subscribers.hasSubscribers() {
 		client.notifySubscribers(ctx, exp, res)
 	}
-	return res, &e.tracking
+	return res, e.experiments
 }
 
 // fireTracking reports one evaluation's tracking data to the configured
 // callbacks and plugins. Plugin panics are recovered so plugins never
 // interrupt evaluation.
-func (client *Client) fireTracking(ctx context.Context, t *EvalTracking) {
+func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 	plugins := client.data.getPlugins()
-	for _, u := range t.FeatureUsage {
+	for _, u := range e.featureUsage {
 		if client.featureUsageCallback != nil {
-			client.featureUsageCallback(ctx, u.Key, u.Result, client.extraData)
+			client.featureUsageCallback(ctx, u.key, u.result, client.extraData)
 		}
 		for _, p := range plugins {
-			client.safePluginFeatureEvaluated(ctx, p, u.Key, u.Result)
+			client.safePluginFeatureEvaluated(ctx, p, u.key, u.result)
 		}
 	}
-	for _, d := range t.Experiments {
+	for _, d := range e.experiments {
 		if client.experimentCallback != nil {
 			client.experimentCallback(ctx, d.Experiment, d.Result, client.extraData)
 		}

--- a/client_option.go
+++ b/client_option.go
@@ -219,14 +219,10 @@ func WithGrowthBookTracking(config TrackingPluginConfig) ClientOption {
 	}
 }
 
-// WithDeferredTracking enables deferred tracking: every experiment exposure
-// produced by this client's evaluations — passthrough and prerequisite
-// assignments included — is buffered for later retrieval with
-// Client.DeferredTrackingCalls, in addition to firing any configured
-// callbacks and plugins. Intended for servers that forward exposures to
-// client SDKs (e.g. remote evaluation): create a child client per user
-// request, evaluate, then read the buffer. Clients cloned from this one
-// share its buffer.
+// WithDeferredTracking buffers every experiment exposure produced by
+// evaluation (passthrough and prerequisite assignments included) for later
+// retrieval with Client.DeferredTrackingCalls. Callbacks and plugins still
+// fire; clients cloned from this one share its buffer.
 func WithDeferredTracking() ClientOption {
 	return func(c *Client) error {
 		c.deferredTracks = newTrackingBuffer()

--- a/client_option.go
+++ b/client_option.go
@@ -219,6 +219,21 @@ func WithGrowthBookTracking(config TrackingPluginConfig) ClientOption {
 	}
 }
 
+// WithDeferredTracking enables deferred tracking: every experiment exposure
+// produced by this client's evaluations — passthrough and prerequisite
+// assignments included — is buffered for later retrieval with
+// Client.DeferredTrackingCalls, in addition to firing any configured
+// callbacks and plugins. Intended for servers that forward exposures to
+// client SDKs (e.g. remote evaluation): create a child client per user
+// request, evaluate, then read the buffer. Clients cloned from this one
+// share its buffer.
+func WithDeferredTracking() ClientOption {
+	return func(c *Client) error {
+		c.deferredTracks = newTrackingBuffer()
+		return nil
+	}
+}
+
 // Child client instance options
 
 // WithEnabled creates child client instance with updated enabled switch.
@@ -281,6 +296,12 @@ func (c *Client) WithFeatureUsageCallback(cb FeatureUsageCallback) (*Client, err
 // WithEventLogger creates child client with updated event logger function.
 func (c *Client) WithEventLogger(cb EventLogger) (*Client, error) {
 	return c.cloneWith(WithEventLogger(cb))
+}
+
+// WithDeferredTracking creates child client with deferred tracking enabled
+// and a fresh buffer.
+func (c *Client) WithDeferredTracking() (*Client, error) {
+	return c.cloneWith(WithDeferredTracking())
 }
 
 func withValueAttributes(value value.ObjValue) ClientOption {

--- a/client_option.go
+++ b/client_option.go
@@ -143,7 +143,7 @@ func WithExtraData(extraData any) ClientOption {
 	}
 }
 
-// WithExperiementCallbaback sets experiment callback function.
+// WithExperimentCallback sets experiment callback function.
 func WithExperimentCallback(cb ExperimentCallback) ClientOption {
 	return func(c *Client) error {
 		c.experimentCallback = cb

--- a/client_test.go
+++ b/client_test.go
@@ -227,7 +227,7 @@ func TestClientExperimentTracking(t *testing.T) {
 	ctx := context.TODO()
 	count := 0
 	var extraData any
-	cb := func(ctx context.Context, exp *Experiment, result *ExperimentResult, ed any) {
+	cb := func(ctx context.Context, exp *Experiment, result *ExperimentResult, userCtx *TrackingUserContext, ed any) {
 		count++
 		extraData = ed
 	}

--- a/evaluator.go
+++ b/evaluator.go
@@ -15,7 +15,8 @@ type evaluator struct {
 	client      *Client
 	ctx         context.Context
 
-	tracking           EvalTracking
+	experiments        []TrackingData
+	featureUsage       []featureUsage
 	trackedExperiments map[string]bool
 	trackedFeatures    map[string]string
 }

--- a/evaluator.go
+++ b/evaluator.go
@@ -16,6 +16,7 @@ type evaluator struct {
 	ctx         context.Context
 
 	recording          bool // false when no callbacks, plugins, or buffer consume tracking
+	userCtx            *TrackingUserContext
 	experiments        []TrackingData
 	featureUsage       []featureUsage
 	trackedExperiments map[string]bool

--- a/evaluator.go
+++ b/evaluator.go
@@ -14,9 +14,21 @@ type evaluator struct {
 	evaluated   stack[string]
 	client      *Client
 	ctx         context.Context
+
+	// tracking collects what this evaluation must report through callbacks
+	// and plugins (see Client.fireTracking), deduped by the two maps below.
+	tracking           EvalTracking
+	trackedExperiments map[string]bool
+	trackedFeatures    map[string]string
 }
 
 func (e *evaluator) evalFeature(key string) *FeatureResult {
+	res := e.doEvalFeature(key)
+	e.recordFeatureUsage(key, res)
+	return res
+}
+
+func (e *evaluator) doEvalFeature(key string) *FeatureResult {
 	if e.evaluated.has(key) {
 		return getFeatureResult(nil, CyclicPrerequisiteResultSource, "", nil, nil)
 	}
@@ -273,6 +285,14 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 			hashValue,
 			e.client.stickyBucketAssignments,
 		)
+	}
+
+	// 14. Record the assignment — the JS SDK fires its tracking callback at
+	// this point. This is the only place assignments are recorded, so forced
+	// variations and querystring overrides (which return earlier) are not
+	// reported, and passthrough assignments (discarded by evalRule) are.
+	if result.InExperiment {
+		e.recordExperiment(exp, result)
 	}
 
 	return result

--- a/evaluator.go
+++ b/evaluator.go
@@ -15,6 +15,7 @@ type evaluator struct {
 	client      *Client
 	ctx         context.Context
 
+	recording          bool // false when no callbacks, plugins, or buffer consume tracking
 	experiments        []TrackingData
 	featureUsage       []featureUsage
 	trackedExperiments map[string]bool
@@ -286,9 +287,9 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 		)
 	}
 
-	// 14. Record the assignment for reporting — where the JS SDK fires its
-	// tracking callback. Earlier returns (forced variations, overrides) are
-	// deliberately not recorded; passthrough assignments are.
+	// 14. Record the assignment for reporting. Earlier returns (forced
+	// variations, overrides) are deliberately not recorded; passthrough
+	// assignments are.
 	if result.InExperiment {
 		e.recordExperiment(exp, result)
 	}

--- a/evaluator.go
+++ b/evaluator.go
@@ -15,8 +15,6 @@ type evaluator struct {
 	client      *Client
 	ctx         context.Context
 
-	// tracking collects what this evaluation must report through callbacks
-	// and plugins (see Client.fireTracking), deduped by the two maps below.
 	tracking           EvalTracking
 	trackedExperiments map[string]bool
 	trackedFeatures    map[string]string
@@ -287,10 +285,9 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 		)
 	}
 
-	// 14. Record the assignment — the JS SDK fires its tracking callback at
-	// this point. This is the only place assignments are recorded, so forced
-	// variations and querystring overrides (which return earlier) are not
-	// reported, and passthrough assignments (discarded by evalRule) are.
+	// 14. Record the assignment for reporting — where the JS SDK fires its
+	// tracking callback. Earlier returns (forced variations, overrides) are
+	// deliberately not recorded; passthrough assignments are.
 	if result.InExperiment {
 		e.recordExperiment(exp, result)
 	}

--- a/event_logger.go
+++ b/event_logger.go
@@ -13,10 +13,7 @@ type EventProperties map[string]any
 // with: the calling client's attributes and URL. It is the Go equivalent
 // of the userContext argument the JS and Python SDKs pass to their event
 // loggers.
-type EventUserContext struct {
-	Attributes Attributes
-	URL        string
-}
+type EventUserContext = TrackingUserContext
 
 // EventLogger is invoked by [Client.LogEvent] for every custom event.
 // Implementations should return quickly (e.g. by enqueueing work);
@@ -37,14 +34,7 @@ type EventLoggerPlugin interface {
 // implements [EventLoggerPlugin]. If neither is configured a warning is
 // logged and the call is a no-op.
 func (client *Client) LogEvent(ctx context.Context, eventName string, properties EventProperties) {
-	clientURL := ""
-	if client.url != nil {
-		clientURL = client.url.String()
-	}
-	userCtx := &EventUserContext{
-		Attributes: attributesFromValue(client.attributes),
-		URL:        clientURL,
-	}
+	userCtx := client.trackingUserContext()
 
 	logged := false
 	if client.eventLogger != nil {

--- a/namespace.go
+++ b/namespace.go
@@ -20,6 +20,10 @@ func (namespace *Namespace) inNamespace(userId string) bool {
 	return n >= namespace.Start && n < namespace.End
 }
 
+func (namespace Namespace) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]any{namespace.Id, namespace.Start, namespace.End})
+}
+
 func (namespace *Namespace) UnmarshalJSON(data []byte) error {
 	arr := []any{}
 	err := json.Unmarshal(data, &arr)

--- a/tracking.go
+++ b/tracking.go
@@ -14,11 +14,12 @@ type TrackingData struct {
 	Result     *ExperimentResult `json:"result"`
 }
 
-// DedupeKey identifies an exposure the way the JS SDK's
-// getExperimentDedupeKey does. Exposures are deduplicated by this key within
-// a single evaluation; use it to deduplicate across evaluations if needed.
+// DedupeKey identifies an exposure by the same fields as the JS SDK's
+// getExperimentDedupeKey, with separators so distinct exposures can't
+// collide on field boundaries. Exposures are deduplicated by this key within
+// a single evaluation and in the deferred tracking buffer.
 func (t TrackingData) DedupeKey() string {
-	return t.Result.HashAttribute + t.Result.HashValue + t.Experiment.Key + strconv.Itoa(t.Result.VariationId)
+	return t.Result.HashAttribute + "\x00" + t.Result.HashValue + "\x00" + t.Experiment.Key + "\x00" + strconv.Itoa(t.Result.VariationId)
 }
 
 type featureUsage struct {

--- a/tracking.go
+++ b/tracking.go
@@ -7,11 +7,20 @@ import (
 	"sync"
 )
 
+// TrackingUserContext is the user context an evaluation ran with — the
+// evaluating client's attributes and URL. It is passed to ExperimentCallback
+// and carried on TrackingData, mirroring the JS SDK type of the same name.
+type TrackingUserContext struct {
+	Attributes Attributes `json:"attributes"`
+	URL        string     `json:"url,omitempty"`
+}
+
 // TrackingData is a single experiment exposure, in the JSON shape client
 // SDKs accept as deferred tracking calls.
 type TrackingData struct {
-	Experiment *Experiment       `json:"experiment"`
-	Result     *ExperimentResult `json:"result"`
+	Experiment *Experiment          `json:"experiment"`
+	Result     *ExperimentResult    `json:"result"`
+	User       *TrackingUserContext `json:"user,omitempty"`
 }
 
 // DedupeKey identifies an exposure by hash attribute, hash value, experiment
@@ -77,11 +86,25 @@ func (client *Client) ClearDeferredTrackingCalls() {
 	b.data = nil
 }
 
+func (client *Client) trackingUserContext() *TrackingUserContext {
+	clientURL := ""
+	if client.url != nil {
+		clientURL = client.url.String()
+	}
+	return &TrackingUserContext{
+		Attributes: attributesFromValue(client.attributes),
+		URL:        clientURL,
+	}
+}
+
 func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 	if !e.recording {
 		return
 	}
-	data := TrackingData{Experiment: exp, Result: res}
+	if e.userCtx == nil {
+		e.userCtx = e.client.trackingUserContext()
+	}
+	data := TrackingData{Experiment: exp, Result: res, User: e.userCtx}
 	key := data.DedupeKey()
 	if e.trackedExperiments[key] {
 		return

--- a/tracking.go
+++ b/tracking.go
@@ -1,0 +1,85 @@
+package growthbook
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// TrackingData is a single experiment exposure: the experiment and the
+// user's assignment. It matches the JS SDK's TrackingData shape, so a
+// serialized list can be handed to a client-side GrowthBook instance via
+// setDeferredTrackingCalls.
+type TrackingData struct {
+	Experiment *Experiment       `json:"experiment"`
+	Result     *ExperimentResult `json:"result"`
+}
+
+// DedupeKey identifies an exposure the way the JS SDK's
+// getExperimentDedupeKey does. Exposures are deduplicated by this key within
+// a single evaluation; callers batching several evaluations for the same
+// user can use it to deduplicate across them.
+func (t TrackingData) DedupeKey() string {
+	return t.Result.HashAttribute + t.Result.HashValue + t.Experiment.Key + strconv.Itoa(t.Result.VariationId)
+}
+
+// FeatureUsage is a single feature evaluation: the feature key and its
+// result.
+type FeatureUsage struct {
+	Key    string         `json:"key"`
+	Result *FeatureResult `json:"result"`
+}
+
+// EvalTracking is everything one evaluation reports through callbacks and
+// plugins: every feature evaluated (the requested feature and any
+// prerequisites) and every experiment assignment made along the way —
+// including passthrough assignments — in evaluation order.
+//
+// It is scoped to a single EvalFeatureWithTracking /
+// RunExperimentWithTracking call and complete when that call returns, so a
+// server that forwards exposures elsewhere (e.g. remote evaluation) can read
+// it synchronously instead of correlating the client-wide callbacks across
+// concurrent requests.
+type EvalTracking struct {
+	FeatureUsage []FeatureUsage `json:"featureUsage"`
+	Experiments  []TrackingData `json:"experiments"`
+}
+
+// recordExperiment saves an assignment for reporting. The JS SDK fires its
+// tracking callback at the equivalent point in its runExperiment, deduping
+// repeats of the same assignment.
+func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
+	data := TrackingData{Experiment: exp, Result: res}
+	key := data.DedupeKey()
+	if e.trackedExperiments[key] {
+		return
+	}
+	if e.trackedExperiments == nil {
+		e.trackedExperiments = make(map[string]bool)
+	}
+	e.trackedExperiments[key] = true
+	e.tracking.Experiments = append(e.tracking.Experiments, data)
+}
+
+// recordFeatureUsage saves a feature evaluation for reporting. Mirrors the
+// JS SDK's onFeatureUsage: a feature is reported once per evaluation unless
+// its value changed.
+func (e *evaluator) recordFeatureUsage(key string, res *FeatureResult) {
+	stringified := stringifyFeatureValue(res.Value)
+	if prev, ok := e.trackedFeatures[key]; ok && prev == stringified {
+		return
+	}
+	if e.trackedFeatures == nil {
+		e.trackedFeatures = make(map[string]string)
+	}
+	e.trackedFeatures[key] = stringified
+	e.tracking.FeatureUsage = append(e.tracking.FeatureUsage, FeatureUsage{Key: key, Result: res})
+}
+
+func stringifyFeatureValue(v FeatureValue) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}

--- a/tracking.go
+++ b/tracking.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"sync"
 )
 
 // TrackingData is a single experiment exposure. It serializes to the JS
@@ -23,6 +24,57 @@ func (t TrackingData) DedupeKey() string {
 type featureUsage struct {
 	key    string
 	result *FeatureResult
+}
+
+// trackingBuffer accumulates exposures across evaluations, deduped by
+// DedupeKey, keeping first-seen order.
+type trackingBuffer struct {
+	mu   sync.Mutex
+	seen map[string]bool
+	data []TrackingData
+}
+
+func newTrackingBuffer() *trackingBuffer {
+	return &trackingBuffer{seen: make(map[string]bool)}
+}
+
+func (b *trackingBuffer) add(data []TrackingData) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, d := range data {
+		key := d.DedupeKey()
+		if b.seen[key] {
+			continue
+		}
+		b.seen[key] = true
+		b.data = append(b.data, d)
+	}
+}
+
+// DeferredTrackingCalls returns the experiment exposures buffered so far —
+// passthrough and prerequisite assignments included, deduped by DedupeKey,
+// in first-seen order. Returns nil unless deferred tracking is enabled (see
+// WithDeferredTracking).
+func (client *Client) DeferredTrackingCalls() []TrackingData {
+	if client.deferredTracks == nil {
+		return nil
+	}
+	b := client.deferredTracks
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]TrackingData(nil), b.data...)
+}
+
+// ClearDeferredTrackingCalls empties the deferred tracking buffer.
+func (client *Client) ClearDeferredTrackingCalls() {
+	if client.deferredTracks == nil {
+		return
+	}
+	b := client.deferredTracks
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.seen = make(map[string]bool)
+	b.data = nil
 }
 
 func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {

--- a/tracking.go
+++ b/tracking.go
@@ -74,28 +74,31 @@ func (client *Client) DeferredTrackingCalls() []TrackingData {
 	b.mu.Lock()
 	shared := append([]TrackingData(nil), b.data...)
 	b.mu.Unlock()
-
-	detached, err := detachTrackingData(shared)
-	if err != nil {
-		client.logger.Warn("Returning aliased tracking data, deep copy failed", "error", err)
-		return shared
-	}
-	return detached
+	return client.detachTrackingData(shared)
 }
 
-func detachTrackingData(data []TrackingData) ([]TrackingData, error) {
+// detachTrackingData deep-copies entries via a JSON round-trip, dropping
+// (and logging) any entry that cannot be serialized — such an exposure
+// could not be forwarded anyway, and returning it aliased would break the
+// detached-copy guarantee.
+func (client *Client) detachTrackingData(data []TrackingData) []TrackingData {
 	if len(data) == 0 {
-		return data, nil
+		return nil
 	}
-	raw, err := json.Marshal(data)
-	if err != nil {
-		return nil, err
+	out := make([]TrackingData, 0, len(data))
+	for _, d := range data {
+		raw, err := json.Marshal(d)
+		if err == nil {
+			var detached TrackingData
+			if err = json.Unmarshal(raw, &detached); err == nil {
+				out = append(out, detached)
+				continue
+			}
+		}
+		client.logger.Warn("Dropping unserializable exposure from deferred tracking",
+			"experiment", d.Experiment.Key, "error", err)
 	}
-	var out []TrackingData
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	return out
 }
 
 // ClearDeferredTrackingCalls empties the deferred tracking buffer.

--- a/tracking.go
+++ b/tracking.go
@@ -6,10 +6,8 @@ import (
 	"strconv"
 )
 
-// TrackingData is a single experiment exposure: the experiment and the
-// user's assignment. It matches the JS SDK's TrackingData shape, so a
-// serialized list can be handed to a client-side GrowthBook instance via
-// setDeferredTrackingCalls.
+// TrackingData is a single experiment exposure. It serializes to the JS
+// SDK's TrackingData shape, compatible with setDeferredTrackingCalls.
 type TrackingData struct {
 	Experiment *Experiment       `json:"experiment"`
 	Result     *ExperimentResult `json:"result"`
@@ -17,37 +15,26 @@ type TrackingData struct {
 
 // DedupeKey identifies an exposure the way the JS SDK's
 // getExperimentDedupeKey does. Exposures are deduplicated by this key within
-// a single evaluation; callers batching several evaluations for the same
-// user can use it to deduplicate across them.
+// a single evaluation; use it to deduplicate across evaluations if needed.
 func (t TrackingData) DedupeKey() string {
 	return t.Result.HashAttribute + t.Result.HashValue + t.Experiment.Key + strconv.Itoa(t.Result.VariationId)
 }
 
-// FeatureUsage is a single feature evaluation: the feature key and its
-// result.
+// FeatureUsage is a single feature evaluation.
 type FeatureUsage struct {
 	Key    string         `json:"key"`
 	Result *FeatureResult `json:"result"`
 }
 
 // EvalTracking is everything one evaluation reports through callbacks and
-// plugins: every feature evaluated (the requested feature and any
-// prerequisites) and every experiment assignment made along the way —
-// including passthrough assignments — in evaluation order.
-//
-// It is scoped to a single EvalFeatureWithTracking /
-// RunExperimentWithTracking call and complete when that call returns, so a
-// server that forwards exposures elsewhere (e.g. remote evaluation) can read
-// it synchronously instead of correlating the client-wide callbacks across
-// concurrent requests.
+// plugins: every feature evaluated (prerequisites included) and every
+// experiment assignment made (passthrough included), in evaluation order.
+// It is scoped to a single call and complete when that call returns.
 type EvalTracking struct {
 	FeatureUsage []FeatureUsage `json:"featureUsage"`
 	Experiments  []TrackingData `json:"experiments"`
 }
 
-// recordExperiment saves an assignment for reporting. The JS SDK fires its
-// tracking callback at the equivalent point in its runExperiment, deduping
-// repeats of the same assignment.
 func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 	data := TrackingData{Experiment: exp, Result: res}
 	key := data.DedupeKey()
@@ -61,9 +48,8 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 	e.tracking.Experiments = append(e.tracking.Experiments, data)
 }
 
-// recordFeatureUsage saves a feature evaluation for reporting. Mirrors the
-// JS SDK's onFeatureUsage: a feature is reported once per evaluation unless
-// its value changed.
+// recordFeatureUsage mirrors the JS SDK's onFeatureUsage: a feature is
+// reported once per evaluation unless its value changed.
 func (e *evaluator) recordFeatureUsage(key string, res *FeatureResult) {
 	stringified := stringifyFeatureValue(res.Value)
 	if prev, ok := e.trackedFeatures[key]; ok && prev == stringified {

--- a/tracking.go
+++ b/tracking.go
@@ -63,16 +63,39 @@ func (b *trackingBuffer) add(data []TrackingData) {
 
 // DeferredTrackingCalls returns the experiment exposures buffered so far —
 // passthrough and prerequisite assignments included, deduped by DedupeKey,
-// in first-seen order. Returns nil unless deferred tracking is enabled (see
-// WithDeferredTracking).
+// in first-seen order — as detached copies in the SDK's JSON shape, safe to
+// retain or mutate without affecting the buffer. Returns nil unless deferred
+// tracking is enabled (see WithDeferredTracking).
 func (client *Client) DeferredTrackingCalls() []TrackingData {
 	if client.deferredTracks == nil {
 		return nil
 	}
 	b := client.deferredTracks
 	b.mu.Lock()
-	defer b.mu.Unlock()
-	return append([]TrackingData(nil), b.data...)
+	shared := append([]TrackingData(nil), b.data...)
+	b.mu.Unlock()
+
+	detached, err := detachTrackingData(shared)
+	if err != nil {
+		client.logger.Warn("Returning aliased tracking data, deep copy failed", "error", err)
+		return shared
+	}
+	return detached
+}
+
+func detachTrackingData(data []TrackingData) ([]TrackingData, error) {
+	if len(data) == 0 {
+		return data, nil
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	var out []TrackingData
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ClearDeferredTrackingCalls empties the deferred tracking buffer.

--- a/tracking.go
+++ b/tracking.go
@@ -20,19 +20,9 @@ func (t TrackingData) DedupeKey() string {
 	return t.Result.HashAttribute + t.Result.HashValue + t.Experiment.Key + strconv.Itoa(t.Result.VariationId)
 }
 
-// FeatureUsage is a single feature evaluation.
-type FeatureUsage struct {
-	Key    string         `json:"key"`
-	Result *FeatureResult `json:"result"`
-}
-
-// EvalTracking is everything one evaluation reports through callbacks and
-// plugins: every feature evaluated (prerequisites included) and every
-// experiment assignment made (passthrough included), in evaluation order.
-// It is scoped to a single call and complete when that call returns.
-type EvalTracking struct {
-	FeatureUsage []FeatureUsage `json:"featureUsage"`
-	Experiments  []TrackingData `json:"experiments"`
+type featureUsage struct {
+	key    string
+	result *FeatureResult
 }
 
 func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
@@ -45,7 +35,7 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 		e.trackedExperiments = make(map[string]bool)
 	}
 	e.trackedExperiments[key] = true
-	e.tracking.Experiments = append(e.tracking.Experiments, data)
+	e.experiments = append(e.experiments, data)
 }
 
 // recordFeatureUsage mirrors the JS SDK's onFeatureUsage: a feature is
@@ -59,7 +49,7 @@ func (e *evaluator) recordFeatureUsage(key string, res *FeatureResult) {
 		e.trackedFeatures = make(map[string]string)
 	}
 	e.trackedFeatures[key] = stringified
-	e.tracking.FeatureUsage = append(e.tracking.FeatureUsage, FeatureUsage{Key: key, Result: res})
+	e.featureUsage = append(e.featureUsage, featureUsage{key: key, result: res})
 }
 
 func stringifyFeatureValue(v FeatureValue) string {

--- a/tracking.go
+++ b/tracking.go
@@ -102,12 +102,7 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 	if !e.recording {
 		return
 	}
-	if e.userCtx == nil {
-		e.userCtx = e.client.trackingUserContext()
-	}
-	expCopy, resCopy := *exp, *res
-	data := TrackingData{Experiment: &expCopy, Result: &resCopy, User: e.userCtx}
-	key := data.DedupeKey()
+	key := TrackingData{Experiment: exp, Result: res}.DedupeKey()
 	if e.trackedExperiments[key] {
 		return
 	}
@@ -115,7 +110,11 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 		e.trackedExperiments = make(map[string]bool)
 	}
 	e.trackedExperiments[key] = true
-	e.experiments = append(e.experiments, data)
+	if e.userCtx == nil {
+		e.userCtx = e.client.trackingUserContext()
+	}
+	expCopy, resCopy := *exp, *res
+	e.experiments = append(e.experiments, TrackingData{Experiment: &expCopy, Result: &resCopy, User: e.userCtx})
 }
 
 // recordFeatureUsage reports a feature once per evaluation unless its value

--- a/tracking.go
+++ b/tracking.go
@@ -7,17 +7,16 @@ import (
 	"sync"
 )
 
-// TrackingData is a single experiment exposure. It serializes to the JS
-// SDK's TrackingData shape, compatible with setDeferredTrackingCalls.
+// TrackingData is a single experiment exposure, in the JSON shape client
+// SDKs accept as deferred tracking calls.
 type TrackingData struct {
 	Experiment *Experiment       `json:"experiment"`
 	Result     *ExperimentResult `json:"result"`
 }
 
-// DedupeKey identifies an exposure by the same fields as the JS SDK's
-// getExperimentDedupeKey, with separators so distinct exposures can't
-// collide on field boundaries. Exposures are deduplicated by this key within
-// a single evaluation and in the deferred tracking buffer.
+// DedupeKey identifies an exposure by hash attribute, hash value, experiment
+// key, and variation. Exposures are deduplicated by this key within a single
+// evaluation and in the deferred tracking buffer.
 func (t TrackingData) DedupeKey() string {
 	return t.Result.HashAttribute + "\x00" + t.Result.HashValue + "\x00" + t.Experiment.Key + "\x00" + strconv.Itoa(t.Result.VariationId)
 }
@@ -79,6 +78,9 @@ func (client *Client) ClearDeferredTrackingCalls() {
 }
 
 func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
+	if !e.recording {
+		return
+	}
 	data := TrackingData{Experiment: exp, Result: res}
 	key := data.DedupeKey()
 	if e.trackedExperiments[key] {
@@ -91,9 +93,12 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 	e.experiments = append(e.experiments, data)
 }
 
-// recordFeatureUsage mirrors the JS SDK's onFeatureUsage: a feature is
-// reported once per evaluation unless its value changed.
+// recordFeatureUsage reports a feature once per evaluation unless its value
+// changed.
 func (e *evaluator) recordFeatureUsage(key string, res *FeatureResult) {
+	if !e.recording {
+		return
+	}
 	stringified := stringifyFeatureValue(res.Value)
 	if prev, ok := e.trackedFeatures[key]; ok && prev == stringified {
 		return

--- a/tracking.go
+++ b/tracking.go
@@ -16,7 +16,8 @@ type TrackingUserContext struct {
 }
 
 // TrackingData is a single experiment exposure, in the JSON shape client
-// SDKs accept as deferred tracking calls.
+// SDKs accept as deferred tracking calls. It holds its own copies of the
+// experiment and result, snapshotted at evaluation time.
 type TrackingData struct {
 	Experiment *Experiment          `json:"experiment"`
 	Result     *ExperimentResult    `json:"result"`
@@ -104,7 +105,8 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 	if e.userCtx == nil {
 		e.userCtx = e.client.trackingUserContext()
 	}
-	data := TrackingData{Experiment: exp, Result: res, User: e.userCtx}
+	expCopy, resCopy := *exp, *res
+	data := TrackingData{Experiment: &expCopy, Result: &resCopy, User: e.userCtx}
 	key := data.DedupeKey()
 	if e.trackedExperiments[key] {
 		return

--- a/tracking_plugin_test.go
+++ b/tracking_plugin_test.go
@@ -369,7 +369,7 @@ func TestTrackingPluginWithExistingCallbacks(t *testing.T) {
 	client, err := NewClient(ctx,
 		WithClientKey("sdk-test-key"),
 		WithAttributes(Attributes{"id": "user-cb"}),
-		WithExperimentCallback(func(ctx context.Context, exp *Experiment, result *ExperimentResult, extraData any) {
+		WithExperimentCallback(func(ctx context.Context, exp *Experiment, result *ExperimentResult, userCtx *TrackingUserContext, extraData any) {
 			callbackCalled = true
 		}),
 		WithFeatureUsageCallback(func(ctx context.Context, key string, result *FeatureResult, extraData any) {

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -118,11 +118,11 @@ func exposures(t *testing.T, data []TrackingData) []trackedExposure {
 	return out
 }
 
-func newTrackingTestClient(t *testing.T) (*Client, *trackingRecorder, *trackingRecorder) {
+func newTrackingTestClient(t *testing.T, extra ...ClientOption) (*Client, *trackingRecorder, *trackingRecorder) {
 	t.Helper()
 	plugin := &trackingRecorder{}
 	callbacks := &trackingRecorder{}
-	client, err := NewClient(context.Background(),
+	opts := []ClientOption{
 		WithJsonFeatures(trackingFeaturesJSON),
 		WithAttributes(Attributes{"id": "user-1"}),
 		WithDeferredTracking(),
@@ -133,7 +133,8 @@ func newTrackingTestClient(t *testing.T) (*Client, *trackingRecorder, *trackingR
 			callbacks.OnFeatureEvaluated(ctx, key, res)
 		}),
 		WithPlugins(plugin),
-	)
+	}
+	client, err := NewClient(context.Background(), append(opts, extra...)...)
 	require.NoError(t, err)
 	return client, callbacks, plugin
 }
@@ -373,61 +374,31 @@ func TestRunExperimentTracking(t *testing.T) {
 	})
 
 	t.Run("client-forced variations are served but not tracked (JS parity)", func(t *testing.T) {
-		var seen []string
-		client, err := NewClient(ctx,
-			WithJsonFeatures(trackingFeaturesJSON),
-			WithAttributes(Attributes{"id": "user-1"}),
-			WithDeferredTracking(),
-			WithForcedVariations(ForcedVariationsMap{"map-forced": 1}),
-			WithExperimentCallback(func(_ context.Context, exp *Experiment, _ *ExperimentResult, _ any) {
-				seen = append(seen, exp.Key)
-			}),
-		)
-		require.NoError(t, err)
+		client, callbacks, _ := newTrackingTestClient(t, WithForcedVariations(ForcedVariationsMap{"map-forced": 1}))
 
 		exp := Experiment{Key: "map-forced", Variations: []FeatureValue{"x", "y"}}
 		res := client.RunExperiment(ctx, &exp)
 		require.True(t, res.InExperiment)
 		require.Equal(t, "y", res.Value)
 
-		require.Empty(t, seen)
+		require.Empty(t, callbacks.exposures)
 		require.Empty(t, client.DeferredTrackingCalls())
 	})
 
 	t.Run("querystring overrides are served but not tracked (JS parity)", func(t *testing.T) {
-		var seen []string
-		client, err := NewClient(ctx,
-			WithJsonFeatures(trackingFeaturesJSON),
-			WithAttributes(Attributes{"id": "user-1"}),
-			WithDeferredTracking(),
-			WithUrl("http://example.com/?qs-exp=1"),
-			WithExperimentCallback(func(_ context.Context, exp *Experiment, _ *ExperimentResult, _ any) {
-				seen = append(seen, exp.Key)
-			}),
-		)
-		require.NoError(t, err)
+		client, callbacks, _ := newTrackingTestClient(t, WithUrl("http://example.com/?qs-exp=1"))
 
 		exp := Experiment{Key: "qs-exp", Variations: []FeatureValue{"x", "y"}}
 		res := client.RunExperiment(ctx, &exp)
 		require.True(t, res.InExperiment)
 		require.Equal(t, "y", res.Value)
 
-		require.Empty(t, seen)
+		require.Empty(t, callbacks.exposures)
 		require.Empty(t, client.DeferredTrackingCalls())
 	})
 
 	t.Run("sticky bucket assignments are tracked", func(t *testing.T) {
-		var seen []trackedExposure
-		client, err := NewClient(ctx,
-			WithJsonFeatures(trackingFeaturesJSON),
-			WithAttributes(Attributes{"id": "user-1"}),
-			WithDeferredTracking(),
-			WithStickyBucketService(NewInMemoryStickyBucketService()),
-			WithExperimentCallback(func(_ context.Context, exp *Experiment, res *ExperimentResult, _ any) {
-				seen = append(seen, trackedExposure{exp.Key, res.VariationId, res.Passthrough, res.FeatureId})
-			}),
-		)
-		require.NoError(t, err)
+		client, callbacks, _ := newTrackingTestClient(t, WithStickyBucketService(NewInMemoryStickyBucketService()))
 
 		first := client.EvalFeature(ctx, "ramped-treatment")
 		require.False(t, first.ExperimentResult.StickyBucketUsed)
@@ -435,7 +406,7 @@ func TestRunExperimentTracking(t *testing.T) {
 		require.True(t, second.ExperimentResult.StickyBucketUsed)
 
 		want := trackedExposure{"ramp-t", 0, false, "ramped-treatment"}
-		require.Equal(t, []trackedExposure{want, want}, seen)
+		require.Equal(t, []trackedExposure{want, want}, callbacks.exposures)
 		require.Len(t, client.DeferredTrackingCalls(), 1)
 	})
 }

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -267,6 +267,20 @@ func TestDeferredTracking(t *testing.T) {
 		require.Len(t, client.DeferredTrackingCalls(), 1)
 	})
 
+	t.Run("returned entries are detached from the buffer", func(t *testing.T) {
+		client, _, _ := newTrackingTestClient(t)
+		client.EvalFeature(ctx, "ramped-treatment")
+
+		calls := client.DeferredTrackingCalls()
+		require.Len(t, calls, 1)
+		calls[0].Experiment.Key = "mutated"
+		calls[0].Result.VariationId = 99
+
+		again := client.DeferredTrackingCalls()
+		require.Equal(t, "ramp-t", again[0].Experiment.Key)
+		require.Equal(t, 0, again[0].Result.VariationId)
+	})
+
 	t.Run("nil without WithDeferredTracking", func(t *testing.T) {
 		client, err := NewClient(ctx,
 			WithJsonFeatures(trackingFeaturesJSON),

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -9,13 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests pin what one evaluation reports through callbacks, plugins,
-// and the EvalTracking return value. Weights of [0,1] or [1,0] make every
-// assignment deterministic regardless of the hash attribute's value.
-//
-// "ramped" models a monitored ramp step: the treatment arm serves the rule's
-// value and the control arm is a passthrough variation, so control users
-// fall through to the rules below but their assignment is still an exposure.
+// Weights of [0,1] or [1,0] make every assignment deterministic. The
+// "ramped" features model a monitored ramp step, whose control arm is a
+// passthrough variation.
 const trackingFeaturesJSON = `{
   "ramped": {
     "defaultValue": "default",
@@ -97,8 +93,8 @@ type trackedUsage struct {
 	source FeatureResultSource
 }
 
-// trackingRecorder records what it is told; it doubles as a Plugin and as
-// the body of the two client callbacks.
+// trackingRecorder doubles as a Plugin and as the body of the two client
+// callbacks.
 type trackingRecorder struct {
 	exposures []trackedExposure
 	usage     []trackedUsage
@@ -234,8 +230,6 @@ func TestPrerequisiteTracking(t *testing.T) {
 	})
 
 	t.Run("no state leaks across evaluations, and no cross-call dedupe", func(t *testing.T) {
-		// Repeated exposures across calls are fine: the analysis layer
-		// dedupes exposures at the query level.
 		client, callbacks, _ := newTrackingTestClient(t)
 		client.EvalFeature(ctx, "child")
 		client.EvalFeature(ctx, "child")
@@ -245,9 +239,6 @@ func TestPrerequisiteTracking(t *testing.T) {
 }
 
 func TestEvalTrackingWithoutCallbacks(t *testing.T) {
-	// A remote-eval style server configures no callbacks or plugins and
-	// reads the tracking data from the return value instead. It must be
-	// complete when the call returns.
 	ctx := context.Background()
 	client, err := NewClient(ctx,
 		WithJsonFeatures(trackingFeaturesJSON),
@@ -351,8 +342,6 @@ func TestTrackingDataShape(t *testing.T) {
 }
 
 func TestConcurrentEvaluationsAreIsolated(t *testing.T) {
-	// Tracking state lives on the per-call evaluator, so concurrent
-	// evaluations on a shared client must each get their own complete data.
 	ctx := context.Background()
 	client, err := NewClient(ctx,
 		WithJsonFeatures(trackingFeaturesJSON),

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -303,6 +303,31 @@ func TestDeferredTracking(t *testing.T) {
 		child.EvalFeature(ctx, "ramped")
 		require.Len(t, client.DeferredTrackingCalls(), 1)
 	})
+
+	t.Run("re-arming a clone detaches it from the parent's buffer", func(t *testing.T) {
+		parent, _, _ := newTrackingTestClient(t)
+		child, err := parent.WithDeferredTracking()
+		require.NoError(t, err)
+
+		child.EvalFeature(ctx, "ramped")
+		require.Len(t, child.DeferredTrackingCalls(), 1)
+		require.Empty(t, parent.DeferredTrackingCalls())
+	})
+
+	t.Run("a shared armed client accumulates all users without cross-user dedupe", func(t *testing.T) {
+		shared, _, _ := newTrackingTestClient(t)
+		user1, err := shared.WithAttributes(Attributes{"id": "user-1"})
+		require.NoError(t, err)
+		user2, err := shared.WithAttributes(Attributes{"id": "user-2"})
+		require.NoError(t, err)
+
+		user1.EvalFeature(ctx, "ramped-treatment")
+		user2.EvalFeature(ctx, "ramped-treatment")
+
+		calls := shared.DeferredTrackingCalls()
+		require.Len(t, calls, 2)
+		require.NotEqual(t, calls[0].Result.HashValue, calls[1].Result.HashValue)
+	})
 }
 
 func TestRunExperimentTracking(t *testing.T) {

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -423,6 +423,28 @@ func TestRunExperimentTracking(t *testing.T) {
 		require.Empty(t, client.DeferredTrackingCalls())
 	})
 
+	t.Run("recorded exposures snapshot the experiment and result", func(t *testing.T) {
+		client, callbacks, _ := newTrackingTestClient(t)
+		var exp Experiment
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"key": "direct",
+			"variations": ["x", "y"],
+			"weights": [1, 0],
+			"coverage": 1
+		}`), &exp))
+
+		res := client.RunExperiment(ctx, &exp)
+		require.True(t, res.InExperiment)
+		exp.Key = "mutated"
+		res.VariationId = 99
+
+		calls := client.DeferredTrackingCalls()
+		require.Len(t, calls, 1)
+		require.Equal(t, "direct", calls[0].Experiment.Key)
+		require.Equal(t, 0, calls[0].Result.VariationId)
+		require.Equal(t, []trackedExposure{{"direct", 0, false, ""}}, callbacks.exposures)
+	})
+
 	t.Run("sticky bucket assignments are tracked", func(t *testing.T) {
 		client, callbacks, _ := newTrackingTestClient(t, WithStickyBucketService(NewInMemoryStickyBucketService()))
 

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -118,15 +118,6 @@ func exposures(t *testing.T, data []TrackingData) []trackedExposure {
 	return out
 }
 
-func usages(t *testing.T, data []FeatureUsage) []trackedUsage {
-	t.Helper()
-	out := make([]trackedUsage, 0, len(data))
-	for _, d := range data {
-		out = append(out, trackedUsage{d.Key, d.Result.Source})
-	}
-	return out
-}
-
 func newTrackingTestClient(t *testing.T) (*Client, *trackingRecorder, *trackingRecorder) {
 	t.Helper()
 	plugin := &trackingRecorder{}
@@ -160,8 +151,8 @@ func TestPassthroughAssignmentTracked(t *testing.T) {
 		want := []trackedExposure{{"ramp", 1, true, "ramped"}}
 		require.Equal(t, want, callbacks.exposures)
 		require.Equal(t, want, plugin.exposures)
-		require.Equal(t, want, exposures(t, tracking.Experiments))
-		require.Equal(t, []trackedUsage{{"ramped", ForceResultSource}}, usages(t, tracking.FeatureUsage))
+		require.Equal(t, want, exposures(t, tracking))
+		require.Equal(t, []trackedUsage{{"ramped", ForceResultSource}}, callbacks.usage)
 	})
 
 	t.Run("control arm falls through to an experiment rule: both tracked, in evaluation order", func(t *testing.T) {
@@ -177,7 +168,7 @@ func TestPassthroughAssignmentTracked(t *testing.T) {
 		}
 		require.Equal(t, want, callbacks.exposures)
 		require.Equal(t, want, plugin.exposures)
-		require.Equal(t, want, exposures(t, tracking.Experiments))
+		require.Equal(t, want, exposures(t, tracking))
 	})
 
 	t.Run("treatment arm serves the rule value with a single exposure", func(t *testing.T) {
@@ -190,7 +181,7 @@ func TestPassthroughAssignmentTracked(t *testing.T) {
 		want := []trackedExposure{{"ramp-t", 0, false, "ramped-treatment"}}
 		require.Equal(t, want, callbacks.exposures)
 		require.Equal(t, want, plugin.exposures)
-		require.Equal(t, want, exposures(t, tracking.Experiments))
+		require.Equal(t, want, exposures(t, tracking))
 	})
 }
 
@@ -206,7 +197,7 @@ func TestPrerequisiteTracking(t *testing.T) {
 		wantExposures := []trackedExposure{{"parent-exp", 0, false, "parent"}}
 		require.Equal(t, wantExposures, callbacks.exposures)
 		require.Equal(t, wantExposures, plugin.exposures)
-		require.Equal(t, wantExposures, exposures(t, tracking.Experiments))
+		require.Equal(t, wantExposures, exposures(t, tracking))
 
 		wantUsage := []trackedUsage{
 			{"parent", ExperimentResultSource},
@@ -214,7 +205,6 @@ func TestPrerequisiteTracking(t *testing.T) {
 		}
 		require.Equal(t, wantUsage, callbacks.usage)
 		require.Equal(t, wantUsage, plugin.usage)
-		require.Equal(t, wantUsage, usages(t, tracking.FeatureUsage))
 	})
 
 	t.Run("a prerequisite consulted by several rules is reported once", func(t *testing.T) {
@@ -223,10 +213,11 @@ func TestPrerequisiteTracking(t *testing.T) {
 
 		require.Equal(t, "r2", res.Value)
 		require.Equal(t, []trackedExposure{{"parent-exp", 0, false, "parent"}}, callbacks.exposures)
+		require.Len(t, tracking, 1)
 		require.Equal(t, []trackedUsage{
 			{"parent", ExperimentResultSource},
 			{"child-twice", ForceResultSource},
-		}, usages(t, tracking.FeatureUsage))
+		}, callbacks.usage)
 	})
 
 	t.Run("no state leaks across evaluations, and no cross-call dedupe", func(t *testing.T) {
@@ -251,7 +242,7 @@ func TestEvalTrackingWithoutCallbacks(t *testing.T) {
 	require.Equal(t, []trackedExposure{
 		{"ramp2", 1, true, "ramped-into-experiment"},
 		{"exp2", 0, false, "ramped-into-experiment"},
-	}, exposures(t, tracking.Experiments))
+	}, exposures(t, tracking))
 }
 
 func TestRunExperimentTracking(t *testing.T) {
@@ -277,8 +268,8 @@ func TestRunExperimentTracking(t *testing.T) {
 			{"direct", 0, false, ""},
 		}
 		require.Equal(t, want, callbacks.exposures)
-		require.Equal(t, want, exposures(t, tracking.Experiments))
-		require.Equal(t, []trackedUsage{{"parent", ExperimentResultSource}}, usages(t, tracking.FeatureUsage))
+		require.Equal(t, want, exposures(t, tracking))
+		require.Equal(t, []trackedUsage{{"parent", ExperimentResultSource}}, callbacks.usage)
 	})
 
 	t.Run("forced variations are served but not tracked (JS parity)", func(t *testing.T) {
@@ -293,7 +284,7 @@ func TestRunExperimentTracking(t *testing.T) {
 
 		require.Empty(t, callbacks.exposures)
 		require.Empty(t, plugin.exposures)
-		require.Empty(t, tracking.Experiments)
+		require.Empty(t, tracking)
 	})
 }
 
@@ -306,7 +297,7 @@ func TestFeatureUsageEdgeCases(t *testing.T) {
 
 		require.Equal(t, UnknownFeatureResultSource, res.Source)
 		require.Equal(t, []trackedUsage{{"no-such-feature", UnknownFeatureResultSource}}, callbacks.usage)
-		require.Empty(t, tracking.Experiments)
+		require.Empty(t, tracking)
 	})
 
 	t.Run("cyclic prerequisites report each feature once", func(t *testing.T) {
@@ -355,8 +346,7 @@ func TestConcurrentEvaluationsAreIsolated(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_, tracking := client.EvalFeatureWithTracking(ctx, "child")
-			require.Len(t, tracking.Experiments, 1)
-			require.Len(t, tracking.FeatureUsage, 2)
+			require.Len(t, tracking, 1)
 		}()
 	}
 	wg.Wait()

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -126,7 +126,7 @@ func newTrackingTestClient(t *testing.T, extra ...ClientOption) (*Client, *track
 		WithJsonFeatures(trackingFeaturesJSON),
 		WithAttributes(Attributes{"id": "user-1"}),
 		WithDeferredTracking(),
-		WithExperimentCallback(func(ctx context.Context, exp *Experiment, res *ExperimentResult, _ any) {
+		WithExperimentCallback(func(ctx context.Context, exp *Experiment, res *ExperimentResult, _ *TrackingUserContext, _ any) {
 			callbacks.OnExperimentViewed(ctx, exp, res)
 		}),
 		WithFeatureUsageCallback(func(ctx context.Context, key string, res *FeatureResult, _ any) {
@@ -328,7 +328,29 @@ func TestDeferredTracking(t *testing.T) {
 		calls := shared.DeferredTrackingCalls()
 		require.Len(t, calls, 2)
 		require.NotEqual(t, calls[0].Result.HashValue, calls[1].Result.HashValue)
+		require.Equal(t, "user-1", calls[0].User.Attributes["id"])
+		require.Equal(t, "user-2", calls[1].User.Attributes["id"])
 	})
+}
+
+func TestExperimentCallbackUserContext(t *testing.T) {
+	ctx := context.Background()
+	var got *TrackingUserContext
+	client, err := NewClient(ctx,
+		WithJsonFeatures(trackingFeaturesJSON),
+		WithAttributes(Attributes{"id": "user-1"}),
+		WithUrl("http://example.com/checkout"),
+		WithExperimentCallback(func(_ context.Context, _ *Experiment, _ *ExperimentResult, userCtx *TrackingUserContext, _ any) {
+			got = userCtx
+		}),
+	)
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "ramped-treatment")
+	require.True(t, res.InExperiment())
+	require.NotNil(t, got)
+	require.Equal(t, "user-1", got.Attributes["id"])
+	require.Equal(t, "http://example.com/checkout", got.URL)
 }
 
 func TestRunExperimentTracking(t *testing.T) {
@@ -471,6 +493,8 @@ func TestTrackingDataShape(t *testing.T) {
 		for _, field := range []string{"inExperiment", "variationId", "value", "hashAttribute", "hashValue", "key", "passthrough"} {
 			require.Contains(t, m["result"], field)
 		}
+		require.Contains(t, m["user"], "attributes")
+		require.NotContains(t, m["user"], "url")
 	})
 }
 

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -457,13 +457,20 @@ func TestTrackingDataShape(t *testing.T) {
 		require.NotEqual(t, td.DedupeKey(), other.DedupeKey())
 	})
 
-	t.Run("serializes with the JS TrackingData field names", func(t *testing.T) {
-		b, err := json.Marshal(td)
+	t.Run("a real exposure serializes with the deferred tracking field names", func(t *testing.T) {
+		client, _, _ := newTrackingTestClient(t)
+		client.EvalFeature(context.Background(), "ramped-treatment")
+		calls := client.DeferredTrackingCalls()
+		require.Len(t, calls, 1)
+
+		b, err := json.Marshal(calls[0])
 		require.NoError(t, err)
-		var m map[string]json.RawMessage
+		var m map[string]map[string]json.RawMessage
 		require.NoError(t, json.Unmarshal(b, &m))
-		require.Contains(t, m, "experiment")
-		require.Contains(t, m, "result")
+		require.Equal(t, `"ramp-t"`, string(m["experiment"]["key"]))
+		for _, field := range []string{"inExperiment", "variationId", "value", "hashAttribute", "hashValue", "key", "passthrough"} {
+			require.Contains(t, m["result"], field)
+		}
 	})
 }
 

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -1,0 +1,374 @@
+package growthbook
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin what one evaluation reports through callbacks, plugins,
+// and the EvalTracking return value. Weights of [0,1] or [1,0] make every
+// assignment deterministic regardless of the hash attribute's value.
+//
+// "ramped" models a monitored ramp step: the treatment arm serves the rule's
+// value and the control arm is a passthrough variation, so control users
+// fall through to the rules below but their assignment is still an exposure.
+const trackingFeaturesJSON = `{
+  "ramped": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "ramp",
+        "coverage": 1,
+        "variations": ["treatment", "default"],
+        "weights": [0, 1],
+        "meta": [{"key": "0"}, {"key": "1", "passthrough": true}]
+      },
+      {"force": "fallthrough-value"}
+    ]
+  },
+  "ramped-treatment": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "ramp-t",
+        "coverage": 1,
+        "variations": ["treatment", "default"],
+        "weights": [1, 0],
+        "meta": [{"key": "0"}, {"key": "1", "passthrough": true}]
+      },
+      {"force": "fallthrough-value"}
+    ]
+  },
+  "ramped-into-experiment": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "ramp2",
+        "coverage": 1,
+        "variations": ["treatment", "default"],
+        "weights": [0, 1],
+        "meta": [{"key": "0"}, {"key": "1", "passthrough": true}]
+      },
+      {"key": "exp2", "coverage": 1, "variations": ["a", "b"], "weights": [1, 0]}
+    ]
+  },
+  "parent": {
+    "defaultValue": "off",
+    "rules": [
+      {"key": "parent-exp", "coverage": 1, "variations": ["on", "off"], "weights": [1, 0]}
+    ]
+  },
+  "child": {
+    "defaultValue": "child-default",
+    "rules": [
+      {"parentConditions": [{"id": "parent", "condition": {"value": "on"}}], "force": "child-on"}
+    ]
+  },
+  "child-twice": {
+    "defaultValue": "child-default",
+    "rules": [
+      {"parentConditions": [{"id": "parent", "condition": {"value": "nope"}}], "force": "r1"},
+      {"parentConditions": [{"id": "parent", "condition": {"value": "on"}}], "force": "r2"}
+    ]
+  },
+  "cycle-a": {
+    "defaultValue": "a-default",
+    "rules": [{"parentConditions": [{"id": "cycle-b", "condition": {"value": "x"}}], "force": "a-forced"}]
+  },
+  "cycle-b": {
+    "defaultValue": "b-default",
+    "rules": [{"parentConditions": [{"id": "cycle-a", "condition": {"value": "x"}}], "force": "b-forced"}]
+  }
+}`
+
+type trackedExposure struct {
+	key         string
+	variationId int
+	passthrough bool
+	featureId   string
+}
+
+type trackedUsage struct {
+	key    string
+	source FeatureResultSource
+}
+
+// trackingRecorder records what it is told; it doubles as a Plugin and as
+// the body of the two client callbacks.
+type trackingRecorder struct {
+	exposures []trackedExposure
+	usage     []trackedUsage
+}
+
+func (r *trackingRecorder) Init(*Client) error { return nil }
+func (r *trackingRecorder) Close() error       { return nil }
+func (r *trackingRecorder) OnExperimentViewed(_ context.Context, exp *Experiment, res *ExperimentResult) {
+	r.exposures = append(r.exposures, trackedExposure{exp.Key, res.VariationId, res.Passthrough, res.FeatureId})
+}
+func (r *trackingRecorder) OnFeatureEvaluated(_ context.Context, key string, res *FeatureResult) {
+	r.usage = append(r.usage, trackedUsage{key, res.Source})
+}
+
+func exposures(t *testing.T, data []TrackingData) []trackedExposure {
+	t.Helper()
+	out := make([]trackedExposure, 0, len(data))
+	for _, d := range data {
+		out = append(out, trackedExposure{d.Experiment.Key, d.Result.VariationId, d.Result.Passthrough, d.Result.FeatureId})
+	}
+	return out
+}
+
+func usages(t *testing.T, data []FeatureUsage) []trackedUsage {
+	t.Helper()
+	out := make([]trackedUsage, 0, len(data))
+	for _, d := range data {
+		out = append(out, trackedUsage{d.Key, d.Result.Source})
+	}
+	return out
+}
+
+func newTrackingTestClient(t *testing.T) (*Client, *trackingRecorder, *trackingRecorder) {
+	t.Helper()
+	plugin := &trackingRecorder{}
+	callbacks := &trackingRecorder{}
+	client, err := NewClient(context.Background(),
+		WithJsonFeatures(trackingFeaturesJSON),
+		WithAttributes(Attributes{"id": "user-1"}),
+		WithExperimentCallback(func(ctx context.Context, exp *Experiment, res *ExperimentResult, _ any) {
+			callbacks.OnExperimentViewed(ctx, exp, res)
+		}),
+		WithFeatureUsageCallback(func(ctx context.Context, key string, res *FeatureResult, _ any) {
+			callbacks.OnFeatureEvaluated(ctx, key, res)
+		}),
+		WithPlugins(plugin),
+	)
+	require.NoError(t, err)
+	return client, callbacks, plugin
+}
+
+func TestPassthroughAssignmentTracked(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("control arm falls through to a force rule and is tracked", func(t *testing.T) {
+		client, callbacks, plugin := newTrackingTestClient(t)
+		res, tracking := client.EvalFeatureWithTracking(ctx, "ramped")
+
+		require.Equal(t, "fallthrough-value", res.Value)
+		require.Equal(t, ForceResultSource, res.Source)
+		require.False(t, res.InExperiment())
+
+		want := []trackedExposure{{"ramp", 1, true, "ramped"}}
+		require.Equal(t, want, callbacks.exposures)
+		require.Equal(t, want, plugin.exposures)
+		require.Equal(t, want, exposures(t, tracking.Experiments))
+		require.Equal(t, []trackedUsage{{"ramped", ForceResultSource}}, usages(t, tracking.FeatureUsage))
+	})
+
+	t.Run("control arm falls through to an experiment rule: both tracked, in evaluation order", func(t *testing.T) {
+		client, callbacks, plugin := newTrackingTestClient(t)
+		res, tracking := client.EvalFeatureWithTracking(ctx, "ramped-into-experiment")
+
+		require.Equal(t, "a", res.Value)
+		require.True(t, res.InExperiment())
+
+		want := []trackedExposure{
+			{"ramp2", 1, true, "ramped-into-experiment"},
+			{"exp2", 0, false, "ramped-into-experiment"},
+		}
+		require.Equal(t, want, callbacks.exposures)
+		require.Equal(t, want, plugin.exposures)
+		require.Equal(t, want, exposures(t, tracking.Experiments))
+	})
+
+	t.Run("treatment arm serves the rule value with a single exposure", func(t *testing.T) {
+		client, callbacks, plugin := newTrackingTestClient(t)
+		res, tracking := client.EvalFeatureWithTracking(ctx, "ramped-treatment")
+
+		require.Equal(t, "treatment", res.Value)
+		require.True(t, res.InExperiment())
+
+		want := []trackedExposure{{"ramp-t", 0, false, "ramped-treatment"}}
+		require.Equal(t, want, callbacks.exposures)
+		require.Equal(t, want, plugin.exposures)
+		require.Equal(t, want, exposures(t, tracking.Experiments))
+	})
+}
+
+func TestPrerequisiteTracking(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a prerequisite's experiment assignment is tracked", func(t *testing.T) {
+		client, callbacks, plugin := newTrackingTestClient(t)
+		res, tracking := client.EvalFeatureWithTracking(ctx, "child")
+
+		require.Equal(t, "child-on", res.Value)
+
+		wantExposures := []trackedExposure{{"parent-exp", 0, false, "parent"}}
+		require.Equal(t, wantExposures, callbacks.exposures)
+		require.Equal(t, wantExposures, plugin.exposures)
+		require.Equal(t, wantExposures, exposures(t, tracking.Experiments))
+
+		wantUsage := []trackedUsage{
+			{"parent", ExperimentResultSource},
+			{"child", ForceResultSource},
+		}
+		require.Equal(t, wantUsage, callbacks.usage)
+		require.Equal(t, wantUsage, plugin.usage)
+		require.Equal(t, wantUsage, usages(t, tracking.FeatureUsage))
+	})
+
+	t.Run("a prerequisite consulted by several rules is reported once", func(t *testing.T) {
+		client, callbacks, _ := newTrackingTestClient(t)
+		res, tracking := client.EvalFeatureWithTracking(ctx, "child-twice")
+
+		require.Equal(t, "r2", res.Value)
+		require.Equal(t, []trackedExposure{{"parent-exp", 0, false, "parent"}}, callbacks.exposures)
+		require.Equal(t, []trackedUsage{
+			{"parent", ExperimentResultSource},
+			{"child-twice", ForceResultSource},
+		}, usages(t, tracking.FeatureUsage))
+	})
+
+	t.Run("no state leaks across evaluations, and no cross-call dedupe", func(t *testing.T) {
+		// Repeated exposures across calls are fine: the analysis layer
+		// dedupes exposures at the query level.
+		client, callbacks, _ := newTrackingTestClient(t)
+		client.EvalFeature(ctx, "child")
+		client.EvalFeature(ctx, "child")
+		require.Len(t, callbacks.exposures, 2)
+		require.Len(t, callbacks.usage, 4)
+	})
+}
+
+func TestEvalTrackingWithoutCallbacks(t *testing.T) {
+	// A remote-eval style server configures no callbacks or plugins and
+	// reads the tracking data from the return value instead. It must be
+	// complete when the call returns.
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(trackingFeaturesJSON),
+		WithAttributes(Attributes{"id": "user-1"}),
+	)
+	require.NoError(t, err)
+
+	res, tracking := client.EvalFeatureWithTracking(ctx, "ramped-into-experiment")
+	require.Equal(t, "a", res.Value)
+	require.Equal(t, []trackedExposure{
+		{"ramp2", 1, true, "ramped-into-experiment"},
+		{"exp2", 0, false, "ramped-into-experiment"},
+	}, exposures(t, tracking.Experiments))
+}
+
+func TestRunExperimentTracking(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("direct experiment and its prerequisite assignments are both reported", func(t *testing.T) {
+		client, callbacks, _ := newTrackingTestClient(t)
+		var exp Experiment
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"key": "direct",
+			"variations": ["x", "y"],
+			"weights": [1, 0],
+			"coverage": 1,
+			"parentConditions": [{"id": "parent", "condition": {"value": "on"}}]
+		}`), &exp))
+
+		res, tracking := client.RunExperimentWithTracking(ctx, &exp)
+		require.True(t, res.InExperiment)
+		require.Equal(t, "x", res.Value)
+
+		want := []trackedExposure{
+			{"parent-exp", 0, false, "parent"},
+			{"direct", 0, false, ""},
+		}
+		require.Equal(t, want, callbacks.exposures)
+		require.Equal(t, want, exposures(t, tracking.Experiments))
+		require.Equal(t, []trackedUsage{{"parent", ExperimentResultSource}}, usages(t, tracking.FeatureUsage))
+	})
+
+	t.Run("forced variations are served but not tracked (JS parity)", func(t *testing.T) {
+		client, callbacks, plugin := newTrackingTestClient(t)
+		force := 1
+		exp := Experiment{Key: "forced", Variations: []FeatureValue{"x", "y"}, Force: &force}
+
+		res, tracking := client.RunExperimentWithTracking(ctx, &exp)
+		require.True(t, res.InExperiment)
+		require.False(t, res.HashUsed)
+		require.Equal(t, "y", res.Value)
+
+		require.Empty(t, callbacks.exposures)
+		require.Empty(t, plugin.exposures)
+		require.Empty(t, tracking.Experiments)
+	})
+}
+
+func TestFeatureUsageEdgeCases(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unknown feature usage is reported", func(t *testing.T) {
+		client, callbacks, _ := newTrackingTestClient(t)
+		res, tracking := client.EvalFeatureWithTracking(ctx, "no-such-feature")
+
+		require.Equal(t, UnknownFeatureResultSource, res.Source)
+		require.Equal(t, []trackedUsage{{"no-such-feature", UnknownFeatureResultSource}}, callbacks.usage)
+		require.Empty(t, tracking.Experiments)
+	})
+
+	t.Run("cyclic prerequisites report each feature once", func(t *testing.T) {
+		client, callbacks, _ := newTrackingTestClient(t)
+		res, _ := client.EvalFeatureWithTracking(ctx, "cycle-a")
+
+		require.Equal(t, CyclicPrerequisiteResultSource, res.Source)
+		require.Equal(t, []trackedUsage{
+			{"cycle-a", CyclicPrerequisiteResultSource},
+			{"cycle-b", CyclicPrerequisiteResultSource},
+		}, callbacks.usage)
+	})
+}
+
+func TestTrackingDataShape(t *testing.T) {
+	td := TrackingData{
+		Experiment: &Experiment{Key: "exp"},
+		Result:     &ExperimentResult{HashAttribute: "id", HashValue: "u1", VariationId: 2},
+	}
+
+	t.Run("DedupeKey matches the JS SDK's getExperimentDedupeKey", func(t *testing.T) {
+		require.Equal(t, "idu1exp2", td.DedupeKey())
+	})
+
+	t.Run("serializes with the JS TrackingData field names", func(t *testing.T) {
+		b, err := json.Marshal(td)
+		require.NoError(t, err)
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(b, &m))
+		require.Contains(t, m, "experiment")
+		require.Contains(t, m, "result")
+	})
+}
+
+func TestConcurrentEvaluationsAreIsolated(t *testing.T) {
+	// Tracking state lives on the per-call evaluator, so concurrent
+	// evaluations on a shared client must each get their own complete data.
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(trackingFeaturesJSON),
+		WithAttributes(Attributes{"id": "user-1"}),
+	)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, tracking := client.EvalFeatureWithTracking(ctx, "child")
+			require.Len(t, tracking.Experiments, 1)
+			require.Len(t, tracking.FeatureUsage, 2)
+		}()
+	}
+	wg.Wait()
+}

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -3,6 +3,7 @@ package growthbook
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"sync"
 	"testing"
 
@@ -281,6 +282,25 @@ func TestDeferredTracking(t *testing.T) {
 		require.Equal(t, 0, again[0].Result.VariationId)
 	})
 
+	t.Run("unserializable exposures are dropped, not returned aliased", func(t *testing.T) {
+		client, callbacks, _ := newTrackingTestClient(t)
+		one := 1.0
+		exp := Experiment{
+			Key:        "nan-exp",
+			Variations: []FeatureValue{math.NaN(), "b"},
+			Weights:    []float64{1, 0},
+			Coverage:   &one,
+		}
+
+		res := client.RunExperiment(ctx, &exp)
+		require.True(t, res.InExperiment)
+		require.Len(t, callbacks.exposures, 1, "callbacks still fire for unserializable exposures")
+		require.Empty(t, client.DeferredTrackingCalls())
+
+		client.EvalFeature(ctx, "ramped-treatment")
+		require.Len(t, client.DeferredTrackingCalls(), 1, "a bad exposure must not poison later ones")
+	})
+
 	t.Run("nil without WithDeferredTracking", func(t *testing.T) {
 		client, err := NewClient(ctx,
 			WithJsonFeatures(trackingFeaturesJSON),
@@ -546,8 +566,7 @@ func TestTrackingDataShape(t *testing.T) {
 		require.Equal(t, []BucketRange{{Min: 0, Max: 1}, {Min: 0, Max: 0}}, got.Ranges)
 		require.Equal(t, exp.Filters, got.Filters)
 
-		_, err := detachTrackingData(calls)
-		require.NoError(t, err)
+		require.Len(t, client.detachTrackingData(calls), 1)
 
 		b, err := json.Marshal(calls[0])
 		require.NoError(t, err)

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -523,6 +523,38 @@ func TestTrackingDataShape(t *testing.T) {
 		require.NotEqual(t, td.DedupeKey(), other.DedupeKey())
 	})
 
+	t.Run("exposures with namespaces, ranges, and filters detach losslessly", func(t *testing.T) {
+		ctx := context.Background()
+		client, _, _ := newTrackingTestClient(t)
+		var exp Experiment
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"key": "kitchen-sink",
+			"variations": ["x", "y"],
+			"ranges": [[0, 1], [0, 0]],
+			"namespace": ["ns-1", 0, 1],
+			"filters": [{"seed": "s", "ranges": [[0, 1]], "attribute": "id", "hashVersion": 2}],
+			"meta": [{"key": "a"}, {"key": "b"}]
+		}`), &exp))
+
+		res := client.RunExperiment(ctx, &exp)
+		require.True(t, res.InExperiment)
+
+		calls := client.DeferredTrackingCalls()
+		require.Len(t, calls, 1)
+		got := calls[0].Experiment
+		require.Equal(t, &Namespace{Id: "ns-1", Start: 0, End: 1}, got.Namespace)
+		require.Equal(t, []BucketRange{{Min: 0, Max: 1}, {Min: 0, Max: 0}}, got.Ranges)
+		require.Equal(t, exp.Filters, got.Filters)
+
+		_, err := detachTrackingData(calls)
+		require.NoError(t, err)
+
+		b, err := json.Marshal(calls[0])
+		require.NoError(t, err)
+		require.Contains(t, string(b), `"namespace":["ns-1",0,1]`)
+		require.Contains(t, string(b), `"ranges":[[0,1],[0,0]]`)
+	})
+
 	t.Run("a real exposure serializes with the deferred tracking field names", func(t *testing.T) {
 		client, _, _ := newTrackingTestClient(t)
 		client.EvalFeature(context.Background(), "ramped-treatment")

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -125,6 +125,7 @@ func newTrackingTestClient(t *testing.T) (*Client, *trackingRecorder, *trackingR
 	client, err := NewClient(context.Background(),
 		WithJsonFeatures(trackingFeaturesJSON),
 		WithAttributes(Attributes{"id": "user-1"}),
+		WithDeferredTracking(),
 		WithExperimentCallback(func(ctx context.Context, exp *Experiment, res *ExperimentResult, _ any) {
 			callbacks.OnExperimentViewed(ctx, exp, res)
 		}),
@@ -142,7 +143,7 @@ func TestPassthroughAssignmentTracked(t *testing.T) {
 
 	t.Run("control arm falls through to a force rule and is tracked", func(t *testing.T) {
 		client, callbacks, plugin := newTrackingTestClient(t)
-		res, tracking := client.EvalFeatureWithTracking(ctx, "ramped")
+		res := client.EvalFeature(ctx, "ramped")
 
 		require.Equal(t, "fallthrough-value", res.Value)
 		require.Equal(t, ForceResultSource, res.Source)
@@ -151,13 +152,13 @@ func TestPassthroughAssignmentTracked(t *testing.T) {
 		want := []trackedExposure{{"ramp", 1, true, "ramped"}}
 		require.Equal(t, want, callbacks.exposures)
 		require.Equal(t, want, plugin.exposures)
-		require.Equal(t, want, exposures(t, tracking))
+		require.Equal(t, want, exposures(t, client.DeferredTrackingCalls()))
 		require.Equal(t, []trackedUsage{{"ramped", ForceResultSource}}, callbacks.usage)
 	})
 
 	t.Run("control arm falls through to an experiment rule: both tracked, in evaluation order", func(t *testing.T) {
 		client, callbacks, plugin := newTrackingTestClient(t)
-		res, tracking := client.EvalFeatureWithTracking(ctx, "ramped-into-experiment")
+		res := client.EvalFeature(ctx, "ramped-into-experiment")
 
 		require.Equal(t, "a", res.Value)
 		require.True(t, res.InExperiment())
@@ -168,12 +169,12 @@ func TestPassthroughAssignmentTracked(t *testing.T) {
 		}
 		require.Equal(t, want, callbacks.exposures)
 		require.Equal(t, want, plugin.exposures)
-		require.Equal(t, want, exposures(t, tracking))
+		require.Equal(t, want, exposures(t, client.DeferredTrackingCalls()))
 	})
 
 	t.Run("treatment arm serves the rule value with a single exposure", func(t *testing.T) {
 		client, callbacks, plugin := newTrackingTestClient(t)
-		res, tracking := client.EvalFeatureWithTracking(ctx, "ramped-treatment")
+		res := client.EvalFeature(ctx, "ramped-treatment")
 
 		require.Equal(t, "treatment", res.Value)
 		require.True(t, res.InExperiment())
@@ -181,7 +182,7 @@ func TestPassthroughAssignmentTracked(t *testing.T) {
 		want := []trackedExposure{{"ramp-t", 0, false, "ramped-treatment"}}
 		require.Equal(t, want, callbacks.exposures)
 		require.Equal(t, want, plugin.exposures)
-		require.Equal(t, want, exposures(t, tracking))
+		require.Equal(t, want, exposures(t, client.DeferredTrackingCalls()))
 	})
 }
 
@@ -190,14 +191,14 @@ func TestPrerequisiteTracking(t *testing.T) {
 
 	t.Run("a prerequisite's experiment assignment is tracked", func(t *testing.T) {
 		client, callbacks, plugin := newTrackingTestClient(t)
-		res, tracking := client.EvalFeatureWithTracking(ctx, "child")
+		res := client.EvalFeature(ctx, "child")
 
 		require.Equal(t, "child-on", res.Value)
 
 		wantExposures := []trackedExposure{{"parent-exp", 0, false, "parent"}}
 		require.Equal(t, wantExposures, callbacks.exposures)
 		require.Equal(t, wantExposures, plugin.exposures)
-		require.Equal(t, wantExposures, exposures(t, tracking))
+		require.Equal(t, wantExposures, exposures(t, client.DeferredTrackingCalls()))
 
 		wantUsage := []trackedUsage{
 			{"parent", ExperimentResultSource},
@@ -209,40 +210,99 @@ func TestPrerequisiteTracking(t *testing.T) {
 
 	t.Run("a prerequisite consulted by several rules is reported once", func(t *testing.T) {
 		client, callbacks, _ := newTrackingTestClient(t)
-		res, tracking := client.EvalFeatureWithTracking(ctx, "child-twice")
+		res := client.EvalFeature(ctx, "child-twice")
 
 		require.Equal(t, "r2", res.Value)
 		require.Equal(t, []trackedExposure{{"parent-exp", 0, false, "parent"}}, callbacks.exposures)
-		require.Len(t, tracking, 1)
 		require.Equal(t, []trackedUsage{
 			{"parent", ExperimentResultSource},
 			{"child-twice", ForceResultSource},
 		}, callbacks.usage)
 	})
 
-	t.Run("no state leaks across evaluations, and no cross-call dedupe", func(t *testing.T) {
+	t.Run("callbacks fire per call; the deferred buffer dedupes across calls", func(t *testing.T) {
 		client, callbacks, _ := newTrackingTestClient(t)
 		client.EvalFeature(ctx, "child")
 		client.EvalFeature(ctx, "child")
+
 		require.Len(t, callbacks.exposures, 2)
 		require.Len(t, callbacks.usage, 4)
+		require.Len(t, client.DeferredTrackingCalls(), 1)
 	})
 }
 
-func TestEvalTrackingWithoutCallbacks(t *testing.T) {
+func TestDeferredTracking(t *testing.T) {
 	ctx := context.Background()
-	client, err := NewClient(ctx,
-		WithJsonFeatures(trackingFeaturesJSON),
-		WithAttributes(Attributes{"id": "user-1"}),
-	)
-	require.NoError(t, err)
 
-	res, tracking := client.EvalFeatureWithTracking(ctx, "ramped-into-experiment")
-	require.Equal(t, "a", res.Value)
-	require.Equal(t, []trackedExposure{
-		{"ramp2", 1, true, "ramped-into-experiment"},
-		{"exp2", 0, false, "ramped-into-experiment"},
-	}, exposures(t, tracking))
+	t.Run("works without callbacks or plugins", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithDeferredTracking(),
+		)
+		require.NoError(t, err)
+
+		client.EvalFeature(ctx, "ramped-into-experiment")
+		require.Equal(t, []trackedExposure{
+			{"ramp2", 1, true, "ramped-into-experiment"},
+			{"exp2", 0, false, "ramped-into-experiment"},
+		}, exposures(t, client.DeferredTrackingCalls()))
+	})
+
+	t.Run("accumulates across evaluations and clears", func(t *testing.T) {
+		client, _, _ := newTrackingTestClient(t)
+		client.EvalFeature(ctx, "ramped")
+		client.EvalFeature(ctx, "child")
+
+		require.Equal(t, []trackedExposure{
+			{"ramp", 1, true, "ramped"},
+			{"parent-exp", 0, false, "parent"},
+		}, exposures(t, client.DeferredTrackingCalls()))
+
+		client.ClearDeferredTrackingCalls()
+		require.Empty(t, client.DeferredTrackingCalls())
+
+		client.EvalFeature(ctx, "ramped")
+		require.Len(t, client.DeferredTrackingCalls(), 1)
+	})
+
+	t.Run("nil without WithDeferredTracking", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+		)
+		require.NoError(t, err)
+		client.EvalFeature(ctx, "ramped")
+		require.Nil(t, client.DeferredTrackingCalls())
+		client.ClearDeferredTrackingCalls()
+	})
+
+	t.Run("children armed separately have isolated buffers", func(t *testing.T) {
+		base, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+		)
+		require.NoError(t, err)
+
+		child1, err := base.WithDeferredTracking()
+		require.NoError(t, err)
+		child2, err := base.WithDeferredTracking()
+		require.NoError(t, err)
+
+		child1.EvalFeature(ctx, "ramped")
+		require.Len(t, child1.DeferredTrackingCalls(), 1)
+		require.Empty(t, child2.DeferredTrackingCalls())
+		require.Nil(t, base.DeferredTrackingCalls())
+	})
+
+	t.Run("clones of an armed client share its buffer", func(t *testing.T) {
+		client, _, _ := newTrackingTestClient(t)
+		child, err := client.WithExtraData("request-scoped")
+		require.NoError(t, err)
+
+		child.EvalFeature(ctx, "ramped")
+		require.Len(t, client.DeferredTrackingCalls(), 1)
+	})
 }
 
 func TestRunExperimentTracking(t *testing.T) {
@@ -259,7 +319,7 @@ func TestRunExperimentTracking(t *testing.T) {
 			"parentConditions": [{"id": "parent", "condition": {"value": "on"}}]
 		}`), &exp))
 
-		res, tracking := client.RunExperimentWithTracking(ctx, &exp)
+		res := client.RunExperiment(ctx, &exp)
 		require.True(t, res.InExperiment)
 		require.Equal(t, "x", res.Value)
 
@@ -268,7 +328,7 @@ func TestRunExperimentTracking(t *testing.T) {
 			{"direct", 0, false, ""},
 		}
 		require.Equal(t, want, callbacks.exposures)
-		require.Equal(t, want, exposures(t, tracking))
+		require.Equal(t, want, exposures(t, client.DeferredTrackingCalls()))
 		require.Equal(t, []trackedUsage{{"parent", ExperimentResultSource}}, callbacks.usage)
 	})
 
@@ -277,14 +337,14 @@ func TestRunExperimentTracking(t *testing.T) {
 		force := 1
 		exp := Experiment{Key: "forced", Variations: []FeatureValue{"x", "y"}, Force: &force}
 
-		res, tracking := client.RunExperimentWithTracking(ctx, &exp)
+		res := client.RunExperiment(ctx, &exp)
 		require.True(t, res.InExperiment)
 		require.False(t, res.HashUsed)
 		require.Equal(t, "y", res.Value)
 
 		require.Empty(t, callbacks.exposures)
 		require.Empty(t, plugin.exposures)
-		require.Empty(t, tracking)
+		require.Empty(t, client.DeferredTrackingCalls())
 	})
 }
 
@@ -293,16 +353,16 @@ func TestFeatureUsageEdgeCases(t *testing.T) {
 
 	t.Run("unknown feature usage is reported", func(t *testing.T) {
 		client, callbacks, _ := newTrackingTestClient(t)
-		res, tracking := client.EvalFeatureWithTracking(ctx, "no-such-feature")
+		res := client.EvalFeature(ctx, "no-such-feature")
 
 		require.Equal(t, UnknownFeatureResultSource, res.Source)
 		require.Equal(t, []trackedUsage{{"no-such-feature", UnknownFeatureResultSource}}, callbacks.usage)
-		require.Empty(t, tracking)
+		require.Empty(t, client.DeferredTrackingCalls())
 	})
 
 	t.Run("cyclic prerequisites report each feature once", func(t *testing.T) {
 		client, callbacks, _ := newTrackingTestClient(t)
-		res, _ := client.EvalFeatureWithTracking(ctx, "cycle-a")
+		res := client.EvalFeature(ctx, "cycle-a")
 
 		require.Equal(t, CyclicPrerequisiteResultSource, res.Source)
 		require.Equal(t, []trackedUsage{
@@ -332,11 +392,12 @@ func TestTrackingDataShape(t *testing.T) {
 	})
 }
 
-func TestConcurrentEvaluationsAreIsolated(t *testing.T) {
+func TestConcurrentDeferredTracking(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClient(ctx,
 		WithJsonFeatures(trackingFeaturesJSON),
 		WithAttributes(Attributes{"id": "user-1"}),
+		WithDeferredTracking(),
 	)
 	require.NoError(t, err)
 
@@ -345,9 +406,14 @@ func TestConcurrentEvaluationsAreIsolated(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, tracking := client.EvalFeatureWithTracking(ctx, "child")
-			require.Len(t, tracking, 1)
+			client.EvalFeature(ctx, "child")
+			client.EvalFeature(ctx, "ramped")
 		}()
 	}
 	wg.Wait()
+
+	require.ElementsMatch(t, []trackedExposure{
+		{"parent-exp", 0, false, "parent"},
+		{"ramp", 1, true, "ramped"},
+	}, exposures(t, client.DeferredTrackingCalls()))
 }

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -351,6 +351,12 @@ func TestExperimentCallbackUserContext(t *testing.T) {
 	require.NotNil(t, got)
 	require.Equal(t, "user-1", got.Attributes["id"])
 	require.Equal(t, "http://example.com/checkout", got.URL)
+
+	child, err := client.WithAttributes(Attributes{"id": "user-2"})
+	require.NoError(t, err)
+	child.EvalFeature(ctx, "ramped-treatment")
+	require.Equal(t, "user-2", got.Attributes["id"])
+	require.Equal(t, "http://example.com/checkout", got.URL)
 }
 
 func TestRunExperimentTracking(t *testing.T) {

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -374,12 +374,16 @@ func TestRunExperimentTracking(t *testing.T) {
 	})
 
 	t.Run("client-forced variations are served but not tracked (JS parity)", func(t *testing.T) {
-		client, callbacks, _ := newTrackingTestClient(t, WithForcedVariations(ForcedVariationsMap{"map-forced": 1}))
+		client, callbacks, _ := newTrackingTestClient(t,
+			WithForcedVariations(ForcedVariationsMap{"map-forced": 1, "parent-exp": 1}))
 
 		exp := Experiment{Key: "map-forced", Variations: []FeatureValue{"x", "y"}}
 		res := client.RunExperiment(ctx, &exp)
 		require.True(t, res.InExperiment)
 		require.Equal(t, "y", res.Value)
+
+		res2 := client.EvalFeature(ctx, "parent")
+		require.Equal(t, "off", res2.Value)
 
 		require.Empty(t, callbacks.exposures)
 		require.Empty(t, client.DeferredTrackingCalls())
@@ -441,8 +445,16 @@ func TestTrackingDataShape(t *testing.T) {
 		Result:     &ExperimentResult{HashAttribute: "id", HashValue: "u1", VariationId: 2},
 	}
 
-	t.Run("DedupeKey matches the JS SDK's getExperimentDedupeKey", func(t *testing.T) {
-		require.Equal(t, "idu1exp2", td.DedupeKey())
+	t.Run("DedupeKey dedupes by the JS SDK's getExperimentDedupeKey fields", func(t *testing.T) {
+		require.Equal(t, "id\x00u1\x00exp\x002", td.DedupeKey())
+	})
+
+	t.Run("DedupeKey does not collide on field boundaries", func(t *testing.T) {
+		other := TrackingData{
+			Experiment: &Experiment{Key: "1exp"},
+			Result:     &ExperimentResult{HashAttribute: "id", HashValue: "u", VariationId: 2},
+		}
+		require.NotEqual(t, td.DedupeKey(), other.DedupeKey())
 	})
 
 	t.Run("serializes with the JS TrackingData field names", func(t *testing.T) {

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -371,6 +371,73 @@ func TestRunExperimentTracking(t *testing.T) {
 		require.Empty(t, plugin.exposures)
 		require.Empty(t, client.DeferredTrackingCalls())
 	})
+
+	t.Run("client-forced variations are served but not tracked (JS parity)", func(t *testing.T) {
+		var seen []string
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithDeferredTracking(),
+			WithForcedVariations(ForcedVariationsMap{"map-forced": 1}),
+			WithExperimentCallback(func(_ context.Context, exp *Experiment, _ *ExperimentResult, _ any) {
+				seen = append(seen, exp.Key)
+			}),
+		)
+		require.NoError(t, err)
+
+		exp := Experiment{Key: "map-forced", Variations: []FeatureValue{"x", "y"}}
+		res := client.RunExperiment(ctx, &exp)
+		require.True(t, res.InExperiment)
+		require.Equal(t, "y", res.Value)
+
+		require.Empty(t, seen)
+		require.Empty(t, client.DeferredTrackingCalls())
+	})
+
+	t.Run("querystring overrides are served but not tracked (JS parity)", func(t *testing.T) {
+		var seen []string
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithDeferredTracking(),
+			WithUrl("http://example.com/?qs-exp=1"),
+			WithExperimentCallback(func(_ context.Context, exp *Experiment, _ *ExperimentResult, _ any) {
+				seen = append(seen, exp.Key)
+			}),
+		)
+		require.NoError(t, err)
+
+		exp := Experiment{Key: "qs-exp", Variations: []FeatureValue{"x", "y"}}
+		res := client.RunExperiment(ctx, &exp)
+		require.True(t, res.InExperiment)
+		require.Equal(t, "y", res.Value)
+
+		require.Empty(t, seen)
+		require.Empty(t, client.DeferredTrackingCalls())
+	})
+
+	t.Run("sticky bucket assignments are tracked", func(t *testing.T) {
+		var seen []trackedExposure
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithDeferredTracking(),
+			WithStickyBucketService(NewInMemoryStickyBucketService()),
+			WithExperimentCallback(func(_ context.Context, exp *Experiment, res *ExperimentResult, _ any) {
+				seen = append(seen, trackedExposure{exp.Key, res.VariationId, res.Passthrough, res.FeatureId})
+			}),
+		)
+		require.NoError(t, err)
+
+		first := client.EvalFeature(ctx, "ramped-treatment")
+		require.False(t, first.ExperimentResult.StickyBucketUsed)
+		second := client.EvalFeature(ctx, "ramped-treatment")
+		require.True(t, second.ExperimentResult.StickyBucketUsed)
+
+		want := trackedExposure{"ramp-t", 0, false, "ramped-treatment"}
+		require.Equal(t, []trackedExposure{want, want}, seen)
+		require.Len(t, client.DeferredTrackingCalls(), 1)
+	})
 }
 
 func TestFeatureUsageEdgeCases(t *testing.T) {

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -456,11 +456,13 @@ func TestRunExperimentTracking(t *testing.T) {
 		res := client.RunExperiment(ctx, &exp)
 		require.True(t, res.InExperiment)
 		exp.Key = "mutated"
+		exp.Variations[0] = "mutated-in-place"
 		res.VariationId = 99
 
 		calls := client.DeferredTrackingCalls()
 		require.Len(t, calls, 1)
 		require.Equal(t, "direct", calls[0].Experiment.Key)
+		require.Equal(t, FeatureValue("x"), calls[0].Experiment.Variations[0])
 		require.Equal(t, 0, calls[0].Result.VariationId)
 		require.Equal(t, []trackedExposure{{"direct", 0, false, ""}}, callbacks.exposures)
 	})


### PR DESCRIPTION
### What's broken

The SDK only reports the experiment that decided the final value of the feature you asked for. Anything else that happens during evaluation is never tracked:

- **Passthrough assignments** — e.g. the control arm of a monitored ramp step. Users get the right values, but no control exposures are ever recorded, so the ramp's health check sees an empty control arm and holds the step. (#83 fixes this piece.)
- **Prerequisite experiments** — if a prerequisite feature is decided by an experiment, the user gets bucketed but the exposure is never tracked.
- **Prerequisite feature usage** — feature-usage callbacks never fire for prerequisite features.

### What this PR does

Records everything during evaluation — every feature evaluated and every experiment assignment made — and reports it all through the existing callbacks and plugins, in order. This matches how the JS SDK behaves.

For servers that don't track exposures themselves but forward them to client SDKs (remote evaluation), there's a deferred tracking mode — the Go version of the JS SDK's deferred tracking queue. The buffer lives on the client you arm, and the natural place to arm it is the per-request child client, which is Go's user context:

```go
child, _ := client.WithAttributes(attrs)  // one per user request
child, _ = child.WithDeferredTracking()

child.EvalFeature(ctx, "feature-a")       // standard eval methods, no variants
child.EvalFeature(ctx, "feature-b")

exposures := child.DeferredTrackingCalls()
// every assignment the request produced, passthrough + prerequisites
// included, deduped, in first-seen order
```

The buffer is mutex-guarded and isolated per armed client; clones made from an armed client share its buffer, and re-arming gives a fresh one. It serializes to the same shape as the JS SDK's tracking data, so it can be handed to a JS client's `setDeferredTrackingCalls` as-is. `ClearDeferredTrackingCalls` empties it. Feature-usage logs are deliberately not buffered — usage is telemetry about where evaluation happened, and remote-eval clients report their own; it still reaches the server's callbacks and plugins.

Dedupe scope follows the JS SDK: callbacks dedupe within one evaluation, and the buffer — which has a user context — dedupes over its lifetime. Across separate un-buffered calls nothing is filtered; analysis already dedupes exposures at query time.

`ExperimentCallback` also gains a typed `TrackingUserContext` parameter — the attributes and URL the evaluation ran with, the JS SDK `trackingCallback`'s user argument. This is the one **compile-visible breaking change**: existing callbacks add one parameter. The same user context is stamped on each buffered `TrackingData` as its `user` field (snapshotted at evaluation time, so a shared buffer keeps per-user context), which is what a JS client's `fireDeferredTrackingCalls` passes to its callback. `EventUserContext` becomes an alias of `TrackingUserContext`; event logger code is unaffected. Upcoming features (e.g. contextual bandits) need the user context at exposure time, so one migration now beats two.

When no callbacks, plugins, or buffer are configured, evaluation skips tracking collection entirely — consumer-less `EvalFeature` benchmarks match `main`.

### Behavior and API changes (all matching JS)

1. **Breaking:** `ExperimentCallback` is now `func(ctx, experiment, result, userCtx *TrackingUserContext, extraData any)` — existing callbacks add the one `userCtx` parameter to compile. Everything else is additive.
2. `EvalFeature` now tracks passthrough and prerequisite assignments, and reports prerequisite feature usage.
3. `Namespace` and `BucketRange` now marshal as their payload tuple forms (`[id, start, end]`, `[min, max]`) instead of structs that couldn't be re-parsed — experiment JSON round-trips and matches what other SDKs emit. Found via the deferred-tracking deep copy, but applies to all marshaling.
4. Forced variations (`force`, client-forced, querystring overrides) no longer fire tracking callbacks — from `RunExperiment` or from a feature's experiment rules in `EvalFeature`. The JS SDK never tracked these, since they aren't randomized exposures. Easy to drop this change if you'd rather keep the old behavior.

### Docs

The README's Tracking section gains a "Deferred Tracking" subsection, and the changelog describes each behavior change.

### Testing

- New `tracking_test.go` covers all of the above: passthrough and prerequisite tracking (these fail on `main`/v0.3.0), ordering, both dedupe scopes, buffer read/clear, buffer sharing across clones and isolation between armed clients, multi-user buffers, sticky-bucket assignments (tracked), forced/client-forced/querystring variations (not tracked), and concurrent use of a shared armed client.
- `go test -race ./...` passes, with the `cases.json` conformance suite unchanged.

### Known gaps, out of scope here

- The forwarded `experiment.condition` serializes as `{}` (`condition.Base` has no marshaler) — harmless to deferred tracking, but the forwarded experiment isn't full-fidelity.
- Pre-existing parity gaps untouched by this PR: force rules' `tracks` arrays aren't parsed or fired, and `EventLogger` doesn't emit `experiment_viewed`/`feature_evaluated` the way JS's `eventLogger` does.

Follow-up: these behaviors belong in the shared `cases.json` suite so every SDK pins them; that needs coordination in the main repo.
