### PR TITLE
Add contextual bandit support; serve null from force:null rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ All notable changes to this project will be documented in this file.
   condition matches the user supplies the weights; with no match, the rule's
   aggregate weights apply under a fallback leaf. Assignments carry `leafId`,
   `variationWeights`, and `banditVersion` on `ExperimentResult` — and on
-  forwarded deferred-tracking data. Previously bandit rules were skipped and
-  served the next rule or the default value.
+  forwarded deferred-tracking data. Definitions decode leniently: a
+  malformed one is dropped (its rules fall back to aggregate weights) and
+  never blocks the feature update it arrived with. Previously bandit rules
+  were skipped and served the next rule or the default value.
 - **Bugfix (JS parity):** a feature rule of `{"force": null}` now serves
   `null` with source `force`, as the JS SDK does. Previously a null force
   was indistinguishable from an absent one, so the rule was skipped and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
   `variationWeights`, and `banditVersion` on `ExperimentResult` — and on
   forwarded deferred-tracking data. Previously bandit rules were skipped and
   served the next rule or the default value.
+- **Bugfix (JS parity):** a feature rule of `{"force": null}` now serves
+  `null` with source `force`, as the JS SDK does. Previously a null force
+  was indistinguishable from an absent one, so the rule was skipped and the
+  next rule or default value was served.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Added contextual bandit support (JS parity): feature rules carrying a
+  `contextualBanditRef` now evaluate using the per-context variation weights
+  from the payload's `contextualBandits` definitions (encrypted payloads
+  supported, plus a `WithContextualBandits` option and
+  `SetContextualBandits` for manual setup). The first context whose
+  condition matches the user supplies the weights; with no match, the rule's
+  aggregate weights apply under a fallback leaf. Assignments carry `leafId`,
+  `variationWeights`, and `banditVersion` on `ExperimentResult` — and on
+  forwarded deferred-tracking data. Previously bandit rules were skipped and
+  served the next rule or the default value.
+
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
 - **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [v0.5.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.5.0) - 2026-08-28
 
 - Added contextual bandit support (JS parity): feature rules carrying a
   `contextualBanditRef` now evaluate using the per-context variation weights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to this project will be documented in this file.
   `null` with source `force`, as the JS SDK does. Previously a null force
   was indistinguishable from an absent one, so the rule was skipped and the
   next rule or default value was served.
+- **Behavior change:** rule and experiment conditions now marshal as their
+  parsed content in canonical form instead of `{}`, so feature JSON survives
+  a marshal/unmarshal round trip. Previously a reloaded gated rule lost its
+  condition and applied unconditionally.
+- Deliberate divergence from the JS SDK: sticky-bucketed assignments on
+  bandit rules carry no bandit attribution, since the leaf weights did not
+  produce the assignment. GrowthBook disables sticky bucketing on bandit
+  rules, so served payloads never hit this path.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ All notable changes to this project will be documented in this file.
   condition matches the user supplies the weights; with no match, the rule's
   aggregate weights apply under a fallback leaf. Assignments carry `leafId`,
   `variationWeights`, and `banditVersion` on `ExperimentResult` — and on
-  forwarded deferred-tracking data. Definitions decode leniently: a
-  malformed one is dropped (its rules fall back to aggregate weights) and
-  never blocks the feature update it arrived with. Previously bandit rules
-  were skipped and served the next rule or the default value.
+  forwarded deferred-tracking data. Definitions decode leniently and never
+  block the feature update they arrived with: a malformed definition is
+  dropped (its rules fall back to aggregate weights), and a malformed
+  context within a definition is dropped while its siblings are kept.
+  Previously bandit rules were skipped and served the next rule or the
+  default value.
 - **Bugfix (JS parity):** a feature rule of `{"force": null}` now serves
   `null` with source `force`, as the JS SDK does. Previously a null force
   was indistinguishable from an absent one, so the rule was skipped and the
@@ -24,10 +26,14 @@ All notable changes to this project will be documented in this file.
   parsed content in canonical form instead of `{}`, so feature JSON survives
   a marshal/unmarshal round trip. Previously a reloaded gated rule lost its
   condition and applied unconditionally.
-- Deliberate divergence from the JS SDK: sticky-bucketed assignments on
-  bandit rules carry no bandit attribution, since the leaf weights did not
-  produce the assignment. GrowthBook disables sticky bucketing on bandit
-  rules, so served payloads never hit this path.
+- Deliberate divergences from the JS SDK, all in favor of truthful bandit
+  exposures: sticky-bucketed assignments on bandit rules carry no bandit
+  attribution (the leaf weights did not produce the assignment; GrowthBook
+  disables sticky bucketing on bandit rules, so served payloads never hit
+  this path); reported `variationWeights` are the sanitized weights the
+  assignment actually used, where the JS SDK reports raw invalid weights;
+  and a type-malformed context is dropped rather than routed with junk
+  attribution.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -263,29 +263,6 @@ Plugins are shared with child clients. Any panics in plugin methods are recovere
 
 ---
 
-### Contextual Bandits
-
-Contextual bandit experiments reweight their variations per user segment.
-The GrowthBook API serves each bandit's per-context weights in the SDK
-payload alongside features (encrypted payloads included), and the SDK uses
-the first context whose condition matches the user — no extra setup needed.
-
-Assignments made by a bandit carry their attribution — `LeafId`,
-`VariationWeights`, and `BanditVersion` on the `ExperimentResult` — through
-callbacks, plugins, and deferred tracking alike.
-
-Good to know:
-
-- GrowthBook only serves bandit definitions to SDK versions that support
-  them, so make sure your SDK connection reports v0.5.0 or newer. Without
-  definitions in the payload, bandit rules serve their aggregate weights.
-- When no context matches the user, the rule's aggregate weights apply and
-  the exposure is attributed to the fallback leaf (`LeafId: -1`).
-- `WithContextualBandits` and `SetContextualBandits` exist for manual setup
-  and tests.
-
----
-
 ### Sticky Bucketing
 
 Sticky Bucketing ensures users see consistent experiment variations across sessions and devices. The SDK provides an in-memory implementation by default, but you can implement your own storage solution.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,29 @@ Plugins are shared with child clients. Any panics in plugin methods are recovere
 
 ---
 
+### Contextual Bandits
+
+Contextual bandit experiments reweight their variations per user segment.
+The GrowthBook API serves each bandit's per-context weights in the SDK
+payload alongside features (encrypted payloads included), and the SDK uses
+the first context whose condition matches the user — no extra setup needed.
+
+Assignments made by a bandit carry their attribution — `LeafId`,
+`VariationWeights`, and `BanditVersion` on the `ExperimentResult` — through
+callbacks, plugins, and deferred tracking alike.
+
+Good to know:
+
+- GrowthBook only serves bandit definitions to SDK versions that support
+  them, so make sure your SDK connection reports v0.5.0 or newer. Without
+  definitions in the payload, bandit rules serve their aggregate weights.
+- When no context matches the user, the rule's aggregate weights apply and
+  the exposure is attributed to the fallback leaf (`LeafId: -1`).
+- `WithContextualBandits` and `SetContextualBandits` exist for manual setup
+  and tests.
+
+---
+
 ### Sticky Bucketing
 
 Sticky Bucketing ensures users see consistent experiment variations across sessions and devices. The SDK provides an in-memory implementation by default, but you can implement your own storage solution.

--- a/bucket_range.go
+++ b/bucket_range.go
@@ -25,24 +25,7 @@ func (c *Client) getBucketRanges(numVariations int, coverage float64, weights []
 		coverage = 1
 	}
 
-	// Default to equal weights if missing or invalid
-	if len(weights) == 0 {
-		weights = getEqualWeights(numVariations)
-	}
-	if len(weights) != numVariations {
-		c.logger.Warn("Experiment weights and variations arrays must be the same length")
-		weights = getEqualWeights(numVariations)
-	}
-
-	// If weights don't add up to 1 (or close to it), default to equal weights
-	totalWeight := 0.0
-	for i := range weights {
-		totalWeight += weights[i]
-	}
-	if totalWeight < 0.99 || totalWeight > 1.01 {
-		c.logger.Warn("Experiment weights must add up to 1")
-		weights = getEqualWeights(numVariations)
-	}
+	weights = c.effectiveWeights(numVariations, weights)
 
 	// Cast weights to ranges
 	cumulative := 0.0
@@ -53,6 +36,27 @@ func (c *Client) getBucketRanges(numVariations int, coverage float64, weights []
 		ranges[i] = BucketRange{start, start + coverage*weights[i]}
 	}
 	return ranges
+}
+
+// effectiveWeights returns the weights assignment will actually use: equal
+// weights when missing, the wrong length, or not summing to ~1.
+func (c *Client) effectiveWeights(numVariations int, weights []float64) []float64 {
+	if len(weights) == 0 {
+		return getEqualWeights(numVariations)
+	}
+	if len(weights) != numVariations {
+		c.logger.Warn("Experiment weights and variations arrays must be the same length")
+		return getEqualWeights(numVariations)
+	}
+	totalWeight := 0.0
+	for i := range weights {
+		totalWeight += weights[i]
+	}
+	if totalWeight < 0.99 || totalWeight > 1.01 {
+		c.logger.Warn("Experiment weights must add up to 1")
+		return getEqualWeights(numVariations)
+	}
+	return weights
 }
 
 // Given a hash and bucket ranges, assigns one of the bucket ranges.

--- a/cases.json
+++ b/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.7.1",
+  "specVersion": "0.8.0",
   "evalCondition": [
     [
       "$not - pass",
@@ -63,32 +63,24 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "a"
-              }
+              "$elemMatch": { "$eq": "a" }
             }
           },
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "b"
-              }
+              "$elemMatch": { "$eq": "b" }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "c"
-                  }
+                  "$elemMatch": { "$eq": "c" }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "e"
-                  }
+                  "$elemMatch": { "$eq": "e" }
                 }
               }
             ]
@@ -96,30 +88,21 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "f"
-                }
+                "$elemMatch": { "$eq": "f" }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "g"
-                }
+                "$elemMatch": { "$eq": "g" }
               }
             }
           }
         ]
       },
       {
-        "$groups": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "$groups": ["a", "b", "c", "d"]
       },
       true
     ],
@@ -129,32 +112,24 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "a"
-              }
+              "$elemMatch": { "$eq": "a" }
             }
           },
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "b"
-              }
+              "$elemMatch": { "$eq": "b" }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "c"
-                  }
+                  "$elemMatch": { "$eq": "c" }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "e"
-                  }
+                  "$elemMatch": { "$eq": "e" }
                 }
               }
             ]
@@ -162,30 +137,21 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "d"
-                }
+                "$elemMatch": { "$eq": "d" }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "g"
-                }
+                "$elemMatch": { "$eq": "g" }
               }
             }
           }
         ]
       },
       {
-        "$groups": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "$groups": ["a", "b", "c", "d"]
       },
       false
     ],
@@ -423,11 +389,7 @@
       "$in - pass",
       {
         "num": {
-          "$in": [
-            1,
-            2,
-            3
-          ]
+          "$in": [1, 2, 3]
         }
       },
       {
@@ -439,11 +401,7 @@
       "$in - fail",
       {
         "num": {
-          "$in": [
-            1,
-            2,
-            3
-          ]
+          "$in": [1, 2, 3]
         }
       },
       {
@@ -467,18 +425,11 @@
       "$in - array pass 1",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "a"
-        ]
+        "tags": ["d", "e", "a"]
       },
       true
     ],
@@ -486,18 +437,11 @@
       "$in - array pass 2",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       true
     ],
@@ -505,18 +449,11 @@
       "$in - array pass 3",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "a"
-        ]
+        "tags": ["d", "b", "a"]
       },
       true
     ],
@@ -524,18 +461,11 @@
       "$in - array fail 1",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       false
     ],
@@ -543,10 +473,7 @@
       "$in - array fail 2",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
@@ -558,10 +485,7 @@
       "$in - fail (case sensitive mismatch)",
       {
         "country": {
-          "$in": [
-            "us",
-            "uk"
-          ]
+          "$in": ["us", "uk"]
         }
       },
       {
@@ -573,11 +497,7 @@
       "$nin - pass",
       {
         "num": {
-          "$nin": [
-            1,
-            2,
-            3
-          ]
+          "$nin": [1, 2, 3]
         }
       },
       {
@@ -589,11 +509,7 @@
       "$nin - fail",
       {
         "num": {
-          "$nin": [
-            1,
-            2,
-            3
-          ]
+          "$nin": [1, 2, 3]
         }
       },
       {
@@ -617,18 +533,11 @@
       "$nin - array fail 1",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "a"
-        ]
+        "tags": ["d", "e", "a"]
       },
       false
     ],
@@ -636,18 +545,11 @@
       "$nin - array fail 2",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       false
     ],
@@ -655,18 +557,11 @@
       "$nin - array fail 3",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "a"
-        ]
+        "tags": ["d", "b", "a"]
       },
       false
     ],
@@ -674,18 +569,11 @@
       "$nin - array pass 1",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       true
     ],
@@ -693,10 +581,7 @@
       "$nin - array pass 2",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
@@ -708,10 +593,7 @@
       "$nin - pass (case sensitive mismatch)",
       {
         "country": {
-          "$nin": [
-            "us",
-            "uk"
-          ]
+          "$nin": ["us", "uk"]
         }
       },
       {
@@ -723,10 +605,7 @@
       "$ini - pass (case insensitive match)",
       {
         "country": {
-          "$ini": [
-            "us",
-            "uk"
-          ]
+          "$ini": ["us", "uk"]
         }
       },
       {
@@ -738,10 +617,7 @@
       "$ini - pass (uppercase pattern, lowercase value)",
       {
         "country": {
-          "$ini": [
-            "US",
-            "UK"
-          ]
+          "$ini": ["US", "UK"]
         }
       },
       {
@@ -753,10 +629,7 @@
       "$ini - pass (mixed case)",
       {
         "country": {
-          "$ini": [
-            "Us",
-            "Uk"
-          ]
+          "$ini": ["Us", "Uk"]
         }
       },
       {
@@ -768,10 +641,7 @@
       "$ini - fail (no match)",
       {
         "country": {
-          "$ini": [
-            "us",
-            "uk"
-          ]
+          "$ini": ["us", "uk"]
         }
       },
       {
@@ -783,18 +653,11 @@
       "$ini - array pass 1",
       {
         "tags": {
-          "$ini": [
-            "a",
-            "b"
-          ]
+          "$ini": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "A"
-        ]
+        "tags": ["d", "e", "A"]
       },
       true
     ],
@@ -802,18 +665,11 @@
       "$ini - array pass 2",
       {
         "tags": {
-          "$ini": [
-            "A",
-            "B"
-          ]
+          "$ini": ["A", "B"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       true
     ],
@@ -821,18 +677,11 @@
       "$ini - array fail",
       {
         "tags": {
-          "$ini": [
-            "a",
-            "b"
-          ]
+          "$ini": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       false
     ],
@@ -852,10 +701,7 @@
       "$nini - pass (case insensitive match)",
       {
         "country": {
-          "$nini": [
-            "us",
-            "uk"
-          ]
+          "$nini": ["us", "uk"]
         }
       },
       {
@@ -867,10 +713,7 @@
       "$nini - fail (case insensitive match)",
       {
         "country": {
-          "$nini": [
-            "us",
-            "uk"
-          ]
+          "$nini": ["us", "uk"]
         }
       },
       {
@@ -882,10 +725,7 @@
       "$nini - fail (uppercase pattern, lowercase value)",
       {
         "country": {
-          "$nini": [
-            "US",
-            "UK"
-          ]
+          "$nini": ["US", "UK"]
         }
       },
       {
@@ -897,18 +737,11 @@
       "$nini - array pass",
       {
         "tags": {
-          "$nini": [
-            "a",
-            "b"
-          ]
+          "$nini": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       true
     ],
@@ -916,18 +749,11 @@
       "$nini - array fail 1",
       {
         "tags": {
-          "$nini": [
-            "a",
-            "b"
-          ]
+          "$nini": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "A"
-        ]
+        "tags": ["d", "e", "A"]
       },
       false
     ],
@@ -935,18 +761,11 @@
       "$nini - array fail 2",
       {
         "tags": {
-          "$nini": [
-            "A",
-            "B"
-          ]
+          "$nini": ["A", "B"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       false
     ],
@@ -972,12 +791,7 @@
         }
       },
       {
-        "nums": [
-          0,
-          5,
-          -20,
-          15
-        ]
+        "nums": [0, 5, -20, 15]
       },
       true
     ],
@@ -991,12 +805,7 @@
         }
       },
       {
-        "nums": [
-          0,
-          5,
-          -20,
-          8
-        ]
+        "nums": [0, 5, -20, 8]
       },
       false
     ],
@@ -1004,9 +813,7 @@
       "missing attribute - fail",
       {
         "pets.dog.name": {
-          "$in": [
-            "fido"
-          ]
+          "$in": ["fido"]
         }
       },
       {
@@ -1508,10 +1315,7 @@
         }
       },
       {
-        "a": [
-          1,
-          2
-        ]
+        "a": [1, 2]
       },
       true
     ],
@@ -1566,9 +1370,7 @@
     [
       "$size empty - pass",
       {
-        "tags": {
-          "$size": 0
-        }
+        "tags": { "$size": 0 }
       },
       {
         "tags": []
@@ -1578,14 +1380,10 @@
     [
       "$size empty - fail",
       {
-        "tags": {
-          "$size": 0
-        }
+        "tags": { "$size": 0 }
       },
       {
-        "tags": [
-          10
-        ]
+        "tags": [10]
       },
       false
     ],
@@ -1597,11 +1395,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b",
-          "c"
-        ]
+        "tags": ["a", "b", "c"]
       },
       true
     ],
@@ -1613,10 +1407,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b"
-        ]
+        "tags": ["a", "b"]
       },
       false
     ],
@@ -1628,12 +1419,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "tags": ["a", "b", "c", "d"]
       },
       false
     ],
@@ -1659,11 +1445,7 @@
         }
       },
       {
-        "tags": [
-          0,
-          1,
-          2
-        ]
+        "tags": [0, 1, 2]
       },
       true
     ],
@@ -1677,10 +1459,7 @@
         }
       },
       {
-        "tags": [
-          0,
-          1
-        ]
+        "tags": [0, 1]
       },
       false
     ],
@@ -1694,9 +1473,7 @@
         }
       },
       {
-        "tags": [
-          0
-        ]
+        "tags": [0]
       },
       false
     ],
@@ -1710,11 +1487,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "bar",
-          "baz"
-        ]
+        "tags": ["foo", "bar", "baz"]
       },
       true
     ],
@@ -1728,10 +1501,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "baz"
-        ]
+        "tags": ["foo", "baz"]
       },
       false
     ],
@@ -1740,19 +1510,12 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": [
-              "a",
-              "b"
-            ]
+            "$in": ["a", "b"]
           }
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "b"
-        ]
+        "tags": ["d", "e", "b"]
       },
       true
     ],
@@ -1761,19 +1524,12 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": [
-              "a",
-              "b"
-            ]
+            "$in": ["a", "b"]
           }
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       false
     ],
@@ -1789,10 +1545,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "baz"
-        ]
+        "tags": ["foo", "baz"]
       },
       true
     ],
@@ -1808,11 +1561,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "bar",
-          "baz"
-        ]
+        "tags": ["foo", "bar", "baz"]
       },
       false
     ],
@@ -1913,18 +1662,11 @@
       "$all - pass",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "one",
-          "two",
-          "three"
-        ]
+        "tags": ["one", "two", "three"]
       },
       true
     ],
@@ -1932,18 +1674,11 @@
       "$all - fail",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "one",
-          "two",
-          "four"
-        ]
+        "tags": ["one", "two", "four"]
       },
       false
     ],
@@ -1951,10 +1686,7 @@
       "$all - fail not array",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
@@ -1966,18 +1698,11 @@
       "$all - fail (case sensitive mismatch)",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "ONE",
-          "two",
-          "THREE"
-        ]
+        "tags": ["ONE", "two", "THREE"]
       },
       false
     ],
@@ -1985,18 +1710,11 @@
       "$alli - pass (case insensitive match)",
       {
         "tags": {
-          "$alli": [
-            "one",
-            "three"
-          ]
+          "$alli": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "ONE",
-          "two",
-          "THREE"
-        ]
+        "tags": ["ONE", "two", "THREE"]
       },
       true
     ],
@@ -2004,18 +1722,11 @@
       "$alli - pass (uppercase pattern, lowercase value)",
       {
         "tags": {
-          "$alli": [
-            "ONE",
-            "THREE"
-          ]
+          "$alli": ["ONE", "THREE"]
         }
       },
       {
-        "tags": [
-          "one",
-          "two",
-          "three"
-        ]
+        "tags": ["one", "two", "three"]
       },
       true
     ],
@@ -2023,18 +1734,11 @@
       "$alli - pass (mixed case)",
       {
         "tags": {
-          "$alli": [
-            "One",
-            "Three"
-          ]
+          "$alli": ["One", "Three"]
         }
       },
       {
-        "tags": [
-          "ONE",
-          "two",
-          "three"
-        ]
+        "tags": ["ONE", "two", "three"]
       },
       true
     ],
@@ -2042,18 +1746,11 @@
       "$alli - fail (case insensitive, missing value)",
       {
         "tags": {
-          "$alli": [
-            "one",
-            "three"
-          ]
+          "$alli": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "ONE",
-          "two",
-          "four"
-        ]
+        "tags": ["ONE", "two", "four"]
       },
       false
     ],
@@ -2061,10 +1758,7 @@
       "$alli - fail not array",
       {
         "tags": {
-          "$alli": [
-            "one",
-            "three"
-          ]
+          "$alli": ["one", "three"]
         }
       },
       {
@@ -2155,74 +1849,47 @@
     [
       "equals array - pass",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       true
     ],
     [
       "equals array - fail order",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "world",
-          "hello"
-        ]
+        "tags": ["world", "hello"]
       },
       false
     ],
     [
       "equals array - fail missing item",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello"
-        ]
+        "tags": ["hello"]
       },
       false
     ],
     [
       "equals array - fail extra item",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello",
-          "world",
-          "foo"
-        ]
+        "tags": ["hello", "world", "foo"]
       },
       false
     ],
     [
       "equals array - fail type mismatch",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
         "tags": "hello world"
@@ -2351,9 +2018,7 @@
     [
       "false strict condition - missing attribute",
       {
-        "userId": {
-          "$eq": false
-        }
+        "userId": { "$eq": false }
       },
       {},
       false
@@ -3464,14 +3129,7 @@
     [
       "$or pass but second condition fail",
       {
-        "$or": [
-          {
-            "foo": 1
-          },
-          {
-            "bar": 1
-          }
-        ],
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
         "baz": 2
       },
       {
@@ -3484,14 +3142,7 @@
     [
       "$or and second condition both pass",
       {
-        "$or": [
-          {
-            "foo": 1
-          },
-          {
-            "bar": 1
-          }
-        ],
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
         "baz": 2
       },
       {
@@ -3504,22 +3155,8 @@
     [
       "$and condition pass but $or fail",
       {
-        "$and": [
-          {
-            "foo": 1
-          },
-          {
-            "bar": 1
-          }
-        ],
-        "$or": [
-          {
-            "baz": 1
-          },
-          {
-            "empty": 1
-          }
-        ]
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
       },
       {
         "foo": 1,
@@ -3531,22 +3168,8 @@
     [
       "$and and $or both pass",
       {
-        "$and": [
-          {
-            "foo": 1
-          },
-          {
-            "bar": 1
-          }
-        ],
-        "$or": [
-          {
-            "baz": 1
-          },
-          {
-            "empty": 1
-          }
-        ]
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
       },
       {
         "foo": 1,
@@ -3559,529 +3182,202 @@
     [
       "$inGroup passes for member of known group id",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup fails for non-member of known group id",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": 5
-      },
+      { "id": 5 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup fails for unknown group id",
       {
-        "id": {
-          "$inGroup": "unknowngroup_id"
-        }
+        "id": { "$inGroup": "unknowngroup_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup fails for member of known group id",
       {
-        "id": {
-          "$notInGroup": "group_id"
-        }
+        "id": { "$notInGroup": "group_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup passes for non-member of known group id",
       {
-        "id": {
-          "$notInGroup": "group_id"
-        }
+        "id": { "$notInGroup": "group_id" }
       },
-      {
-        "id": 5
-      },
+      { "id": 5 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup passes for unknown group id",
       {
-        "id": {
-          "$notInGroup": "unknowngroup_id"
-        }
+        "id": { "$notInGroup": "unknowngroup_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup passes for properly typed data",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": "2"
-      },
+      { "id": "2" },
       true,
-      {
-        "group_id": [
-          1,
-          "2",
-          3
-        ]
-      }
+      { "group_id": [1, "2", 3] }
     ],
     [
       "$inGroup fails for improperly typed data",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": "3"
-      },
+      { "id": "3" },
       false,
-      {
-        "group_id": [
-          1,
-          "2",
-          3
-        ]
-      }
+      { "group_id": [1, "2", 3] }
     ]
   ],
   "hash": [
-    [
-      "",
-      "a",
-      1,
-      0.22
-    ],
-    [
-      "",
-      "b",
-      1,
-      0.077
-    ],
-    [
-      "b",
-      "a",
-      1,
-      0.946
-    ],
-    [
-      "ef",
-      "d",
-      1,
-      0.652
-    ],
-    [
-      "asdf",
-      "8952klfjas09ujk",
-      1,
-      0.549
-    ],
-    [
-      "",
-      "123",
-      1,
-      0.011
-    ],
-    [
-      "",
-      "___)((*\":&",
-      1,
-      0.563
-    ],
-    [
-      "seed",
-      "a",
-      2,
-      0.0505
-    ],
-    [
-      "seed",
-      "b",
-      2,
-      0.2696
-    ],
-    [
-      "foo",
-      "ab",
-      2,
-      0.2575
-    ],
-    [
-      "foo",
-      "def",
-      2,
-      0.2019
-    ],
-    [
-      "89123klj",
-      "8952klfjas09ujkasdf",
-      2,
-      0.124
-    ],
-    [
-      "90850943850283058242805",
-      "123",
-      2,
-      0.7516
-    ],
-    [
-      "()**(%$##$%#$#",
-      "___)((*\":&",
-      2,
-      0.0128
-    ],
-    [
-      "abc",
-      "def",
-      99,
-      null
-    ]
+    ["", "a", 1, 0.22],
+    ["", "b", 1, 0.077],
+    ["b", "a", 1, 0.946],
+    ["ef", "d", 1, 0.652],
+    ["asdf", "8952klfjas09ujk", 1, 0.549],
+    ["", "123", 1, 0.011],
+    ["", "___)((*\":&", 1, 0.563],
+    ["seed", "a", 2, 0.0505],
+    ["seed", "b", 2, 0.2696],
+    ["foo", "ab", 2, 0.2575],
+    ["foo", "def", 2, 0.2019],
+    ["89123klj", "8952klfjas09ujkasdf", 2, 0.124],
+    ["90850943850283058242805", "123", 2, 0.7516],
+    ["()**(%$##$%#$#", "___)((*\":&", 2, 0.0128],
+    ["abc", "def", 99, null]
   ],
   "getBucketRange": [
     [
       "normal 50/50",
+      [2, 1, null],
       [
-        2,
-        1,
-        null
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "reduced coverage",
+      [2, 0.5, null],
       [
-        2,
-        0.5,
-        null
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ]
     ],
     [
       "zero coverage",
+      [2, 0, null],
       [
-        2,
-        0,
-        null
-      ],
-      [
-        [
-          0,
-          0
-        ],
-        [
-          0.5,
-          0.5
-        ]
+        [0, 0],
+        [0.5, 0.5]
       ]
     ],
     [
       "4 variations",
+      [4, 1, null],
       [
-        4,
-        1,
-        null
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.25,
-          0.5
-        ],
-        [
-          0.5,
-          0.75
-        ],
-        [
-          0.75,
-          1
-        ]
+        [0, 0.25],
+        [0.25, 0.5],
+        [0.5, 0.75],
+        [0.75, 1]
       ]
     ],
     [
       "uneven weights",
+      [2, 1, [0.4, 0.6]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.6
-        ]
-      ],
-      [
-        [
-          0,
-          0.4
-        ],
-        [
-          0.4,
-          1
-        ]
+        [0, 0.4],
+        [0.4, 1]
       ]
     ],
     [
       "uneven weights, 3 variations",
+      [3, 1, [0.2, 0.3, 0.5]],
       [
-        3,
-        1,
-        [
-          0.2,
-          0.3,
-          0.5
-        ]
-      ],
-      [
-        [
-          0,
-          0.2
-        ],
-        [
-          0.2,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.2],
+        [0.2, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "uneven weights, reduced coverage, 3 variations",
+      [3, 0.2, [0.2, 0.3, 0.5]],
       [
-        3,
-        0.2,
-        [
-          0.2,
-          0.3,
-          0.5
-        ]
-      ],
-      [
-        [
-          0,
-          0.04
-        ],
-        [
-          0.2,
-          0.26
-        ],
-        [
-          0.5,
-          0.6
-        ]
+        [0, 0.04],
+        [0.2, 0.26],
+        [0.5, 0.6]
       ]
     ],
     [
       "negative coverage",
+      [2, -0.2, null],
       [
-        2,
-        -0.2,
-        null
-      ],
-      [
-        [
-          0,
-          0
-        ],
-        [
-          0.5,
-          0.5
-        ]
+        [0, 0],
+        [0.5, 0.5]
       ]
     ],
     [
       "coverage above 1",
+      [2, 1.5, null],
       [
-        2,
-        1.5,
-        null
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights sum below 1",
+      [2, 1, [0.4, 0.1]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.1
-        ]
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights sum above 1",
+      [2, 1, [0.7, 0.6]],
       [
-        2,
-        1,
-        [
-          0.7,
-          0.6
-        ]
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights.length not equal to num variations",
+      [4, 1, [0.4, 0.4, 0.2]],
       [
-        4,
-        1,
-        [
-          0.4,
-          0.4,
-          0.2
-        ]
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.25,
-          0.5
-        ],
-        [
-          0.5,
-          0.75
-        ],
-        [
-          0.75,
-          1
-        ]
+        [0, 0.25],
+        [0.25, 0.5],
+        [0.5, 0.75],
+        [0.75, 1]
       ]
     ],
     [
       "weights sum almost equals 1",
+      [2, 1, [0.4, 0.5999]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.5999
-        ]
-      ],
-      [
-        [
-          0,
-          0.4
-        ],
-        [
-          0.4,
-          0.9999
-        ]
+        [0, 0.4],
+        [0.4, 0.9999]
       ]
     ]
   ],
@@ -4100,11 +3396,7 @@
     ],
     [
       "defaults when empty",
-      {
-        "features": {
-          "feature": {}
-        }
-      },
+      { "features": { "feature": {} } },
       "feature",
       {
         "value": null,
@@ -4116,13 +3408,7 @@
     ],
     [
       "uses defaultValue - number",
-      {
-        "features": {
-          "feature": {
-            "defaultValue": 1
-          }
-        }
-      },
+      { "features": { "feature": { "defaultValue": 1 } } },
       "feature",
       {
         "value": 1,
@@ -4134,13 +3420,7 @@
     ],
     [
       "uses custom values - string",
-      {
-        "features": {
-          "feature": {
-            "defaultValue": "yes"
-          }
-        }
-      },
+      { "features": { "feature": { "defaultValue": "yes" } } },
       "feature",
       {
         "value": "yes",
@@ -4369,12 +3649,7 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": {
-                    "$in": [
-                      "US",
-                      "CA"
-                    ]
-                  },
+                  "country": { "$in": ["US", "CA"] },
                   "browser": "firefox"
                 }
               }
@@ -4405,12 +3680,7 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": {
-                    "$in": [
-                      "US",
-                      "CA"
-                    ]
-                  },
+                  "country": { "$in": ["US", "CA"] },
                   "browser": "firefox"
                 }
               }
@@ -4516,9 +3786,7 @@
       {
         "features": {
           "feature": {
-            "rules": [
-              {}
-            ]
+            "rules": [{}]
           }
         }
       },
@@ -4541,11 +3809,7 @@
           "feature": {
             "rules": [
               {
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -4558,11 +3822,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4591,11 +3851,7 @@
             "rules": [
               {
                 "id": "id",
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -4608,11 +3864,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4640,11 +3892,7 @@
           "feature": {
             "rules": [
               {
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -4657,11 +3905,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4697,14 +3941,8 @@
                 "name": "Test",
                 "phase": "1",
                 "ranges": [
-                  [
-                    0,
-                    0.1
-                  ],
-                  [
-                    0.1,
-                    1.0
-                  ]
+                  [0, 0.1],
+                  [0.1, 1.0]
                 ],
                 "meta": [
                   {
@@ -4720,31 +3958,14 @@
                   {
                     "attribute": "anonId",
                     "seed": "pricing",
-                    "ranges": [
-                      [
-                        0,
-                        1
-                      ]
-                    ]
+                    "ranges": [[0, 1]]
                   }
                 ],
-                "namespace": [
-                  "pricing",
-                  0,
-                  1
-                ],
+                "namespace": ["pricing", 0, 1],
                 "key": "hello",
-                "variations": [
-                  true,
-                  false
-                ],
-                "weights": [
-                  0.1,
-                  0.9
-                ],
-                "condition": {
-                  "premium": true
-                },
+                "variations": [true, false],
+                "weights": [0.1, 0.9],
+                "condition": { "premium": true },
                 "foo": "bar"
               }
             ]
@@ -4760,14 +3981,8 @@
         "experiment": {
           "coverage": 0.99,
           "ranges": [
-            [
-              0,
-              0.1
-            ],
-            [
-              0.1,
-              1.0
-            ]
+            [0, 0.1],
+            [0.1, 1.0]
           ],
           "meta": [
             {
@@ -4783,12 +3998,7 @@
             {
               "attribute": "anonId",
               "seed": "pricing",
-              "ranges": [
-                [
-                  0,
-                  1
-                ]
-              ]
+              "ranges": [[0, 1]]
             }
           ],
           "name": "Test",
@@ -4796,23 +4006,11 @@
           "seed": "feature",
           "hashVersion": 2,
           "hashAttribute": "anonId",
-          "namespace": [
-            "pricing",
-            0,
-            1
-          ],
+          "namespace": ["pricing", 0, 1],
           "key": "hello",
-          "variations": [
-            true,
-            false
-          ],
-          "weights": [
-            0.1,
-            0.9
-          ],
-          "condition": {
-            "premium": true
-          }
+          "variations": [true, false],
+          "weights": [0.1, 0.9],
+          "condition": { "premium": true }
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4842,21 +4040,15 @@
             "rules": [
               {
                 "force": 1,
-                "condition": {
-                  "browser": "chrome"
-                }
+                "condition": { "browser": "chrome" }
               },
               {
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4884,23 +4076,17 @@
               {
                 "force": 1,
                 "id": "1",
-                "condition": {
-                  "browser": "chrome"
-                }
+                "condition": { "browser": "chrome" }
               },
               {
                 "id": "2",
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
                 "id": "3",
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4927,21 +4113,15 @@
             "rules": [
               {
                 "force": 1,
-                "condition": {
-                  "browser": "chrome"
-                }
+                "condition": { "browser": "chrome" }
               },
               {
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4959,20 +4139,13 @@
     [
       "skips experiment on coverage",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "coverage": 0.01
               },
               {
@@ -4994,25 +4167,14 @@
     [
       "skips experiment on namespace",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
-                "namespace": [
-                  "pricing",
-                  0,
-                  0.01
-                ]
+                "variations": [0, 1, 2, 3],
+                "namespace": ["pricing", 0, 0.01]
               },
               {
                 "force": 3
@@ -5033,18 +4195,13 @@
     [
       "handles integer hashAttribute",
       {
-        "attributes": {
-          "id": 123
-        },
+        "attributes": { "id": 123 },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1
-                ]
+                "variations": [0, 1]
               }
             ]
           }
@@ -5058,10 +4215,7 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [
-            0,
-            1
-          ]
+          "variations": [0, 1]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -5081,20 +4235,13 @@
     [
       "skip experiment on missing hashAttribute",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "hashAttribute": "company"
               },
               {
@@ -5116,9 +4263,7 @@
     [
       "include experiments when forced",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "forcedVariations": {
           "feature": 1
         },
@@ -5127,12 +4272,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ]
+                "variations": [0, 1, 2, 3]
               },
               {
                 "force": 3
@@ -5149,12 +4289,7 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [
-            0,
-            1,
-            2,
-            3
-          ]
+          "variations": [0, 1, 2, 3]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -5183,10 +4318,7 @@
               {
                 "force": 2,
                 "coverage": 0.01,
-                "range": [
-                  0,
-                  0.99
-                ]
+                "range": [0, 0.99]
               }
             ]
           }
@@ -5214,10 +4346,7 @@
               {
                 "force": 2,
                 "hashVersion": 2,
-                "range": [
-                  0.96,
-                  0.97
-                ]
+                "range": [0.96, 0.97]
               }
             ]
           }
@@ -5244,10 +4373,7 @@
             "rules": [
               {
                 "force": 2,
-                "range": [
-                  0,
-                  0.01
-                ]
+                "range": [0, 0.01]
               }
             ]
           }
@@ -5277,12 +4403,7 @@
                 "filters": [
                   {
                     "seed": "seed",
-                    "ranges": [
-                      [
-                        0,
-                        0.01
-                      ]
-                    ]
+                    "ranges": [[0, 0.01]]
                   }
                 ]
               }
@@ -5311,10 +4432,7 @@
             "rules": [
               {
                 "force": 2,
-                "range": [
-                  0,
-                  0.5
-                ],
+                "range": [0, 0.5],
                 "seed": "fjdslafdsa",
                 "hashVersion": 2
               }
@@ -5343,20 +4461,11 @@
             "rules": [
               {
                 "key": "holdout",
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.01
-                  ],
-                  [
-                    0.01,
-                    1.0
-                  ]
+                  [0, 0.01],
+                  [0.01, 1.0]
                 ],
                 "meta": [
                   {},
@@ -5367,20 +4476,11 @@
               },
               {
                 "key": "experiment",
-                "variations": [
-                  3,
-                  4
-                ],
+                "variations": [3, 4],
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5396,19 +4496,10 @@
         "experiment": {
           "key": "experiment",
           "hashVersion": 2,
-          "variations": [
-            3,
-            4
-          ],
+          "variations": [3, 4],
           "ranges": [
-            [
-              0,
-              0.5
-            ],
-            [
-              0.5,
-              1.0
-            ]
+            [0, 0.5],
+            [0.5, 1.0]
           ]
         },
         "experimentResult": {
@@ -5439,19 +4530,10 @@
               {
                 "key": "holdout",
                 "hashVersion": 2,
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "ranges": [
-                  [
-                    0,
-                    0.99
-                  ],
-                  [
-                    0.99,
-                    1.0
-                  ]
+                  [0, 0.99],
+                  [0.99, 1.0]
                 ],
                 "meta": [
                   {},
@@ -5463,19 +4545,10 @@
               {
                 "key": "experiment",
                 "hashVersion": 2,
-                "variations": [
-                  3,
-                  4
-                ],
+                "variations": [3, 4],
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5491,14 +4564,8 @@
         "experiment": {
           "hashVersion": 2,
           "ranges": [
-            [
-              0,
-              0.99
-            ],
-            [
-              0.99,
-              1.0
-            ]
+            [0, 0.99],
+            [0.99, 1.0]
           ],
           "meta": [
             {},
@@ -5507,10 +4574,7 @@
             }
           ],
           "key": "holdout",
-          "variations": [
-            1,
-            2
-          ]
+          "variations": [1, 2]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -5540,20 +4604,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5565,17 +4620,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5607,17 +4658,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5646,20 +4693,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5671,17 +4709,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5710,20 +4744,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5732,9 +4757,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": {
-                  "id": "123"
-                },
+                "condition": { "id": "123" },
                 "force": 2
               }
             ]
@@ -5746,9 +4769,7 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
@@ -5757,19 +4778,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": {
-                      "value": {
-                        "$gt": 1
-                      }
-                    },
+                    "condition": { "value": { "$gt": 1 } },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5801,30 +4816,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": {
-                      "value": {
-                        "$gt": 1
-                      }
-                    },
+                    "condition": { "value": { "$gt": 1 } },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5833,9 +4835,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": {
-                  "id": "123"
-                },
+                "condition": { "id": "123" },
                 "force": 2
               }
             ]
@@ -5847,17 +4847,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5887,21 +4883,12 @@
             "rules": [
               {
                 "key": "experiment",
-                "variations": [
-                  0,
-                  1
-                ],
+                "variations": [0, 1],
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5913,17 +4900,13 @@
                 "parentConditions": [
                   {
                     "id": "parentExperimentFlag",
-                    "condition": {
-                      "value": 1
-                    },
+                    "condition": { "value": 1 },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5953,21 +4936,12 @@
             "rules": [
               {
                 "key": "experiment",
-                "variations": [
-                  0,
-                  1
-                ],
+                "variations": [0, 1],
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5979,17 +4953,13 @@
                 "parentConditions": [
                   {
                     "id": "parentExperimentFlag",
-                    "condition": {
-                      "value": 0
-                    },
+                    "condition": { "value": 0 },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -6019,9 +4989,7 @@
                 "parentConditions": [
                   {
                     "id": "flag2",
-                    "condition": {
-                      "value": true
-                    },
+                    "condition": { "value": true },
                     "gate": true
                   }
                 ]
@@ -6035,9 +5003,7 @@
                 "parentConditions": [
                   {
                     "id": "flag1",
-                    "condition": {
-                      "value": true
-                    },
+                    "condition": { "value": true },
                     "gate": true
                   }
                 ]
@@ -6070,18 +5036,12 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": {
-                        "$ne": false
-                      }
-                    },
+                    "condition": { "value": { "$ne": false } },
                     "gate": true
                   },
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": true
-                    },
+                    "condition": { "value": true },
                     "gate": true
                   }
                 ]
@@ -6093,25 +5053,19 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": true
-                    }
+                    "condition": { "value": true }
                   }
                 ],
                 "force": "C"
               },
               {
                 "condition": {
-                  "browser": {
-                    "$ne": "safari"
-                  }
+                  "browser": { "$ne": "safari" }
                 },
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": true
-                    }
+                    "condition": { "value": true }
                   }
                 ],
                 "force": "T"
@@ -6144,20 +5098,13 @@
             "rules": [
               {
                 "force": true,
-                "condition": {
-                  "id": {
-                    "$inGroup": "group_id"
-                  }
-                }
+                "condition": { "id": { "$inGroup": "group_id" } }
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [
-            123,
-            456
-          ]
+          "group_id": [123, 456]
         }
       },
       "inGroup_force_rule",
@@ -6181,35 +5128,19 @@
             "rules": [
               {
                 "key": "experiment",
-                "condition": {
-                  "id": {
-                    "$inGroup": "group_id"
-                  }
-                },
+                "condition": { "id": { "$inGroup": "group_id" } },
                 "hashVersion": 2,
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [
-            123,
-            456
-          ]
+          "group_id": [123, 456]
         }
       },
       "inGroup_experiment_rule",
@@ -6220,24 +5151,11 @@
         "source": "experiment",
         "experiment": {
           "hashVersion": 2,
-          "condition": {
-            "id": {
-              "$inGroup": "group_id"
-            }
-          },
-          "variations": [
-            1,
-            2
-          ],
+          "condition": { "id": { "$inGroup": "group_id" } },
+          "variations": [1, 2],
           "ranges": [
-            [
-              0,
-              0.5
-            ],
-            [
-              0.5,
-              1.0
-            ]
+            [0, 0.5],
+            [0.5, 1.0]
           ],
           "key": "experiment"
         },
@@ -6257,6 +5175,258 @@
       }
     ],
     [
+      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [1, 0],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [1, 0],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0, 1],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
       "multi-armed-bandit type is treated as a standard experiment",
       {
         "attributes": {
@@ -6271,14 +5441,8 @@
                 "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
-                "variations": [
-                  "control",
-                  "treatment"
-                ],
-                "weights": [
-                  0.5,
-                  0.5
-                ],
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
                 "meta": [
                   {
                     "key": "0"
@@ -6301,16 +5465,10 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "variations": [
-            "control",
-            "treatment"
-          ],
+          "variations": ["control", "treatment"],
           "key": "bandit-exp",
           "coverage": 1,
-          "weights": [
-            0.5,
-            0.5
-          ],
+          "weights": [0.5, 0.5],
           "meta": [
             {
               "key": "0"
@@ -6351,14 +5509,8 @@
                 "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
-                "variations": [
-                  "control",
-                  "treatment"
-                ],
-                "weights": [
-                  0.5,
-                  0.5
-                ],
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
                 "meta": [
                   {
                     "key": "0"
@@ -6381,16 +5533,10 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "variations": [
-            "control",
-            "treatment"
-          ],
+          "variations": ["control", "treatment"],
           "key": "bandit-exp",
           "coverage": 1,
-          "weights": [
-            0.5,
-            0.5
-          ],
+          "weights": [0.5, 0.5],
           "meta": [
             {
               "key": "0"
@@ -6431,14 +5577,8 @@
                 "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
-                "variations": [
-                  "control",
-                  "treatment"
-                ],
-                "weights": [
-                  0.5,
-                  0.5
-                ],
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
                 "meta": [
                   {
                     "key": "0"
@@ -6461,16 +5601,10 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "variations": [
-            "control",
-            "treatment"
-          ],
+          "variations": ["control", "treatment"],
           "key": "bandit-exp",
           "coverage": 1,
-          "weights": [
-            0.5,
-            0.5
-          ],
+          "weights": [0.5, 0.5],
           "meta": [
             {
               "key": "0"
@@ -6497,1447 +5631,410 @@
       }
     ],
     [
-      "force rules - coverage rollout uses seed (included)",
-      {
-        "attributes": {
-          "id": "2"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5,
-                "seed": "s1"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "source": "force",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage rollout uses seed (excluded)",
-      {
-        "attributes": {
-          "id": "5"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5,
-                "seed": "s1"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage rollout respects filters (filtered out)",
-      {
-        "attributes": {
-          "id": "5"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5,
-                "filters": [
-                  {
-                    "seed": "s2",
-                    "ranges": [
-                      [
-                        0,
-                        0.5
-                      ]
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage rollout respects filters (in filter range)",
-      {
-        "attributes": {
-          "id": "3"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5,
-                "filters": [
-                  {
-                    "seed": "s2",
-                    "ranges": [
-                      [
-                        0,
-                        0.5
-                      ]
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "source": "force",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage boundary is inclusive (n == coverage)",
-      {
-        "attributes": {
-          "id": "3152"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "source": "force",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - skip if hashAttribute missing and no sticky bucketing (fallbackAttribute set)",
+      "CB rule with empty contexts is overridden by forced variation like a normal experiment",
       {
         "attributes": {
           "id": "1",
-          "deviceId": "d123"
+          "plan": "pro"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
         },
         "features": {
-          "feature": {
-            "defaultValue": 0,
+          "bandit-feature": {
+            "defaultValue": "default",
             "rules": [
               {
-                "force": 1,
-                "coverage": 1,
-                "hashAttribute": "email",
-                "fallbackAttribute": "deviceId"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - skip if hashAttribute missing (no fallback to id)",
-      {
-        "attributes": {
-          "id": "1"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 1,
-                "hashAttribute": "email"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - hashAttribute present is used for coverage",
-      {
-        "attributes": {
-          "id": "1",
-          "email": "a@b.c"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 1,
-                "hashAttribute": "email"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "source": "force",
-        "ruleId": ""
-      }
-    ],
-    [
-      "object value with hashValue key is not coerced",
-      {
-        "attributes": {
-          "id": "1"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": {
-              "hashValue": 123
-            }
-          }
-        }
-      },
-      "feature",
-      {
-        "value": {
-          "hashValue": 123
-        },
-        "on": true,
-        "off": false,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - hashAttribute value of 0 is falsy, experiment skipped",
-      {
-        "attributes": {
-          "id": 0
-        },
-        "features": {
-          "feature": {
-            "defaultValue": "def",
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "def",
-        "on": true,
-        "off": false,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - hashAttribute value of false is falsy, experiment skipped",
-      {
-        "attributes": {
-          "id": false
-        },
-        "features": {
-          "feature": {
-            "defaultValue": "def",
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "def",
-        "on": true,
-        "off": false,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage rollout skipped when hashAttribute value is 0 (falsy)",
-      {
-        "attributes": {
-          "id": 0
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.99
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - parentConditions are not copied onto the experiment",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "features": {
-          "parent": {
-            "defaultValue": "on"
-          },
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  0,
-                  1
-                ],
-                "parentConditions": [
-                  {
-                    "id": "parent",
-                    "condition": {
-                      "value": "on"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            0,
-            1
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": 1,
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - rule status is not copied onto the experiment (draft rule still runs)",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ],
-                "status": "draft"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "b",
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            "a",
-            "b"
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": "b",
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - urlPatterns are not copied onto the experiment",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "url": "http://example.com/",
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ],
-                "urlPatterns": [
-                  {
-                    "type": "simple",
-                    "pattern": "http://other.com",
-                    "include": true
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "b",
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            "a",
-            "b"
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": "b",
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - groups are not copied onto the experiment",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ],
-                "groups": [
-                  "internal"
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "b",
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            "a",
-            "b"
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": "b",
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - legacy url is not copied onto the experiment",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "url": "http://example.com/",
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ],
-                "url": "^/pricing$"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "b",
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            "a",
-            "b"
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": "b",
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - fallbackAttribute ignored without sticky bucket service",
-      {
-        "attributes": {
-          "anonymousId": "123"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
-                "fallbackAttribute": "anonymousId"
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
         }
       },
-      "feature",
+      "bandit-feature",
       {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
       }
     ]
   ],
   "run": [
     [
       "default weights - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "coverage - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       1,
       true,
       true
     ],
     [
       "coverage - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       1,
       true,
       true
     ],
     [
       "coverage - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "three way test - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       1,
       true,
       true
     ],
     [
       "three way test - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       1,
       true,
       true
     ],
     [
       "three way test - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "test name - my-test",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "test name - my-test-3",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test-3",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test-3", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "empty id",
-      {
-        "attributes": {
-          "id": ""
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "null id",
-      {
-        "attributes": {
-          "id": null
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": null } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "missing id",
-      {
-        "attributes": {}
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": {} },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
@@ -7945,68 +6042,31 @@
     [
       "missing attributes",
       {},
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "single variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0] },
       0,
       false,
       false
     ],
     [
       "negative forced variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "force": -8
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "force": -8 },
       0,
       false,
       false
     ],
     [
       "high forced variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "force": 25
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "force": 25 },
       0,
       false,
       false
@@ -8021,10 +6081,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "condition": {
           "browser": "firefox"
         }
@@ -8043,10 +6100,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "condition": {
           "browser": "firefox"
         }
@@ -8065,10 +6119,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "hashAttribute": "companyId"
       },
       1,
@@ -8085,10 +6136,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -8104,10 +6152,7 @@
       },
       {
         "key": "forced-test-qs",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8123,10 +6168,7 @@
       {
         "key": "my-test",
         "active": true,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8142,10 +6184,7 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -8162,10 +6201,7 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8182,10 +6218,7 @@
         "key": "my-test",
         "force": 1,
         "coverage": 0.01,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -8221,19 +6254,12 @@
     [
       "Force variation from context",
       {
-        "attributes": {
-          "id": "1"
-        },
-        "forcedVariations": {
-          "my-test": 0
-        }
+        "attributes": { "id": "1" },
+        "forcedVariations": { "my-test": 0 }
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       true,
@@ -8242,17 +6268,12 @@
     [
       "Skips experiments in QA mode",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -8261,20 +6282,13 @@
     [
       "Works in QA mode if forced in context",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true,
-        "forcedVariations": {
-          "my-test": 1
-        }
+        "forcedVariations": { "my-test": 1 }
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8283,17 +6297,12 @@
     [
       "Works in QA mode if forced in experiment",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "force": 1
       },
       1,
@@ -8309,15 +6318,8 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "namespace": [
-          "namespace",
-          0.1,
-          1
-        ]
+        "variations": [0, 1],
+        "namespace": ["namespace", 0.1, 1]
       },
       1,
       true,
@@ -8332,15 +6334,8 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "namespace": [
-          "namespace",
-          0,
-          0.1
-        ]
+        "variations": [0, 1],
+        "namespace": ["namespace", 0, 0.1]
       },
       0,
       false,
@@ -8355,10 +6350,7 @@
       },
       {
         "key": "no-coverage",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "coverage": 0
       },
       0,
@@ -8375,33 +6367,19 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [
-              [
-                0.8,
-                1.0
-              ]
-            ]
+            "ranges": [[0.8, 1.0]]
           }
         ]
       },
@@ -8419,33 +6397,19 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [
-              [
-                0.6,
-                0.8
-              ]
-            ]
+            "ranges": [[0.6, 0.8]]
           }
         ]
       },
@@ -8462,30 +6426,17 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           }
         ],
-        "namespace": [
-          "test",
-          0,
-          0.001
-        ]
+        "namespace": ["test", 0, 0.001]
       },
       1,
       true,
@@ -8500,25 +6451,13 @@
       },
       {
         "key": "ranges",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0.99,
-            1.0
-          ],
-          [
-            0.0,
-            0.99
-          ]
+          [0.99, 1.0],
+          [0.0, 0.99]
         ],
         "coverage": 0.01,
-        "weights": [
-          0.99,
-          0.01
-        ]
+        "weights": [0.99, 0.01]
       },
       1,
       true,
@@ -8533,19 +6472,10 @@
       },
       {
         "key": "configs",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0,
-            0.1
-          ],
-          [
-            0.9,
-            1.0
-          ]
+          [0, 0.1],
+          [0.9, 1.0]
         ]
       },
       0,
@@ -8563,19 +6493,10 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0,
-            0.5
-          ],
-          [
-            0.5,
-            1.0
-          ]
+          [0, 0.5],
+          [0.5, 1.0]
         ]
       },
       1,
@@ -8593,10 +6514,7 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8613,14 +6531,8 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.5,
-          0.5
-        ],
+        "variations": [0, 1],
+        "weights": [0.5, 0.5],
         "coverage": 0.99
       },
       1,
@@ -8630,9 +6542,7 @@
     [
       "Prerequisite condition passes",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "features": {
           "parentFlag": {
             "defaultValue": true
@@ -8641,10 +6551,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -8661,9 +6568,7 @@
     [
       "Prerequisite condition fails",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "features": {
           "parentFlag": {
             "defaultValue": false
@@ -8672,10 +6577,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -8692,29 +6594,15 @@
     [
       "SavedGroups correctly pulled from context for experiment",
       {
-        "attributes": {
-          "id": "4"
-        },
-        "savedGroups": {
-          "group_id": [
-            "4",
-            "5",
-            "6"
-          ]
-        }
+        "attributes": { "id": "4" },
+        "savedGroups": { "group_id": ["4", "5", "6"] }
       },
       {
         "key": "group-filtered-test",
         "condition": {
-          "id": {
-            "$inGroup": "group_id"
-          }
+          "id": { "$inGroup": "group_id" }
         },
-        "variations": [
-          0,
-          1,
-          2
-        ]
+        "variations": [0, 1, 2]
       },
       0,
       true,
@@ -8726,14 +6614,8 @@
       "even range, 0.2",
       0.2,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -8741,14 +6623,8 @@
       "even range, 0.4",
       0.4,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -8756,14 +6632,8 @@
       "even range, 0.6",
       0.6,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -8771,14 +6641,8 @@
       "even range, 0.8",
       0.8,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -8786,14 +6650,8 @@
       "even range, 0",
       0,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -8801,14 +6659,8 @@
       "even range, 0.5",
       0.5,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -8816,14 +6668,8 @@
       "reduced range, 0.2",
       0.2,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       0
     ],
@@ -8831,14 +6677,8 @@
       "reduced range, 0.4",
       0.4,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -8846,14 +6686,8 @@
       "reduced range, 0.6",
       0.6,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       1
     ],
@@ -8861,14 +6695,8 @@
       "reduced range, 0.8",
       0.8,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -8876,14 +6704,8 @@
       "reduced range, 0.25",
       0.25,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -8891,14 +6713,8 @@
       "reduced range, 0.5",
       0.5,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       1
     ],
@@ -8906,44 +6722,17 @@
       "zero range",
       0.5,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 0.5],
+        [0.5, 1]
       ],
       2
     ]
   ],
   "getQueryStringOverride": [
-    [
-      "empty url",
-      "my-test",
-      "",
-      2,
-      null
-    ],
-    [
-      "no query string",
-      "my-test",
-      "http://example.com",
-      2,
-      null
-    ],
-    [
-      "empty query string",
-      "my-test",
-      "http://example.com?",
-      2,
-      null
-    ],
+    ["empty url", "my-test", "", 2, null],
+    ["no query string", "my-test", "http://example.com", 2, null],
+    ["empty query string", "my-test", "http://example.com?", 2, null],
     [
       "no query string match",
       "my-test",
@@ -8951,62 +6740,14 @@
       2,
       null
     ],
-    [
-      "invalid query string",
-      "my-test",
-      "http://example.com??&&&?#",
-      2,
-      null
-    ],
-    [
-      "simple match 0",
-      "my-test",
-      "http://example.com?my-test=0",
-      2,
-      0
-    ],
-    [
-      "simple match 1",
-      "my-test",
-      "http://example.com?my-test=1",
-      2,
-      1
-    ],
-    [
-      "negative variation",
-      "my-test",
-      "http://example.com?my-test=-1",
-      2,
-      null
-    ],
-    [
-      "float",
-      "my-test",
-      "http://example.com?my-test=2.054",
-      2,
-      null
-    ],
-    [
-      "string",
-      "my-test",
-      "http://example.com?my-test=foo",
-      2,
-      null
-    ],
-    [
-      "variation too high",
-      "my-test",
-      "http://example.com?my-test=5",
-      2,
-      null
-    ],
-    [
-      "high numVariations",
-      "my-test",
-      "http://example.com?my-test=5",
-      6,
-      5
-    ],
+    ["invalid query string", "my-test", "http://example.com??&&&?#", 2, null],
+    ["simple match 0", "my-test", "http://example.com?my-test=0", 2, 0],
+    ["simple match 1", "my-test", "http://example.com?my-test=1", 2, 1],
+    ["negative variation", "my-test", "http://example.com?my-test=-1", 2, null],
+    ["float", "my-test", "http://example.com?my-test=2.054", 2, null],
+    ["string", "my-test", "http://example.com?my-test=foo", 2, null],
+    ["variation too high", "my-test", "http://example.com?my-test=5", 2, null],
+    ["high numVariations", "my-test", "http://example.com?my-test=5", 6, 5],
     [
       "equal to numVariations",
       "my-test",
@@ -9028,215 +6769,33 @@
       2,
       1
     ],
-    [
-      "anchor",
-      "my-test",
-      "http://example.com?my-test=1#foo",
-      2,
-      1
-    ]
+    ["anchor", "my-test", "http://example.com?my-test=1#foo", 2, 1]
   ],
   "inNamespace": [
-    [
-      "user 1, namespace1, 1",
-      "1",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 1, namespace1, 2",
-      "1",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 1, namespace2, 1",
-      "1",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 1, namespace2, 2",
-      "1",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 2, namespace1, 1",
-      "2",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 2, namespace1, 2",
-      "2",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 2, namespace2, 1",
-      "2",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 2, namespace2, 2",
-      "2",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 3, namespace1, 1",
-      "3",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 3, namespace1, 2",
-      "3",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 3, namespace2, 1",
-      "3",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      true
-    ],
-    [
-      "user 3, namespace2, 2",
-      "3",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      false
-    ],
-    [
-      "user 4, namespace1, 1",
-      "4",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 4, namespace1, 2",
-      "4",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 4, namespace2, 1",
-      "4",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      true
-    ],
-    [
-      "user 4, namespace2, 2",
-      "4",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      false
-    ]
+    ["user 1, namespace1, 1", "1", ["namespace1", 0, 0.4], false],
+    ["user 1, namespace1, 2", "1", ["namespace1", 0.4, 1], true],
+    ["user 1, namespace2, 1", "1", ["namespace2", 0, 0.4], false],
+    ["user 1, namespace2, 2", "1", ["namespace2", 0.4, 1], true],
+    ["user 2, namespace1, 1", "2", ["namespace1", 0, 0.4], false],
+    ["user 2, namespace1, 2", "2", ["namespace1", 0.4, 1], true],
+    ["user 2, namespace2, 1", "2", ["namespace2", 0, 0.4], false],
+    ["user 2, namespace2, 2", "2", ["namespace2", 0.4, 1], true],
+    ["user 3, namespace1, 1", "3", ["namespace1", 0, 0.4], false],
+    ["user 3, namespace1, 2", "3", ["namespace1", 0.4, 1], true],
+    ["user 3, namespace2, 1", "3", ["namespace2", 0, 0.4], true],
+    ["user 3, namespace2, 2", "3", ["namespace2", 0.4, 1], false],
+    ["user 4, namespace1, 1", "4", ["namespace1", 0, 0.4], false],
+    ["user 4, namespace1, 2", "4", ["namespace1", 0.4, 1], true],
+    ["user 4, namespace2, 1", "4", ["namespace2", 0, 0.4], true],
+    ["user 4, namespace2, 2", "4", ["namespace2", 0.4, 1], false]
   ],
   "getEqualWeights": [
-    [
-      -1,
-      []
-    ],
-    [
-      0,
-      []
-    ],
-    [
-      1,
-      [
-        1
-      ]
-    ],
-    [
-      2,
-      [
-        0.5,
-        0.5
-      ]
-    ],
-    [
-      3,
-      [
-        0.33333333,
-        0.33333333,
-        0.33333333
-      ]
-    ],
-    [
-      4,
-      [
-        0.25,
-        0.25,
-        0.25,
-        0.25
-      ]
-    ]
+    [-1, []],
+    [0, []],
+    [1, [1]],
+    [2, [0.5, 0.5]],
+    [3, [0.33333333, 0.33333333, 0.33333333]],
+    [4, [0.25, 0.25, 0.25, 0.25]]
   ],
   "decrypt": [
     [
@@ -9304,20 +6863,13 @@
     [
       "use fallbackAttribute when missing hashAttribute",
       {
-        "attributes": {
-          "anonymousId": "123"
-        },
+        "attributes": { "anonymousId": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "hashAttribute": "id",
                 "fallbackAttribute": "anonymousId"
               }
@@ -9341,9 +6893,7 @@
       },
       {
         "anonymousId||123": {
-          "assignments": {
-            "feature__0": "3"
-          },
+          "assignments": { "feature__0": "3" },
           "attributeName": "anonymousId",
           "attributeValue": "123"
         }
@@ -9369,31 +6919,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9417,9 +6947,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -9445,31 +6973,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9500,9 +7008,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "2"
-          },
+          "assignments": { "feature-exp__0": "2" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -9528,31 +7034,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9583,9 +7069,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -9611,31 +7095,11 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9666,16 +7130,12 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -9701,31 +7161,11 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9763,16 +7203,12 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": {
-            "feature-exp__0": "2"
-          },
+          "assignments": { "feature-exp__0": "2" },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -9797,31 +7233,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9830,9 +7246,7 @@
       },
       [
         {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -9881,31 +7295,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9914,9 +7308,7 @@
       },
       [
         {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -9954,31 +7346,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10009,9 +7381,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__3": "2"
-          },
+          "assignments": { "feature-exp__3": "2" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -10038,31 +7408,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10082,9 +7432,7 @@
       null,
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__2": "2"
-          },
+          "assignments": { "feature-exp__2": "2" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -10111,31 +7459,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10196,31 +7524,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 4,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10280,31 +7588,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 1,
                 "disableStickyBucketing": true,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10315,9 +7603,7 @@
         {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": {
-            "feature-exp__0": "1"
-          }
+          "assignments": { "feature-exp__0": "1" }
         }
       ],
       "exp1",
@@ -10337,58 +7623,7 @@
         "id||i123": {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": {
-            "feature-exp__0": "1"
-          }
-        }
-      }
-    ],
-    [
-      "falsy hashAttribute value (0) falls through to fallbackAttribute",
-      {
-        "attributes": {
-          "id": 0,
-          "anonymousId": "123"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
-                "hashAttribute": "id",
-                "fallbackAttribute": "anonymousId"
-              }
-            ]
-          }
-        }
-      },
-      [],
-      "feature",
-      {
-        "bucket": 0.863,
-        "featureId": "feature",
-        "hashAttribute": "anonymousId",
-        "hashUsed": true,
-        "hashValue": "123",
-        "inExperiment": true,
-        "key": "3",
-        "stickyBucketUsed": false,
-        "value": 3,
-        "variationId": 3
-      },
-      {
-        "anonymousId||123": {
-          "assignments": {
-            "feature__0": "3"
-          },
-          "attributeName": "anonymousId",
-          "attributeValue": "123"
+          "assignments": { "feature-exp__0": "1" }
         }
       }
     ]
@@ -10397,9 +7632,7 @@
     [
       "redirects correctly without query strings",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -10411,10 +7644,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10435,9 +7665,7 @@
     [
       "redirects with query string on original url and persistQueryString enabled",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home?color=blue&food=sushi",
         "experiments": [
           {
@@ -10449,10 +7677,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10474,9 +7699,7 @@
     [
       "merges query strings on original url & redirect url with param conflicts correctly when persistQueryString enabled",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home?color=blue&food=sushi&title=original",
         "experiments": [
           {
@@ -10488,10 +7711,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10513,9 +7733,7 @@
     [
       "only performs a redirect for first eligible experiment when there are multiple eligible experiments",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -10527,10 +7745,7 @@
                 "pattern": "http://www.example.com/"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10547,10 +7762,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10567,10 +7779,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10587,6 +7796,3030 @@
           "urlWithParams": "http://www.example.com/home-new-new"
         }
       ]
+    ]
+  ],
+  "contextualBandit": [
+    [
+      "single catch-all leaf routes and sets CB result fields",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "anything"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "matches the first (specific) leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "falls through to the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $in matches",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free",
+          "cartValue": 100
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": ["free", "basic"]
+                  }
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $gte matches second leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "cartValue": 600
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": ["free", "basic"]
+                  }
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "first-match-wins when multiple leaf conditions match",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "pro"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "country": "US"
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "missing attribute used by a leaf condition falls into the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule outer condition fails, a following force rule applies",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "condition": {
+                  "country": "US"
+                },
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              },
+              {
+                "force": "forced"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "forced",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition fails - CB rule skipped",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage excludes user even though a leaf matched",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.01,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "three-arm CB leaf routes with positional weights",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["c0", "c1", "c2"],
+                "weights": [0.34, 0.33, 0.33],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [0, 0, 1]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0.34, 0.33, 0.33]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "c2",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["c0", "c1", "c2"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            },
+            {
+              "key": "2"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0, 0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "2",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 2,
+          "value": "c2",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0, 0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule as a later rule in the list",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "first",
+                "seed": "first",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "CA"
+                }
+              },
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 2",
+      {
+        "attributes": {
+          "id": "2"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "2",
+          "stickyBucketUsed": false,
+          "bucket": 0.9374,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 3",
+      {
+        "attributes": {
+          "id": "3"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "3",
+          "stickyBucketUsed": false,
+          "bucket": 0.8606,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.1, 0.9]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.1, 0.9],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0.1, 0.9],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 4",
+      {
+        "attributes": {
+          "id": "4"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.1, 0.9]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.1, 0.9],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "4",
+          "stickyBucketUsed": false,
+          "bucket": 0.4818,
+          "leafId": 1,
+          "variationWeights": [0.1, 0.9],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB empty hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": "",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB null hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": null,
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB missing hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB buckets on a custom hashAttribute",
+      {
+        "attributes": {
+          "anonId": "123",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "anonId",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "anonId",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "anonId",
+          "hashValue": "123",
+          "stickyBucketUsed": false,
+          "bucket": 0.0484,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "forcedVariations from context overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "querystring force overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "url": "https://example.com/?bandit-exp=1",
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB skipped in QA mode",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB in QA mode if forced in context",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "forcedVariations": {
+          "bandit-exp": 0
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB rule when globally disabled",
+      {
+        "enabled": false,
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "JSON variation values with CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": {
+              "color": "none"
+            },
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "green"
+                  }
+                ],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": {
+          "color": "blue"
+        },
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            {
+              "color": "blue"
+            },
+            {
+              "color": "green"
+            }
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": {
+            "color": "blue"
+          },
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "single-variation CB rule is invalid - not in experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control"],
+                "weights": [1],
+                "meta": [
+                  {
+                    "key": "0"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition passes - CB routes",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "condition": {
+            "country": "US"
+          },
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 8",
+      {
+        "attributes": {
+          "id": "8",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 0.5,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "8",
+          "stickyBucketUsed": false,
+          "bucket": 0.011,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "dangling contextualBanditRef uses marginal weights with no CB metadata",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "empty contexts array uses marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "banditVersion omitted from definition is absent from result",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0]
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0]
+        }
+      }
+    ],
+    [
+      "required attribute present but no leaf matches - fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
     ]
   ]
 }

--- a/cases_test.go
+++ b/cases_test.go
@@ -30,6 +30,7 @@ type cases struct {
 	GetEqualWeights        JsonTuples[getEqualWeightsCase]        `json:"getEqualWeights"`
 	Decrypt                JsonTuples[decryptCase]                `json:"decrypt"`
 	StickyBucket           JsonTuples[stickyBucketTestCase]       `json:"stickyBucket"`
+	ContextualBandit       JsonTuples[featureCase]                `json:"contextualBandit"`
 }
 
 type evalConditionCase struct {
@@ -153,13 +154,14 @@ type stickyBucketTestCase struct {
 }
 
 type env struct {
-	Attributes       Attributes            `json:"attributes"`
-	Features         FeatureMap            `json:"features"`
-	Enabled          *bool                 `json:"enabled"`
-	Url              string                `json:"url"`
-	ForcedVariations ForcedVariationsMap   `json:"forcedVariations"`
-	QaMode           *bool                 `json:"qaMode"`
-	SavedGroups      condition.SavedGroups `json:"savedGroups"`
+	Attributes        Attributes                  `json:"attributes"`
+	Features          FeatureMap                  `json:"features"`
+	Enabled           *bool                       `json:"enabled"`
+	Url               string                      `json:"url"`
+	ForcedVariations  ForcedVariationsMap         `json:"forcedVariations"`
+	QaMode            *bool                       `json:"qaMode"`
+	SavedGroups       condition.SavedGroups       `json:"savedGroups"`
+	ContextualBandits ContextualBanditDefinitions `json:"contextualBandits"`
 }
 
 type JsonTuple[T any] struct {
@@ -216,6 +218,7 @@ func TestCasesJson(t *testing.T) {
 	cases.GetEqualWeights.run("getEqualWeights", t)
 	cases.Decrypt.run("decrypt", t)
 	cases.StickyBucket.run("stickyBucket", t)
+	cases.ContextualBandit.run("contextualBandit", t)
 }
 
 // stringifyTopLevelHashValue converts a numeric top-level "hashValue" in an
@@ -415,6 +418,7 @@ func (e *env) client() (*Client, error) {
 		WithForcedVariations(e.ForcedVariations),
 		WithFeatures(e.Features),
 		WithSavedGroups(e.SavedGroups),
+		WithContextualBandits(e.ContextualBandits),
 		withSilentTestLogger(),
 	)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -130,6 +130,15 @@ func (client *Client) SetFeatures(features FeatureMap) error {
 	return nil
 }
 
+// SetContextualBandits updates the shared contextual bandit definitions.
+func (client *Client) SetContextualBandits(bandits ContextualBanditDefinitions) error {
+	client.data.withLock(func(d *data) error {
+		d.contextualBandits = bandits
+		return nil
+	})
+	return nil
+}
+
 // SetJSONFeatures updates shared features from JSON
 func (client *Client) SetJSONFeatures(featuresJSON string) error {
 	var features FeatureMap
@@ -172,9 +181,20 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 	} else {
 		features = resp.Features
 	}
+	bandits := resp.ContextualBandits
+	if resp.EncryptedContextualBandits != "" {
+		banditsJSON, err := client.data.decrypt(resp.EncryptedContextualBandits)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal([]byte(banditsJSON), &bandits); err != nil {
+			return err
+		}
+	}
 	client.data.withLock(func(d *data) error {
 		d.features = features
 		d.savedGroups = resp.SavedGroups
+		d.contextualBandits = bandits
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
@@ -290,10 +310,11 @@ func (client *Client) Logger() *slog.Logger {
 func (client *Client) evaluator(ctx context.Context) *evaluator {
 	client.data.mu.RLock()
 	e := evaluator{
-		features:    client.data.features,
-		savedGroups: client.data.savedGroups,
-		client:      client,
-		ctx:         ctx,
+		features:          client.data.features,
+		savedGroups:       client.data.savedGroups,
+		contextualBandits: client.data.contextualBandits,
+		client:            client,
+		ctx:               ctx,
 		recording: client.experimentCallback != nil || client.featureUsageCallback != nil ||
 			client.deferredTracks != nil || len(client.data.plugins) > 0,
 	}

--- a/client.go
+++ b/client.go
@@ -184,11 +184,12 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 	bandits := resp.ContextualBandits
 	if resp.EncryptedContextualBandits != "" {
 		banditsJSON, err := client.data.decrypt(resp.EncryptedContextualBandits)
-		if err != nil {
-			return err
+		if err == nil {
+			err = json.Unmarshal([]byte(banditsJSON), &bandits)
 		}
-		if err := json.Unmarshal([]byte(banditsJSON), &bandits); err != nil {
-			return err
+		if err != nil {
+			client.logger.Warn("Dropping undecodable contextual bandits, applying the rest of the payload", "error", err)
+			bandits = nil
 		}
 	}
 	client.data.withLock(func(d *data) error {

--- a/client.go
+++ b/client.go
@@ -188,8 +188,7 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 			err = json.Unmarshal([]byte(banditsJSON), &bandits)
 		}
 		if err != nil {
-			client.logger.Warn("Dropping undecodable contextual bandits, applying the rest of the payload", "error", err)
-			bandits = nil
+			client.logger.Warn("Ignoring undecodable encrypted contextual bandits, applying the rest of the payload", "error", err)
 		}
 	}
 	client.data.withLock(func(d *data) error {

--- a/client_data.go
+++ b/client_data.go
@@ -9,20 +9,21 @@ import (
 )
 
 type data struct {
-	mu            sync.RWMutex
-	features      FeatureMap
-	savedGroups   condition.SavedGroups
-	dateUpdated   time.Time
-	apiHost       string
-	clientKey     string
-	decryptionKey string
-	httpClient    *http.Client
-	dataSource    DataSource
-	dsStarted     bool
-	dsStartWait   chan struct{}
-	dsStartErr    error
-	plugins       []Plugin
-	subscribers   subscriberRegistry
+	mu                sync.RWMutex
+	features          FeatureMap
+	savedGroups       condition.SavedGroups
+	contextualBandits ContextualBanditDefinitions
+	dateUpdated       time.Time
+	apiHost           string
+	clientKey         string
+	decryptionKey     string
+	httpClient        *http.Client
+	dataSource        DataSource
+	dsStarted         bool
+	dsStartWait       chan struct{}
+	dsStartErr        error
+	plugins           []Plugin
+	subscribers       subscriberRegistry
 }
 
 func newData() *data {

--- a/client_option.go
+++ b/client_option.go
@@ -52,8 +52,8 @@ func WithAttributes(attributes Attributes) ClientOption {
 	}
 }
 
-// WithContextualBandits sets the contextual bandit definitions referenced by
-// feature rules, normally delivered in the SDK payload.
+// WithContextualBandits sets contextual bandit definitions, normally
+// delivered in the SDK payload.
 func WithContextualBandits(bandits ContextualBanditDefinitions) ClientOption {
 	return func(c *Client) error {
 		c.data.contextualBandits = bandits

--- a/client_option.go
+++ b/client_option.go
@@ -52,6 +52,15 @@ func WithAttributes(attributes Attributes) ClientOption {
 	}
 }
 
+// WithContextualBandits sets the contextual bandit definitions referenced by
+// feature rules, normally delivered in the SDK payload.
+func WithContextualBandits(bandits ContextualBanditDefinitions) ClientOption {
+	return func(c *Client) error {
+		c.data.contextualBandits = bandits
+		return nil
+	}
+}
+
 // WithSavedGroups sets saved groups used to target the same group of users across multiple features and experiments.
 func WithSavedGroups(savedGroups condition.SavedGroups) ClientOption {
 	return func(c *Client) error {

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -21,6 +21,28 @@ type ContextualBanditDefinition struct {
 	Contexts      []ContextualBanditContext `json:"contexts"`
 }
 
+// UnmarshalJSON drops malformed contexts instead of erroring, so one bad
+// leaf does not discard a definition's parseable ones.
+func (d *ContextualBanditDefinition) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		BanditVersion *int              `json:"banditVersion"`
+		Contexts      []json.RawMessage `json:"contexts"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	d.BanditVersion = raw.BanditVersion
+	d.Contexts = nil
+	for _, rawCtx := range raw.Contexts {
+		var c ContextualBanditContext
+		if err := json.Unmarshal(rawCtx, &c); err != nil {
+			continue
+		}
+		d.Contexts = append(d.Contexts, c)
+	}
+	return nil
+}
+
 // ContextualBanditDefinitions maps bandit refs to their definitions.
 type ContextualBanditDefinitions map[string]ContextualBanditDefinition
 
@@ -71,10 +93,13 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 		if !leaf.Condition.Eval(e.client.attributes, e.savedGroups) {
 			continue
 		}
-		exp.Weights = leaf.Weights
+		// Sanitize so the reported weights always equal the weights the
+		// assignment uses — bandit analysis reweights by these propensities.
+		weights := e.client.effectiveWeights(len(exp.Variations), leaf.Weights)
+		exp.Weights = weights
 		exp.ContextualBandit = &CBContext{
 			LeafId:           leaf.LeafId,
-			VariationWeights: leaf.Weights,
+			VariationWeights: weights,
 			BanditVersion:    def.BanditVersion,
 		}
 		return
@@ -82,13 +107,9 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 
 	e.client.logger.DebugContext(e.ctx, "Contextual bandit: no matching leaf, using fallback weights",
 		"id", featureId, "contextualBanditRef", ref)
-	weights := exp.Weights
-	if len(weights) == 0 {
-		weights = getEqualWeights(len(exp.Variations))
-	}
 	exp.ContextualBandit = &CBContext{
 		LeafId:           contextualBanditFallbackLeafId,
-		VariationWeights: weights,
+		VariationWeights: e.client.effectiveWeights(len(exp.Variations), exp.Weights),
 		BanditVersion:    def.BanditVersion,
 	}
 }

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -20,8 +20,7 @@ type ContextualBanditDefinition struct {
 // ContextualBanditDefinitions maps bandit refs to their definitions.
 type ContextualBanditDefinitions map[string]ContextualBanditDefinition
 
-// CBContext is the contextual bandit context an assignment was made with,
-// mirroring the JS SDK type of the same name.
+// CBContext is the contextual bandit context an assignment was made with.
 type CBContext struct {
 	LeafId           int       `json:"leafId"`
 	VariationWeights []float64 `json:"variationWeights"`

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -1,0 +1,69 @@
+package growthbook
+
+import "github.com/growthbook/growthbook-golang/internal/condition"
+
+// ContextualBanditContext is one leaf of a contextual bandit definition: a
+// targeting condition and the variation weights to use when it matches.
+type ContextualBanditContext struct {
+	LeafId    int            `json:"leafId"`
+	Condition condition.Base `json:"condition"`
+	Weights   []float64      `json:"weights"`
+}
+
+// ContextualBanditDefinition holds the per-context variation weights for one
+// contextual bandit, as served in the SDK payload.
+type ContextualBanditDefinition struct {
+	BanditVersion *int                      `json:"banditVersion"`
+	Contexts      []ContextualBanditContext `json:"contexts"`
+}
+
+// ContextualBanditDefinitions maps bandit refs to their definitions.
+type ContextualBanditDefinitions map[string]ContextualBanditDefinition
+
+// CBContext is the contextual bandit context an assignment was made with,
+// mirroring the JS SDK type of the same name.
+type CBContext struct {
+	LeafId           int       `json:"leafId"`
+	VariationWeights []float64 `json:"variationWeights"`
+	BanditVersion    *int      `json:"banditVersion,omitempty"`
+}
+
+const contextualBanditFallbackLeafId = -1
+
+// buildContextualBanditExperiment applies a bandit definition to exp: the
+// first leaf whose condition passes supplies the variation weights; with no
+// matching leaf the aggregate weights stay and the exposure is attributed to
+// the fallback leaf. A missing definition leaves exp untouched.
+func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string, featureId string) {
+	def, ok := e.contextualBandits[ref]
+	if !ok {
+		e.client.logger.DebugContext(e.ctx, "Contextual bandit ref not found in payload, using aggregate weights",
+			"id", featureId, "contextualBanditRef", ref)
+		return
+	}
+
+	for _, leaf := range def.Contexts {
+		if !leaf.Condition.Eval(e.client.attributes, e.savedGroups) {
+			continue
+		}
+		exp.Weights = leaf.Weights
+		exp.ContextualBandit = &CBContext{
+			LeafId:           leaf.LeafId,
+			VariationWeights: leaf.Weights,
+			BanditVersion:    def.BanditVersion,
+		}
+		return
+	}
+
+	e.client.logger.DebugContext(e.ctx, "Contextual bandit: no matching leaf, using fallback weights",
+		"id", featureId, "contextualBanditRef", ref)
+	weights := exp.Weights
+	if len(weights) == 0 {
+		weights = getEqualWeights(len(exp.Variations))
+	}
+	exp.ContextualBandit = &CBContext{
+		LeafId:           contextualBanditFallbackLeafId,
+		VariationWeights: weights,
+		BanditVersion:    def.BanditVersion,
+	}
+}

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -1,6 +1,10 @@
 package growthbook
 
-import "github.com/growthbook/growthbook-golang/internal/condition"
+import (
+	"encoding/json"
+
+	"github.com/growthbook/growthbook-golang/internal/condition"
+)
 
 // ContextualBanditContext is one leaf of a contextual bandit definition: a
 // targeting condition and the variation weights to use when it matches.
@@ -19,6 +23,28 @@ type ContextualBanditDefinition struct {
 
 // ContextualBanditDefinitions maps bandit refs to their definitions.
 type ContextualBanditDefinitions map[string]ContextualBanditDefinition
+
+// UnmarshalJSON decodes leniently, dropping malformed definitions instead of
+// erroring: a bandit blob the SDK cannot parse (e.g. a future schema) must
+// not block the feature update it arrived with. Affected rules fall back to
+// their aggregate weights.
+func (defs *ContextualBanditDefinitions) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		*defs = nil
+		return nil
+	}
+	out := make(ContextualBanditDefinitions, len(raw))
+	for ref, rawDef := range raw {
+		var def ContextualBanditDefinition
+		if err := json.Unmarshal(rawDef, &def); err != nil {
+			continue
+		}
+		out[ref] = def
+	}
+	*defs = out
+	return nil
+}
 
 // CBContext is the contextual bandit context an assignment was made with.
 type CBContext struct {

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -249,16 +249,24 @@ func TestContextualBanditRobustness(t *testing.T) {
 
 	t.Run("sticky-bucketed assignments carry no bandit fields", func(t *testing.T) {
 		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
-			WithStickyBucketService(NewInMemoryStickyBucketService()))
+			WithStickyBucketService(NewInMemoryStickyBucketService()),
+			WithDeferredTracking())
 
 		first := client.EvalFeature(ctx, "bandit-flag")
 		require.False(t, first.ExperimentResult.StickyBucketUsed)
 		require.Equal(t, 10, *first.ExperimentResult.LeafId)
+		client.ClearDeferredTrackingCalls()
 
 		second := client.EvalFeature(ctx, "bandit-flag")
 		require.True(t, second.ExperimentResult.StickyBucketUsed)
 		require.Nil(t, second.ExperimentResult.LeafId)
 		require.Nil(t, second.ExperimentResult.VariationWeights)
+		require.Nil(t, second.Experiment.ContextualBandit)
+
+		calls := client.DeferredTrackingCalls()
+		require.Len(t, calls, 1)
+		require.Nil(t, calls[0].Experiment.ContextualBandit)
+		require.Nil(t, calls[0].Result.LeafId)
 	})
 
 	t.Run("undecodable encrypted bandits do not block the feature update", func(t *testing.T) {

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -289,7 +289,8 @@ func TestFeatureRuleMarshalRoundTrip(t *testing.T) {
 	client, err := NewClient(ctx,
 		WithJsonFeatures(`{
 			"exp": {"defaultValue": "d", "rules": [{"key": "e", "coverage": 1, "variations": ["a", "b"], "weights": [1, 0]}]},
-			"null-force": {"defaultValue": "d", "rules": [{"force": null}]}
+			"null-force": {"defaultValue": "d", "rules": [{"force": null}]},
+			"gated": {"defaultValue": "d", "rules": [{"force": "forced", "condition": {"country": "us"}}]}
 		}`),
 		WithAttributes(Attributes{"id": "u"}))
 	require.NoError(t, err)
@@ -303,6 +304,9 @@ func TestFeatureRuleMarshalRoundTrip(t *testing.T) {
 	res := reloaded.EvalFeature(ctx, "exp")
 	require.Equal(t, "a", res.Value)
 	require.Equal(t, ExperimentResultSource, res.Source)
+
+	gated := reloaded.EvalFeature(ctx, "gated")
+	require.Equal(t, "d", gated.Value, "rule conditions survive the round trip")
 
 	nf := reloaded.EvalFeature(ctx, "null-force")
 	require.Nil(t, nf.Value)

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -78,13 +78,18 @@ const banditDefsJSON = `{
   }
 }`
 
-func newBanditTestClient(t *testing.T, attrs Attributes, extra ...ClientOption) *Client {
+func mustBanditDefs(t *testing.T, raw string) ContextualBanditDefinitions {
 	t.Helper()
 	var defs ContextualBanditDefinitions
-	require.NoError(t, json.Unmarshal([]byte(banditDefsJSON), &defs))
+	require.NoError(t, json.Unmarshal([]byte(raw), &defs))
+	return defs
+}
+
+func newBanditTestClient(t *testing.T, attrs Attributes, extra ...ClientOption) *Client {
+	t.Helper()
 	opts := []ClientOption{
 		WithJsonFeatures(banditFeaturesJSON),
-		WithContextualBandits(defs),
+		WithContextualBandits(mustBanditDefs(t, banditDefsJSON)),
 		WithAttributes(attrs),
 	}
 	client, err := NewClient(context.Background(), append(opts, extra...)...)
@@ -296,13 +301,6 @@ func TestFeatureRuleMarshalRoundTrip(t *testing.T) {
 	require.Equal(t, ForceResultSource, nf.Source)
 }
 
-func mustBanditDefs(t *testing.T, raw string) ContextualBanditDefinitions {
-	t.Helper()
-	var defs ContextualBanditDefinitions
-	require.NoError(t, json.Unmarshal([]byte(raw), &defs))
-	return defs
-}
-
 func TestSetContextualBandits(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClient(ctx,
@@ -314,9 +312,7 @@ func TestSetContextualBandits(t *testing.T) {
 	res := client.EvalFeature(ctx, "bandit-flag")
 	require.Nil(t, res.ExperimentResult.LeafId, "no definitions set yet")
 
-	var defs ContextualBanditDefinitions
-	require.NoError(t, json.Unmarshal([]byte(banditDefsJSON), &defs))
-	require.NoError(t, client.SetContextualBandits(defs))
+	require.NoError(t, client.SetContextualBandits(mustBanditDefs(t, banditDefsJSON)))
 
 	res = client.EvalFeature(ctx, "bandit-flag")
 	require.Equal(t, 20, *res.ExperimentResult.LeafId)

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -219,6 +219,38 @@ func TestFeatureRuleUnmarshalErrors(t *testing.T) {
 	require.Error(t, json.Unmarshal([]byte(`"not-an-object"`), &rule))
 }
 
+func TestLooseContextualBanditPayloads(t *testing.T) {
+	// A bandit blob the SDK cannot parse must not block the feature update
+	// it arrived with; parseable definitions survive alongside broken ones.
+	ctx := context.Background()
+	client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1", "country": "nz"}))
+	require.NoError(t, err)
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(`{
+		"features": `+banditFeaturesJSON+`,
+		"contextualBandits": {
+			"cb-broken": {"contexts": [{"leafId": "not-a-number"}]},
+			"cb-1": `+`{
+				"contexts": [{"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]}]
+			}`+`
+		},
+		"dateUpdated": "2030-01-01T00:00:00Z"
+	}`))
+
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, 20, *res.ExperimentResult.LeafId, "parseable definition survives")
+
+	client2, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1"}))
+	require.NoError(t, err)
+	require.NoError(t, client2.UpdateFromApiResponseJSON(`{
+		"features": {"f": {"defaultValue": 1}},
+		"contextualBandits": ["entirely-wrong-shape"],
+		"dateUpdated": "2030-01-01T00:00:00Z"
+	}`))
+	res2 := client2.EvalFeature(ctx, "f")
+	require.Equal(t, 1.0, res2.Value, "features still update")
+}
+
 func TestContextualBanditsFromApiResponse(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1", "country": "nz"}))

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -20,7 +20,8 @@ const banditFeaturesJSON = `{
         "coverage": 1,
         "contextualBanditRef": "cb-1",
         "contextualVariations": ["a", "b"],
-        "weights": [0.5, 0.5]
+        "weights": [0.5, 0.5],
+        "meta": [{"key": "0"}, {"key": "1"}]
       }
     ]
   },
@@ -192,6 +193,114 @@ func TestContextualBanditTracking(t *testing.T) {
 	nb, err := json.Marshal(calls[0])
 	require.NoError(t, err)
 	require.NotContains(t, string(nb), "leafId")
+}
+
+func TestContextualBanditRobustness(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty contextualVariations falls through without panicking", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithJsonFeatures(`{"f": {"defaultValue": "d", "rules": [
+				{"contextualBanditRef": "x", "contextualVariations": []},
+				{"force": "next-rule"}
+			]}}`),
+			WithAttributes(Attributes{"id": "u"}))
+		require.NoError(t, err)
+		res := client.EvalFeature(ctx, "f")
+		require.Equal(t, "next-rule", res.Value)
+	})
+
+	t.Run("RunExperiment with no variations does not panic", func(t *testing.T) {
+		client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u"}))
+		require.NoError(t, err)
+		res := client.RunExperiment(ctx, &Experiment{Key: "empty"})
+		require.False(t, res.InExperiment)
+		require.Nil(t, res.Value)
+	})
+
+	t.Run("leaf weights of the wrong length are sanitized and reported as used", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithContextualBandits(mustBanditDefs(t, `{
+				"cb-1": {"contexts": [{"leafId": 5, "condition": {}, "weights": [1, 0, 0]}]}
+			}`)))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res.InExperiment())
+		require.Equal(t, 5, *res.ExperimentResult.LeafId)
+		require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights)
+	})
+
+	t.Run("a malformed context is dropped without discarding its siblings", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"},
+			WithContextualBandits(mustBanditDefs(t, `{
+				"cb-1": {"contexts": [
+					{"leafId": "junk", "condition": {}, "weights": [1, 0]},
+					{"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]}
+				]}
+			}`)))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.Equal(t, "b", res.Value)
+		require.Equal(t, 20, *res.ExperimentResult.LeafId)
+	})
+
+	t.Run("sticky-bucketed assignments carry no bandit fields", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithStickyBucketService(NewInMemoryStickyBucketService()))
+
+		first := client.EvalFeature(ctx, "bandit-flag")
+		require.False(t, first.ExperimentResult.StickyBucketUsed)
+		require.Equal(t, 10, *first.ExperimentResult.LeafId)
+
+		second := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, second.ExperimentResult.StickyBucketUsed)
+		require.Nil(t, second.ExperimentResult.LeafId)
+		require.Nil(t, second.ExperimentResult.VariationWeights)
+	})
+
+	t.Run("undecodable encrypted bandits do not block the feature update", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithAttributes(Attributes{"id": "u"}),
+			WithDecryptionKey("Ns04T5n9+59rl2x3SlNHtQ=="))
+		require.NoError(t, err)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": {"f": {"defaultValue": 1}},
+			"encryptedContextualBandits": "not-a-valid-blob",
+			"dateUpdated": "2030-01-01T00:00:00Z"
+		}`))
+		res := client.EvalFeature(ctx, "f")
+		require.Equal(t, 1.0, res.Value)
+	})
+}
+
+func TestFeatureRuleMarshalRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(`{
+			"exp": {"defaultValue": "d", "rules": [{"key": "e", "coverage": 1, "variations": ["a", "b"], "weights": [1, 0]}]},
+			"null-force": {"defaultValue": "d", "rules": [{"force": null}]}
+		}`),
+		WithAttributes(Attributes{"id": "u"}))
+	require.NoError(t, err)
+
+	b, err := json.Marshal(client.Features())
+	require.NoError(t, err)
+	reloaded, err := NewClient(ctx, WithAttributes(Attributes{"id": "u"}))
+	require.NoError(t, err)
+	require.NoError(t, reloaded.SetJSONFeatures(string(b)))
+
+	res := reloaded.EvalFeature(ctx, "exp")
+	require.Equal(t, "a", res.Value)
+	require.Equal(t, ExperimentResultSource, res.Source)
+
+	nf := reloaded.EvalFeature(ctx, "null-force")
+	require.Nil(t, nf.Value)
+	require.Equal(t, ForceResultSource, nf.Source)
+}
+
+func mustBanditDefs(t *testing.T, raw string) ContextualBanditDefinitions {
+	t.Helper()
+	var defs ContextualBanditDefinitions
+	require.NoError(t, json.Unmarshal([]byte(raw), &defs))
+	return defs
 }
 
 func TestSetContextualBandits(t *testing.T) {

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -47,6 +47,17 @@ const banditFeaturesJSON = `{
         "weights": [0, 1]
       }
     ]
+  },
+  "bandit-no-weights": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "bandit-nw",
+        "coverage": 1,
+        "contextualBanditRef": "cb-us-only",
+        "contextualVariations": ["a", "b"]
+      }
+    ]
   }
 }`
 
@@ -135,6 +146,15 @@ func TestContextualBanditLeafSelection(t *testing.T) {
 		require.Nil(t, res.Experiment.ContextualBandit)
 	})
 
+	t.Run("no matching leaf and no rule weights falls back to equal weights", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "de"})
+		res := client.EvalFeature(ctx, "bandit-no-weights")
+
+		require.True(t, res.InExperiment())
+		require.Equal(t, -1, *res.ExperimentResult.LeafId)
+		require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights)
+	})
+
 	t.Run("client-forced variations carry no bandit fields", func(t *testing.T) {
 		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
 			WithForcedVariations(ForcedVariationsMap{"bandit-exp": 1}))
@@ -172,6 +192,31 @@ func TestContextualBanditTracking(t *testing.T) {
 	nb, err := json.Marshal(calls[0])
 	require.NoError(t, err)
 	require.NotContains(t, string(nb), "leafId")
+}
+
+func TestSetContextualBandits(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(banditFeaturesJSON),
+		WithAttributes(Attributes{"id": "u1", "country": "nz"}),
+	)
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Nil(t, res.ExperimentResult.LeafId, "no definitions set yet")
+
+	var defs ContextualBanditDefinitions
+	require.NoError(t, json.Unmarshal([]byte(banditDefsJSON), &defs))
+	require.NoError(t, client.SetContextualBandits(defs))
+
+	res = client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, 20, *res.ExperimentResult.LeafId)
+}
+
+func TestFeatureRuleUnmarshalErrors(t *testing.T) {
+	var rule FeatureRule
+	require.Error(t, json.Unmarshal([]byte(`{"force": }`), &rule))
+	require.Error(t, json.Unmarshal([]byte(`"not-an-object"`), &rule))
 }
 
 func TestContextualBanditsFromApiResponse(t *testing.T) {

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -1,0 +1,191 @@
+package growthbook
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The bandit rules carry variations only under contextualVariations, pinning
+// that bandit-aware SDKs evaluate them while older SDKs skip them. Leaf
+// weights of [1,0]/[0,1] make assignments deterministic.
+const banditFeaturesJSON = `{
+  "bandit-flag": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "bandit-exp",
+        "coverage": 1,
+        "contextualBanditRef": "cb-1",
+        "contextualVariations": ["a", "b"],
+        "weights": [0.5, 0.5]
+      }
+    ]
+  },
+  "bandit-no-match": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "bandit-nm",
+        "coverage": 1,
+        "contextualBanditRef": "cb-us-only",
+        "contextualVariations": ["a", "b"],
+        "weights": [0, 1]
+      }
+    ]
+  },
+  "bandit-missing-ref": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "bandit-mr",
+        "coverage": 1,
+        "contextualBanditRef": "cb-nope",
+        "contextualVariations": ["a", "b"],
+        "weights": [0, 1]
+      }
+    ]
+  }
+}`
+
+const banditDefsJSON = `{
+  "cb-1": {
+    "banditVersion": 3,
+    "contexts": [
+      {"leafId": 10, "condition": {"country": "us"}, "weights": [1, 0]},
+      {"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]},
+      {"leafId": 30, "condition": {}, "weights": [1, 0]}
+    ]
+  },
+  "cb-us-only": {
+    "contexts": [
+      {"leafId": 10, "condition": {"country": "us"}, "weights": [1, 0]}
+    ]
+  }
+}`
+
+func newBanditTestClient(t *testing.T, attrs Attributes, extra ...ClientOption) *Client {
+	t.Helper()
+	var defs ContextualBanditDefinitions
+	require.NoError(t, json.Unmarshal([]byte(banditDefsJSON), &defs))
+	opts := []ClientOption{
+		WithJsonFeatures(banditFeaturesJSON),
+		WithContextualBandits(defs),
+		WithAttributes(attrs),
+	}
+	client, err := NewClient(context.Background(), append(opts, extra...)...)
+	require.NoError(t, err)
+	return client
+}
+
+func TestContextualBanditLeafSelection(t *testing.T) {
+	ctx := context.Background()
+	three := 3
+
+	t.Run("first leaf whose condition passes supplies the weights", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"})
+		res := client.EvalFeature(ctx, "bandit-flag")
+
+		require.Equal(t, "a", res.Value)
+		require.True(t, res.InExperiment())
+		r := res.ExperimentResult
+		require.Equal(t, 10, *r.LeafId)
+		require.Equal(t, []float64{1, 0}, r.VariationWeights)
+		require.Equal(t, three, *r.BanditVersion)
+	})
+
+	t.Run("a later leaf matches a different user", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"})
+		res := client.EvalFeature(ctx, "bandit-flag")
+
+		require.Equal(t, "b", res.Value)
+		require.Equal(t, 20, *res.ExperimentResult.LeafId)
+		require.Equal(t, []float64{0, 1}, res.ExperimentResult.VariationWeights)
+	})
+
+	t.Run("an empty condition acts as a catch-all leaf", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "de"})
+		res := client.EvalFeature(ctx, "bandit-flag")
+
+		require.Equal(t, "a", res.Value)
+		require.Equal(t, 30, *res.ExperimentResult.LeafId)
+	})
+
+	t.Run("no matching leaf assigns with aggregate weights under the fallback leaf", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "de"})
+		res := client.EvalFeature(ctx, "bandit-no-match")
+
+		require.Equal(t, "b", res.Value)
+		r := res.ExperimentResult
+		require.Equal(t, -1, *r.LeafId)
+		require.Equal(t, []float64{0, 1}, r.VariationWeights)
+		require.Nil(t, r.BanditVersion)
+	})
+
+	t.Run("a missing definition assigns with aggregate weights and no bandit fields", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"})
+		res := client.EvalFeature(ctx, "bandit-missing-ref")
+
+		require.Equal(t, "b", res.Value)
+		require.True(t, res.InExperiment())
+		require.Nil(t, res.ExperimentResult.LeafId)
+		require.Nil(t, res.ExperimentResult.VariationWeights)
+		require.Nil(t, res.Experiment.ContextualBandit)
+	})
+
+	t.Run("client-forced variations carry no bandit fields", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithForcedVariations(ForcedVariationsMap{"bandit-exp": 1}))
+		res := client.EvalFeature(ctx, "bandit-flag")
+
+		require.Equal(t, "b", res.Value)
+		require.False(t, res.ExperimentResult.HashUsed)
+		require.Nil(t, res.ExperimentResult.LeafId)
+		require.Nil(t, res.Experiment.ContextualBandit)
+	})
+}
+
+func TestContextualBanditTracking(t *testing.T) {
+	ctx := context.Background()
+	client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"}, WithDeferredTracking())
+
+	client.EvalFeature(ctx, "bandit-flag")
+	calls := client.DeferredTrackingCalls()
+	require.Len(t, calls, 1)
+	require.Equal(t, 10, *calls[0].Result.LeafId)
+	require.Equal(t, 10, calls[0].Experiment.ContextualBandit.LeafId)
+
+	b, err := json.Marshal(calls[0])
+	require.NoError(t, err)
+	var m map[string]map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &m))
+	require.Equal(t, "10", string(m["result"]["leafId"]))
+	require.Equal(t, "[1,0]", string(m["result"]["variationWeights"]))
+	require.Equal(t, "3", string(m["result"]["banditVersion"]))
+
+	client.ClearDeferredTrackingCalls()
+	client.EvalFeature(ctx, "bandit-missing-ref")
+	calls = client.DeferredTrackingCalls()
+	require.Len(t, calls, 1)
+	nb, err := json.Marshal(calls[0])
+	require.NoError(t, err)
+	require.NotContains(t, string(nb), "leafId")
+}
+
+func TestContextualBanditsFromApiResponse(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1", "country": "nz"}))
+	require.NoError(t, err)
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(`{
+		"features": `+banditFeaturesJSON+`,
+		"contextualBandits": `+banditDefsJSON+`,
+		"dateUpdated": "2030-01-01T00:00:00Z"
+	}`))
+
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, "b", res.Value)
+	require.Equal(t, 20, *res.ExperimentResult.LeafId)
+}

--- a/evaluator.go
+++ b/evaluator.go
@@ -341,13 +341,18 @@ func (e *evaluator) getExperimentResult(
 		key = meta.Key
 	}
 
+	var value FeatureValue
+	if variationId < len(exp.Variations) {
+		value = exp.Variations[variationId]
+	}
+
 	res := ExperimentResult{
 		Key:              key,
 		FeatureId:        featureId,
 		InExperiment:     inExperiment,
 		HashUsed:         hashUsed,
 		VariationId:      variationId,
-		Value:            exp.Variations[variationId],
+		Value:            value,
 		HashAttribute:    hashAttribute,
 		HashValue:        hashValue,
 		Bucket:           bucket,
@@ -359,7 +364,9 @@ func (e *evaluator) getExperimentResult(
 		res.Passthrough = meta.Passthrough
 	}
 
-	if cb := exp.ContextualBandit; cb != nil && hashUsed && inExperiment {
+	// A sticky-bucketed assignment did not use the leaf weights, so
+	// reporting them would corrupt the bandit's propensity estimates.
+	if cb := exp.ContextualBandit; cb != nil && hashUsed && inExperiment && !isStickyBucketUsed {
 		leafId := cb.LeafId
 		res.LeafId = &leafId
 		res.VariationWeights = cb.VariationWeights
@@ -418,7 +425,11 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 	}
 	res := e.runExperiment(exp, featureId)
 	if exp.ContextualBandit != nil && !(res.HashUsed && res.InExperiment) {
-		exp.ContextualBandit = nil
+		// Detach via copy: subscribers already hold exp, so mutating it here
+		// would race with them.
+		expCopy := *exp
+		expCopy.ContextualBandit = nil
+		exp = &expCopy
 	}
 	if !res.InExperiment || res.Passthrough {
 		return nil

--- a/evaluator.go
+++ b/evaluator.go
@@ -396,7 +396,7 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 		return nil
 	}
 
-	if rule.Force != nil {
+	if rule.forcePresent || rule.Force != nil {
 		if !rule.Condition.Eval(e.client.attributes, e.savedGroups) {
 			return nil
 		}

--- a/evaluator.go
+++ b/evaluator.go
@@ -424,7 +424,7 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 		e.buildContextualBanditExperiment(exp, rule.ContextualBanditRef, featureId)
 	}
 	res := e.runExperiment(exp, featureId)
-	if exp.ContextualBandit != nil && !(res.HashUsed && res.InExperiment) {
+	if exp.ContextualBandit != nil && res.LeafId == nil {
 		// Detach via copy: subscribers already hold exp, so mutating it here
 		// would race with them.
 		expCopy := *exp

--- a/evaluator.go
+++ b/evaluator.go
@@ -9,11 +9,12 @@ import (
 )
 
 type evaluator struct {
-	features    FeatureMap
-	savedGroups condition.SavedGroups
-	evaluated   stack[string]
-	client      *Client
-	ctx         context.Context
+	features          FeatureMap
+	savedGroups       condition.SavedGroups
+	contextualBandits ContextualBanditDefinitions
+	evaluated         stack[string]
+	client            *Client
+	ctx               context.Context
 
 	recording          bool // false when no callbacks, plugins, or buffer consume tracking
 	userCtx            *TrackingUserContext
@@ -358,6 +359,13 @@ func (e *evaluator) getExperimentResult(
 		res.Passthrough = meta.Passthrough
 	}
 
+	if cb := exp.ContextualBandit; cb != nil && hashUsed && inExperiment {
+		leafId := cb.LeafId
+		res.LeafId = &leafId
+		res.VariationWeights = cb.VariationWeights
+		res.BanditVersion = cb.BanditVersion
+	}
+
 	return &res
 }
 
@@ -400,12 +408,18 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 		return getFeatureResult(rule.Force, ForceResultSource, rule.Id, nil, nil)
 	}
 
-	if len(rule.Variations) == 0 {
+	if len(rule.Variations) == 0 && rule.ContextualVariations == nil {
 		return nil
 	}
 
 	exp := experimentFromFeatureRule(featureId, rule)
+	if rule.ContextualBanditRef != "" {
+		e.buildContextualBanditExperiment(exp, rule.ContextualBanditRef, featureId)
+	}
 	res := e.runExperiment(exp, featureId)
+	if exp.ContextualBandit != nil && !(res.HashUsed && res.InExperiment) {
+		exp.ContextualBandit = nil
+	}
 	if !res.InExperiment || res.Passthrough {
 		return nil
 	}

--- a/experiment.go
+++ b/experiment.go
@@ -84,8 +84,6 @@ func experimentFromFeatureRule(featureId string, rule *FeatureRule) *Experiment 
 		expKey = featureId
 	}
 
-	// Contextual bandit rules carry their variations under
-	// ContextualVariations so SDKs without bandit support skip the rule.
 	variations := rule.Variations
 	if rule.ContextualVariations != nil {
 		variations = rule.ContextualVariations

--- a/experiment.go
+++ b/experiment.go
@@ -65,6 +65,9 @@ type Experiment struct {
 	Groups []string `json:"groups"`
 	// Status controls eval: "draft" is skipped unless qaMode/forced, "stopped" only honors Force, "running" is normal.
 	Status ExperimentStatus `json:"status"`
+	// ContextualBandit is set during evaluation when a contextual bandit
+	// decided this experiment's weights.
+	ContextualBandit *CBContext `json:"contextualBandit,omitempty"`
 }
 
 // NewExperiment creates an experiment with default settings: active,
@@ -81,13 +84,20 @@ func experimentFromFeatureRule(featureId string, rule *FeatureRule) *Experiment 
 		expKey = featureId
 	}
 
+	// Contextual bandit rules carry their variations under
+	// ContextualVariations so SDKs without bandit support skip the rule.
+	variations := rule.Variations
+	if rule.ContextualVariations != nil {
+		variations = rule.ContextualVariations
+	}
+
 	// Copy only the fields the JS SDK forwards when building the inline
 	// experiment (sdk-js core.ts evalFeature). ParentConditions are already
 	// evaluated by evalRule, so forwarding them would evaluate prerequisites
 	// twice; URLPatterns/URL/Groups/Status don't exist on JS feature rules.
 	exp := Experiment{
 		Key:                    expKey,
-		Variations:             rule.Variations,
+		Variations:             variations,
 		Coverage:               rule.Coverage,
 		Weights:                rule.Weights,
 		HashAttribute:          rule.HashAttribute,

--- a/experiment_result.go
+++ b/experiment_result.go
@@ -25,4 +25,10 @@ type ExperimentResult struct {
 	Passthrough bool `json:"passthrough"`
 	// If sticky bucketing was used to assign a variation
 	StickyBucketUsed bool `json:"stickyBucketUsed"`
+	// The contextual bandit leaf used for this assignment
+	LeafId *int `json:"leafId,omitempty"`
+	// The variation weights the contextual bandit assigned with
+	VariationWeights []float64 `json:"variationWeights,omitempty"`
+	// The version of the contextual bandit definition used
+	BanditVersion *int `json:"banditVersion,omitempty"`
 }

--- a/feature_api.go
+++ b/feature_api.go
@@ -12,13 +12,15 @@ import (
 )
 
 type FeatureApiResponse struct {
-	Status            int                   `json:"status"`
-	Features          FeatureMap            `json:"features"`
-	DateUpdated       time.Time             `json:"dateUpdated"`
-	SavedGroups       condition.SavedGroups `json:"savedGroups"`
-	EncryptedFeatures string                `json:"encryptedFeatures"`
-	SseSupport        bool
-	Etag              string
+	Status                     int                         `json:"status"`
+	Features                   FeatureMap                  `json:"features"`
+	DateUpdated                time.Time                   `json:"dateUpdated"`
+	SavedGroups                condition.SavedGroups       `json:"savedGroups"`
+	EncryptedFeatures          string                      `json:"encryptedFeatures"`
+	ContextualBandits          ContextualBanditDefinitions `json:"contextualBandits"`
+	EncryptedContextualBandits string                      `json:"encryptedContextualBandits"`
+	SseSupport                 bool
+	Etag                       string
 }
 
 const userAgent = "Growhthbook Go SDK client"

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -48,6 +48,11 @@ type FeatureRule struct {
 	Name string `json:"name"`
 	// The phase id of the experiment
 	Phase string `json:"phase"`
+	// Reference to a contextual bandit definition in the payload
+	ContextualBanditRef string `json:"contextualBanditRef"`
+	// Variations for a contextual bandit rule, carried separately from
+	// Variations so SDKs without bandit support skip the rule
+	ContextualVariations []FeatureValue `json:"contextualVariations"`
 	// Deprecated: ignored during evaluation. Feature rules never carried URL
 	// targeting in the JS SDK; use Experiment.URLPatterns with RunExperiment.
 	URLPatterns []URLTarget `json:"urlPatterns"`

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -1,6 +1,10 @@
 package growthbook
 
-import "github.com/growthbook/growthbook-golang/internal/condition"
+import (
+	"encoding/json"
+
+	"github.com/growthbook/growthbook-golang/internal/condition"
+)
 
 type FeatureRule struct {
 	// Optional rule id, reserved for future use
@@ -65,4 +69,23 @@ type FeatureRule struct {
 	// Deprecated: ignored during evaluation. Feature rules never carried a
 	// status in the JS SDK; use Experiment.Status with RunExperiment.
 	Status ExperimentStatus `json:"status"`
+
+	// forcePresent distinguishes {"force": null} from an absent force: the
+	// JS SDK serves the null (it checks key presence), so Go must too.
+	forcePresent bool
+}
+
+func (r *FeatureRule) UnmarshalJSON(data []byte) error {
+	type alias FeatureRule
+	if err := json.Unmarshal(data, (*alias)(r)); err != nil {
+		return err
+	}
+	var probe struct {
+		Force json.RawMessage `json:"force"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+	r.forcePresent = probe.Force != nil
+	return nil
 }

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -75,6 +75,22 @@ type FeatureRule struct {
 	forcePresent bool
 }
 
+// MarshalJSON omits an absent force so a marshal/unmarshal round trip does
+// not turn every rule into a force-null rule.
+func (r FeatureRule) MarshalJSON() ([]byte, error) {
+	type alias FeatureRule
+	b, err := json.Marshal(alias(r))
+	if err != nil || r.forcePresent || r.Force != nil {
+		return b, err
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	delete(m, "force")
+	return json.Marshal(m)
+}
+
 func (r *FeatureRule) UnmarshalJSON(data []byte) error {
 	type alias FeatureRule
 	if err := json.Unmarshal(data, (*alias)(r)); err != nil {

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -70,8 +70,8 @@ type FeatureRule struct {
 	// status in the JS SDK; use Experiment.Status with RunExperiment.
 	Status ExperimentStatus `json:"status"`
 
-	// forcePresent distinguishes {"force": null} from an absent force: the
-	// JS SDK serves the null (it checks key presence), so Go must too.
+	// forcePresent distinguishes {"force": null} from an absent force, so a
+	// rule forcing null serves it instead of being skipped.
 	forcePresent bool
 }
 

--- a/force_rule_test.go
+++ b/force_rule_test.go
@@ -1,0 +1,51 @@
+package growthbook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForceNullRule(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(`{
+		  "forced-null": {
+		    "defaultValue": "default",
+		    "rules": [{"force": null}, {"force": "second-rule"}]
+		  },
+		  "gated-null": {
+		    "defaultValue": "default",
+		    "rules": [
+		      {"force": null, "condition": {"country": "us"}},
+		      {"force": "second-rule"}
+		    ]
+		  },
+		  "empty-rule": {
+		    "defaultValue": "default",
+		    "rules": [{}]
+		  }
+		}`),
+		WithAttributes(Attributes{"id": "u1", "country": "nz"}),
+	)
+	require.NoError(t, err)
+
+	t.Run("a null force serves null (JS parity)", func(t *testing.T) {
+		res := client.EvalFeature(ctx, "forced-null")
+		require.Nil(t, res.Value)
+		require.Equal(t, ForceResultSource, res.Source)
+		require.True(t, res.Off)
+	})
+
+	t.Run("a null force still honors its condition", func(t *testing.T) {
+		res := client.EvalFeature(ctx, "gated-null")
+		require.Equal(t, "second-rule", res.Value)
+	})
+
+	t.Run("an absent force is not a force rule", func(t *testing.T) {
+		res := client.EvalFeature(ctx, "empty-rule")
+		require.Equal(t, "default", res.Value)
+		require.Equal(t, DefaultValueResultSource, res.Source)
+	})
+}

--- a/internal/condition/marshal.go
+++ b/internal/condition/marshal.go
@@ -11,6 +11,7 @@ import (
 
 type Base struct {
 	cond Condition
+	raw  json.RawMessage
 }
 
 func (base Base) Eval(actual value.Value, groups SavedGroups) bool {
@@ -26,13 +27,26 @@ func (base *Base) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	json := value.New(m)
-	cond, err := buildBaseCond(json)
+	val := value.New(m)
+	cond, err := buildBaseCond(val)
 	if err != nil {
 		return err
 	}
-	*base = Base{cond}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	*base = Base{cond: cond, raw: raw}
 	return nil
+}
+
+// MarshalJSON emits the parsed condition in canonical form, so conditions
+// survive a marshal/unmarshal round trip instead of collapsing to {}.
+func (base Base) MarshalJSON() ([]byte, error) {
+	if base.raw == nil {
+		return []byte("null"), nil
+	}
+	return base.raw, nil
 }
 
 func buildBaseCond(json value.Value) (Condition, error) {

--- a/subscribe.go
+++ b/subscribe.go
@@ -70,6 +70,9 @@ func (r *subscriberRegistry) subscribersForResult(exp *Experiment, res *Experime
 // Subscribe registers a callback fired when an experiment assignment changes.
 // The returned function unregisters it. Subscribers are shared across child
 // clients created via With* methods - register once on the root client.
+// Subscribers are notified during evaluation, so the experiment may carry
+// in-flight state (e.g. a bandit context) the outcome did not use; the
+// result is the authoritative record of the assignment.
 func (client *Client) Subscribe(fn ExperimentSubscriber) (unsubscribe func()) {
 	if fn == nil {
 		return func() {}

--- a/tests/scripts/check_corpus_freshness.py
+++ b/tests/scripts/check_corpus_freshness.py
@@ -55,9 +55,9 @@ SKIPLIST = REPO_ROOT / "tests" / "scripts" / "corpus_skiplist.json"
 DEFAULT_JS_URL = "https://raw.githubusercontent.com/growthbook/growthbook/main/packages/sdk-js/test/cases.json"
 
 # Top-level keys to diff. Other keys in cases.json (specVersion, decrypt
-# binary blobs, urlRedirect which Go doesn't yet wire, contextualBandit which
-# Go doesn't implement) are skipped either because they're scalar metadata or
-# because the divergence is tracked separately.
+# binary blobs, urlRedirect which Go doesn't yet wire) are skipped either
+# because they're scalar metadata or because the divergence is tracked
+# separately.
 KEYS_TO_DIFF = (
     "evalCondition",
     "feature",
@@ -69,6 +69,7 @@ KEYS_TO_DIFF = (
     "inNamespace",
     "getEqualWeights",
     "stickyBucket",
+    "contextualBandit",
 )
 
 

--- a/tests/scripts/corpus_skiplist.json
+++ b/tests/scripts/corpus_skiplist.json
@@ -1,15 +1,6 @@
 {
-  "_doc": "Skiplist for the corpus freshness check (tests/scripts/check_corpus_freshness.py). Two buckets:\n  * \"missing\" — case names JS has and Go deliberately doesn't carry yet. Use when JS adds a case for a feature Go doesn't (yet) support.\n  * \"drift\"   — case names where Go deliberately keeps a different body from JS. Use sparingly — body-drift on a shared case is usually a bug.\nExtras (Go has, JS doesn't) are reported but never fail CI, so they don't need an entry here.\nAdd a brief reason in `_reasons` whenever you add an entry so future maintainers know why.",
-  "missing": {
-    "feature": [
-      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
-      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
-      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
-      "CB rule with empty contexts is overridden by forced variation like a normal experiment"
-    ]
-  },
+  "_doc": "Skiplist for the corpus freshness check (tests/scripts/check_corpus_freshness.py). Two buckets:\n  * \"missing\" \u2014 case names JS has and Go deliberately doesn't carry yet. Use when JS adds a case for a feature Go doesn't (yet) support.\n  * \"drift\"   \u2014 case names where Go deliberately keeps a different body from JS. Use sparingly \u2014 body-drift on a shared case is usually a bug.\nExtras (Go has, JS doesn't) are reported but never fail CI, so they don't need an entry here.\nAdd a brief reason in `_reasons` whenever you add an entry so future maintainers know why.",
+  "missing": {},
   "drift": {},
-  "_reasons": {
-    "feature::CB rule *": "Contextual Bandit (multi-armed-bandit) rule support is not implemented in the Go SDK (spec 0.8.0: contextualBandits payload). The related non-CB cases (multi-armed-bandit/standard type treated as standard experiment, unknown bandit fields ignored) already pass in Go and are carried in cases.json; only the four cases that require CB bucketing are skiplisted. Tracked as a roadmap item; skiplisting keeps the freshness check green while still flagging future non-bandit drift."
-  }
+  "_reasons": {}
 }

--- a/tracking.go
+++ b/tracking.go
@@ -140,6 +140,11 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 		e.userCtx = e.client.trackingUserContext()
 	}
 	expCopy, resCopy := *exp, *res
+	// The result is the truth for bandit attribution: a snapshot must not
+	// claim a context the assignment did not use (e.g. sticky-bucketed).
+	if res.LeafId == nil {
+		expCopy.ContextualBandit = nil
+	}
 	e.experiments = append(e.experiments, TrackingData{Experiment: &expCopy, Result: &resCopy, User: e.userCtx})
 }
 


### PR DESCRIPTION
### What this adds

Contextual bandit support, matching the JS SDK: feature rules carrying a `contextualBanditRef` now evaluate using the bandit definitions served in the SDK payload (encrypted payloads included), instead of being skipped. Definitions decode leniently — a malformed one is dropped and never blocks the feature update it arrived with. Assignments carry `leafId`, `variationWeights`, and `banditVersion` on `ExperimentResult` and in deferred tracking data.

Three deliberate divergences from JS, all in favor of truthful bandit exposures (detailed in the changelog): sticky-bucketed assignments carry no bandit attribution, reported `variationWeights` are the weights the assignment actually used rather than raw invalid ones, and type-malformed contexts are dropped rather than routed with junk attribution.

Also fixes `{"force": null}` rules (JS parity): they now serve the `null` instead of being skipped. And conditions now marshal as their parsed content instead of `{}`, so feature JSON survives a marshal/unmarshal round trip.

### Dependencies

Needs the main repo's sdk-versioning data to declare the `contextualBandits` capability for `go >= 0.5.0`; without it the API won't include bandit definitions in Go payloads.

### Testing

- New `contextual_bandit_test.go` and `force_rule_test.go`: leaf selection and fallbacks, forced variations carrying no bandit fields, tracking JSON shape, the payload ingestion path, and the force-null cases.
- `go test -race ./...` passes. The conformance corpus is synced to spec 0.8.0 from the pinned JS revision — all 35 shared `contextualBandit` cases and the new bandit `feature` cases pass, and the skiplist's CB-unsupported entries are removed.
