### PR TITLE
Fix tracking plugin wire protocol: /track endpoint with JS-standard EventPayload events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- **Fixed:** the GrowthBook tracking plugin now speaks the ingestor's actual
+  wire protocol: `POST {host}/track?client_key=...` with a bare JSON array of
+  `EventPayload` objects, and built-in events use the standard
+  `"Experiment Viewed"` / `"Feature Evaluated"` names and property shapes
+  shared with the JS SDK (previously: a bespoke `{client_key, events}`
+  envelope POSTed to a `/events` endpoint the ingestor does not serve).
+  Events sent by earlier versions were never ingested, so there is no data
+  migration — warehouse tracking simply starts working.
+- **Changed:** built-in experiment/feature events now flow through the
+  event-logger channel, matching the JS SDK: callbacks registered with
+  `WithEventLogger` and plugins implementing `EventLoggerPlugin` receive
+  `"Experiment Viewed"` and `"Feature Evaluated"` events — with the
+  evaluating client's attributes and URL — in addition to custom `LogEvent`
+  events. Match on the new `EventExperimentViewed` / `EventFeatureEvaluated`
+  constants to filter them. Built-in events cover everything the tracking
+  pipeline records, including passthrough and prerequisite exposures.
+- `GrowthBookTrackingPlugin.OnExperimentViewed` / `OnFeatureEvaluated` are
+  now no-ops; the plugin receives built-in events via `OnEvent`, which is
+  how they gain the user attributes the ingestor payload requires.
+
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 
 - **Breaking change:** `ExperimentCallback` gains a `*TrackingUserContext`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ All notable changes to this project will be documented in this file.
 - `GrowthBookTrackingPlugin.OnExperimentViewed` / `OnFeatureEvaluated` are
   now no-ops; the plugin receives built-in events via `OnEvent`, which is
   how they gain the user attributes the ingestor payload requires.
+- Numeric and boolean identifier attributes (`id`, `user_id`, `device_id`,
+  `anonymous_id`, `page_id`, `session_id`) are stringified into the event
+  payload's id fields instead of being emitted as null. The JS plugin nulls
+  non-string identifiers, but Go attributes commonly carry numeric ids and
+  the SDK already stringifies them for hashing — a deliberate divergence so
+  events stay attributable.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,15 @@ The plugin batches events and sends them in the background. Configuration option
 | `HTTPClient` | Client's HTTP client | Custom HTTP client for sending events |
 | `Logger` | Client's logger | Custom logger for error reporting |
 
-Events tracked automatically:
-- **`experiment_viewed`** — when a user is bucketed into an experiment
-- **`feature_evaluated`** — every time a feature flag is evaluated
+Events tracked automatically (standard GrowthBook event names, shared with
+the JS SDK):
+- **`Experiment Viewed`** — when a user is bucketed into an experiment
+- **`Feature Evaluated`** — every time a feature flag is evaluated
+
+Events are sent in the ingestor's standard `EventPayload` shape (`POST
+{IngestorHost}/track?client_key=...` with a JSON array), carrying the
+evaluating client's attributes — so exposures from child clients are
+attributed to the right user.
 
 If plugin initialization fails (e.g., missing client key), the plugin silently becomes a no-op — it never interferes with SDK evaluation.
 
@@ -147,14 +153,21 @@ the ingestor alongside the automatic events:
 client.LogEvent(ctx, "button_clicked", gb.EventProperties{"button": "buy"})
 ```
 
-You can also handle custom events yourself with `WithEventLogger` (with or
-without the tracking plugin — like callbacks, both fire independently):
+You can also handle events yourself with `WithEventLogger` (with or
+without the tracking plugin — like callbacks, both fire independently).
+Matching the JS SDK, the event logger receives the built-in
+`Experiment Viewed` / `Feature Evaluated` events as well as custom
+`LogEvent` events — match on the `gb.EventExperimentViewed` /
+`gb.EventFeatureEvaluated` constants to filter:
 
 ```go
 client, err := gb.NewClient(
     context.Background(),
     gb.WithEventLogger(func(ctx context.Context, eventName string, properties gb.EventProperties, userCtx *gb.EventUserContext) {
-        // Send to your analytics provider; userCtx carries the calling
+        if eventName == gb.EventExperimentViewed || eventName == gb.EventFeatureEvaluated {
+            return // only interested in custom events
+        }
+        // Send to your analytics provider; userCtx carries the evaluating
         // client's attributes and URL.
     }),
 )

--- a/client.go
+++ b/client.go
@@ -247,12 +247,26 @@ func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 		client.deferredTracks.add(client.detachTrackingData(e.experiments))
 	}
 	plugins := client.data.getPlugins()
+	// Built-in events flow through the event-logger channel alongside the
+	// callbacks, mirroring the JS SDK (core.ts onExperimentViewed /
+	// onFeatureUsage fire eventLogger per tracked item). Resolve the user
+	// context once; exposures carry their own snapshot.
+	dispatchEvents := client.hasEventConsumers()
+	var usageCtx *EventUserContext
+	if dispatchEvents && len(e.featureUsage) > 0 {
+		if usageCtx = e.userCtx; usageCtx == nil {
+			usageCtx = client.trackingUserContext()
+		}
+	}
 	for _, u := range e.featureUsage {
 		if client.featureUsageCallback != nil {
 			client.featureUsageCallback(ctx, u.key, u.result, client.extraData)
 		}
 		for _, p := range plugins {
 			client.safePluginFeatureEvaluated(ctx, p, u.key, u.result)
+		}
+		if dispatchEvents {
+			client.dispatchEvent(ctx, EventFeatureEvaluated, featureEvaluatedProperties(u.key, u.result), usageCtx)
 		}
 	}
 	for _, d := range e.experiments {
@@ -262,6 +276,41 @@ func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
 		for _, p := range plugins {
 			client.safePluginExperimentViewed(ctx, p, d.Experiment, d.Result)
 		}
+		if dispatchEvents {
+			client.dispatchEvent(ctx, EventExperimentViewed, experimentViewedProperties(d.Experiment, d.Result), d.User)
+		}
+	}
+}
+
+// experimentViewedProperties builds the "Experiment Viewed" event properties,
+// matching the JS SDK (core.ts onExperimentViewed): variationId is the
+// variation key, not the numeric index.
+func experimentViewedProperties(exp *Experiment, res *ExperimentResult) EventProperties {
+	return EventProperties{
+		"experimentId":  exp.Key,
+		"variationId":   res.Key,
+		"hashAttribute": res.HashAttribute,
+		"hashValue":     res.HashValue,
+	}
+}
+
+// featureEvaluatedProperties builds the "Feature Evaluated" event properties,
+// matching the JS SDK (core.ts onFeatureUsage).
+func featureEvaluatedProperties(key string, res *FeatureResult) EventProperties {
+	ruleId := res.RuleId
+	if res.Source == DefaultValueResultSource {
+		ruleId = "$default"
+	}
+	variationId := ""
+	if res.ExperimentResult != nil {
+		variationId = res.ExperimentResult.Key
+	}
+	return EventProperties{
+		"feature":     key,
+		"source":      string(res.Source),
+		"value":       res.Value,
+		"ruleId":      ruleId,
+		"variationId": variationId,
 	}
 }
 
@@ -295,7 +344,7 @@ func (client *Client) evaluator(ctx context.Context) *evaluator {
 		client:      client,
 		ctx:         ctx,
 		recording: client.experimentCallback != nil || client.featureUsageCallback != nil ||
-			client.deferredTracks != nil || len(client.data.plugins) > 0,
+			client.eventLogger != nil || client.deferredTracks != nil || len(client.data.plugins) > 0,
 	}
 	client.data.mu.RUnlock()
 	return &e

--- a/event_logger.go
+++ b/event_logger.go
@@ -9,6 +9,16 @@ import (
 // EventProperties holds the custom properties attached to a logged event.
 type EventProperties map[string]any
 
+// Built-in event names dispatched through the event-logger channel for
+// every tracked exposure and feature evaluation, mirroring the JS SDK's
+// EVENT_EXPERIMENT_VIEWED / EVENT_FEATURE_EVALUATED (sdk-js core.ts).
+// Event logger callbacks can match on these to filter built-ins from
+// custom LogEvent events.
+const (
+	EventExperimentViewed = "Experiment Viewed"
+	EventFeatureEvaluated = "Feature Evaluated"
+)
+
 // EventUserContext carries the user context a custom event was logged
 // with: the calling client's attributes and URL. It is the Go equivalent
 // of the userContext argument the JS and Python SDKs pass to their event
@@ -21,9 +31,11 @@ type EventUserContext = TrackingUserContext
 type EventLogger func(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext)
 
 // EventLoggerPlugin is an optional interface a [Plugin] can implement to
-// receive custom events from [Client.LogEvent]. [GrowthBookTrackingPlugin]
-// implements it, sending events to the GrowthBook ingestor through the
-// same batching pipeline as experiment and feature events.
+// receive events from the event-logger channel: custom events from
+// [Client.LogEvent] and the built-in [EventExperimentViewed] /
+// [EventFeatureEvaluated] events for every tracked exposure and feature
+// evaluation. [GrowthBookTrackingPlugin] implements it, sending events to
+// the GrowthBook ingestor through one batching pipeline.
 type EventLoggerPlugin interface {
 	OnEvent(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext)
 }
@@ -34,22 +46,41 @@ type EventLoggerPlugin interface {
 // implements [EventLoggerPlugin]. If neither is configured a warning is
 // logged and the call is a no-op.
 func (client *Client) LogEvent(ctx context.Context, eventName string, properties EventProperties) {
-	userCtx := client.trackingUserContext()
+	if !client.dispatchEvent(ctx, eventName, properties, client.trackingUserContext()) {
+		client.logger.WarnContext(ctx, "LogEvent called but no event logger is configured", "event", eventName)
+	}
+}
 
-	logged := false
+// hasEventConsumers reports whether anything listens on the event-logger
+// channel: a WithEventLogger callback or a plugin implementing
+// EventLoggerPlugin.
+func (client *Client) hasEventConsumers() bool {
 	if client.eventLogger != nil {
-		logged = true
+		return true
+	}
+	for _, p := range client.data.getPlugins() {
+		if _, ok := p.(EventLoggerPlugin); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// dispatchEvent fans one event out to the configured event logger and
+// every EventLoggerPlugin. Returns true if any consumer received it.
+func (client *Client) dispatchEvent(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext) bool {
+	dispatched := false
+	if client.eventLogger != nil {
+		dispatched = true
 		client.safeEventLogger(ctx, eventName, properties, userCtx)
 	}
 	for _, p := range client.data.getPlugins() {
 		if ep, ok := p.(EventLoggerPlugin); ok {
-			logged = true
+			dispatched = true
 			client.safePluginOnEvent(ctx, ep, eventName, properties, userCtx)
 		}
 	}
-	if !logged {
-		client.logger.WarnContext(ctx, "LogEvent called but no event logger is configured", "event", eventName)
-	}
+	return dispatched
 }
 
 // safeEventLogger calls the configured event logger, recovering panics.

--- a/tracking_plugin.go
+++ b/tracking_plugin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -16,9 +17,6 @@ const (
 	defaultIngestorHost = "https://us1.gb-ingest.com"
 	defaultBatchSize    = 100
 	defaultBatchTimeout = 10 * time.Second
-
-	eventExperimentViewed = "experiment_viewed"
-	eventFeatureEvaluated = "feature_evaluated"
 )
 
 var (
@@ -81,15 +79,9 @@ type TrackingPluginConfig struct {
 	Logger *slog.Logger
 }
 
-// trackingEvent is the JSON payload for a single tracking event.
+// trackingEvent is the JSON payload for a single tracking event, in the
+// ingestor's EventPayload shape (same as the JS/Python tracking plugins).
 type trackingEvent map[string]any
-
-// trackingRequest is the JSON body sent to the ingestor. Events are
-// pre-marshaled individually in enqueue.
-type trackingRequest struct {
-	Events    []json.RawMessage `json:"events"`
-	ClientKey string            `json:"client_key"`
-}
 
 // GrowthBookTrackingPlugin sends experiment and feature evaluation
 // events to the GrowthBook ingestor for warehouse analytics.
@@ -151,67 +143,24 @@ func (p *GrowthBookTrackingPlugin) Init(client *Client) error {
 	return nil
 }
 
-// OnExperimentViewed enqueues an experiment_viewed event.
-// No-op if the plugin was not successfully initialized.
+// OnExperimentViewed is a no-op: built-in "Experiment Viewed" events
+// arrive via OnEvent through the client's event-logger dispatch, which
+// carries the user context the ingestor payload needs. Retained to
+// satisfy the Plugin interface.
 func (p *GrowthBookTrackingPlugin) OnExperimentViewed(ctx context.Context, experiment *Experiment, result *ExperimentResult) {
-	if !p.initialized {
-		return
-	}
-	event := trackingEvent{
-		"event_type":      eventExperimentViewed,
-		"timestamp":       time.Now().UnixMilli(),
-		"sdk_language":    "go",
-		"sdk_version":     sdkVersion(),
-		"experiment_id":   experiment.Key,
-		"variation_id":    result.VariationId,
-		"variation_key":   result.Key,
-		"variation_value": result.Value,
-		"in_experiment":   result.InExperiment,
-		"hash_used":       result.HashUsed,
-		"hash_attribute":  result.HashAttribute,
-		"hash_value":      result.HashValue,
-	}
-	if experiment.Name != "" {
-		event["experiment_name"] = experiment.Name
-	}
-	if result.FeatureId != "" {
-		event["feature_id"] = result.FeatureId
-	}
-	p.enqueue(event)
 }
 
-// OnFeatureEvaluated enqueues a feature_evaluated event.
-// No-op if the plugin was not successfully initialized.
+// OnFeatureEvaluated is a no-op: built-in "Feature Evaluated" events
+// arrive via OnEvent through the client's event-logger dispatch.
+// Retained to satisfy the Plugin interface.
 func (p *GrowthBookTrackingPlugin) OnFeatureEvaluated(ctx context.Context, featureKey string, result *FeatureResult) {
-	if !p.initialized {
-		return
-	}
-	event := trackingEvent{
-		"event_type":    eventFeatureEvaluated,
-		"timestamp":     time.Now().UnixMilli(),
-		"sdk_language":  "go",
-		"sdk_version":   sdkVersion(),
-		"feature_key":   featureKey,
-		"feature_value": result.Value,
-		"source":        string(result.Source),
-		"on":            result.On,
-		"off":           result.Off,
-	}
-	if result.RuleId != "" {
-		event["rule_id"] = result.RuleId
-	}
-	if result.Experiment != nil {
-		event["experiment_id"] = result.Experiment.Key
-	}
-	if result.ExperimentResult != nil {
-		event["variation_id"] = result.ExperimentResult.VariationId
-	}
-	p.enqueue(event)
 }
 
-// OnEvent enqueues a custom event logged via [Client.LogEvent]. The
-// payload mirrors the EventPayload shape used by the JS and Python
-// tracking plugins (sdk-js plugins/growthbook-tracking.ts getEventPayload).
+// OnEvent enqueues an event from the client's event-logger dispatch: the
+// built-in Experiment Viewed / Feature Evaluated events and custom events
+// logged via [Client.LogEvent]. The payload mirrors the EventPayload shape
+// used by the JS and Python tracking plugins (sdk-js
+// plugins/growthbook-tracking.ts getEventPayload).
 // No-op if the plugin was not successfully initialized.
 func (p *GrowthBookTrackingPlugin) OnEvent(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext) {
 	if !p.initialized {
@@ -397,27 +346,28 @@ func (p *GrowthBookTrackingPlugin) timerFlush() {
 	}
 }
 
-// sendBatch POSTs a batch of events to the ingestor endpoint.
-// Delivery is best-effort: transient errors are logged and the batch
-// is dropped. No retry is attempted to keep the implementation simple
-// and avoid unbounded memory growth or complex retry state.
+// sendBatch POSTs a batch of events to the ingestor: a bare JSON array to
+// {host}/track?client_key={key}, the contract the JS and Python SDKs use
+// and the only one the ingestor documents. Content-Type text/plain matches
+// those SDKs' requests. Delivery is best-effort: transient errors are
+// logged and the batch is dropped. No retry is attempted to keep the
+// implementation simple and avoid unbounded memory growth or complex
+// retry state.
 func (p *GrowthBookTrackingPlugin) sendBatch(ctx context.Context, events []json.RawMessage) {
-	body, err := json.Marshal(trackingRequest{
-		Events:    events,
-		ClientKey: p.clientKey,
-	})
+	body, err := json.Marshal(events)
 	if err != nil {
 		p.logger.Error("Failed to marshal tracking events", "error", err)
 		return
 	}
 
-	url := p.config.IngestorHost + "/events"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	endpoint := p.config.IngestorHost + "/track?client_key=" + url.QueryEscape(p.clientKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		p.logger.Error("Failed to create tracking request", "error", err)
 		return
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", fmt.Sprintf("growthbook-go-sdk/%s", sdkVersion()))
 
 	resp, err := p.httpClient.Do(req)

--- a/tracking_plugin.go
+++ b/tracking_plugin.go
@@ -11,6 +11,8 @@ import (
 	"runtime/debug"
 	"sync"
 	"time"
+
+	"github.com/growthbook/growthbook-golang/internal/value"
 )
 
 const (
@@ -201,9 +203,9 @@ var (
 
 // addEventAttributes splits attributes into the top-level EventPayload
 // fields and the context_json object, like the JS plugin's parseAttributes:
-// id fields are always present (null when not a string), device_id falls
-// back to anonymous_id then id, and UTM/page_title fields are only set
-// when they hold a string.
+// id fields are always present (scalars stringified, null otherwise — see
+// identifierString), device_id falls back to anonymous_id then id, and
+// UTM/page_title fields are only set when they hold a string.
 func addEventAttributes(event trackingEvent, attributes Attributes) {
 	nested := make(map[string]any, len(attributes))
 	for k, v := range attributes {
@@ -221,12 +223,12 @@ func addEventAttributes(event trackingEvent, attributes Attributes) {
 	event["context_json"] = nested
 
 	for attrKey, field := range eventIDAttrKeys {
-		event[field] = stringOrNil(attributes[attrKey])
+		event[field] = identifierString(attributes[attrKey])
 	}
 	event["device_id"] = nil
 	for _, k := range eventDeviceIDAttrKeys {
 		if truthy(attributes[k]) {
-			event["device_id"] = stringOrNil(attributes[k])
+			event["device_id"] = identifierString(attributes[k])
 			break
 		}
 	}
@@ -237,13 +239,21 @@ func addEventAttributes(event trackingEvent, attributes Attributes) {
 	}
 }
 
-// stringOrNil returns the value if it is a string, otherwise nil —
-// like the JS plugin's parseString.
-func stringOrNil(v any) any {
-	if s, ok := v.(string); ok {
-		return s
+// identifierString returns an identifier attribute's value for the event
+// payload: strings pass through, numeric and boolean scalars are stringified
+// with the SDK's JS-toString semantics, everything else is nil. The JS
+// plugin's parseString nulls all non-strings, but Go attributes commonly
+// carry numeric ids (the README's examples do) and the SDK already
+// stringifies them for hashing — nulling them here would strip attribution
+// from every event. A deliberate, documented divergence from the JS plugin.
+func identifierString(v any) any {
+	val := value.New(v)
+	switch val.Type() {
+	case value.StrType, value.NumType, value.BoolType:
+		return val.String()
+	default:
+		return nil
 	}
-	return nil
 }
 
 // Close flushes any remaining events and releases resources. Safe to

--- a/tracking_plugin_test.go
+++ b/tracking_plugin_test.go
@@ -14,10 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// capturedRequest holds the parsed body from a tracking POST.
+// capturedRequest holds one tracking POST: the request metadata the
+// ingestor contract requires plus the parsed bare-array body.
 type capturedRequest struct {
-	ClientKey string          `json:"client_key"`
-	Events    []trackingEvent `json:"events"`
+	Path        string
+	ClientKey   string
+	ContentType string
+	Events      []trackingEvent
 }
 
 // newTestIngestor creates an httptest server that captures tracking requests.
@@ -33,18 +36,42 @@ func newTestIngestor(t *testing.T) (*httptest.Server, *[]capturedRequest, *sync.
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
 		}
-		var req capturedRequest
-		if err := json.Unmarshal(body, &req); err != nil {
-			t.Errorf("failed to unmarshal body: %v", err)
+		var events []trackingEvent
+		if err := json.Unmarshal(body, &events); err != nil {
+			t.Errorf("body is not a bare JSON array of events: %v", err)
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
 		}
 		mu.Lock()
-		reqs = append(reqs, req)
+		reqs = append(reqs, capturedRequest{
+			Path:        r.URL.Path,
+			ClientKey:   r.URL.Query().Get("client_key"),
+			ContentType: r.Header.Get("Content-Type"),
+			Events:      events,
+		})
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	return srv, &reqs, &mu
+}
+
+// eventsByName splits captured events by event_name, asserting the wire
+// contract on every request: POST /track, client_key in the query string,
+// text/plain content type.
+func eventsByName(t *testing.T, captured []capturedRequest, clientKey string) map[string][]trackingEvent {
+	t.Helper()
+	out := make(map[string][]trackingEvent)
+	for _, req := range captured {
+		require.Equal(t, "/track", req.Path)
+		require.Equal(t, clientKey, req.ClientKey)
+		require.Equal(t, "text/plain", req.ContentType)
+		for _, e := range req.Events {
+			name, _ := e["event_name"].(string)
+			require.NotEmpty(t, name, "every event must carry event_name")
+			out[name] = append(out[name], e)
+		}
+	}
+	return out
 }
 
 func getRequests(reqs *[]capturedRequest, mu *sync.Mutex) []capturedRequest {
@@ -87,38 +114,36 @@ func TestTrackingPluginExperimentViewed(t *testing.T) {
 
 	captured := getRequests(reqs, mu)
 	require.NotEmpty(t, captured)
+	byName := eventsByName(t, captured, "sdk-test-key")
 
-	// Collect all events across batches.
-	var allEvents []trackingEvent
-	for _, batch := range captured {
-		require.Equal(t, "sdk-test-key", batch.ClientKey)
-		allEvents = append(allEvents, batch.Events...)
-	}
+	// One exposure evaluation yields exactly one of each built-in event.
+	require.Len(t, byName[EventExperimentViewed], 1, "expected one Experiment Viewed event")
+	require.Len(t, byName[EventFeatureEvaluated], 1, "expected one Feature Evaluated event")
 
-	// Should have both feature_evaluated and experiment_viewed.
-	var expEvent, featEvent trackingEvent
-	for _, e := range allEvents {
-		switch e["event_type"] {
-		case eventExperimentViewed:
-			expEvent = e
-		case eventFeatureEvaluated:
-			featEvent = e
-		}
-	}
-
-	require.NotNil(t, expEvent, "expected experiment_viewed event")
-	require.Equal(t, "exp-feature", expEvent["experiment_id"])
+	expEvent := byName[EventExperimentViewed][0]
+	require.Equal(t, map[string]any{
+		"experimentId":  "exp-feature",
+		"variationId":   "1", // variation key, not the numeric index
+		"hashAttribute": "id",
+		"hashValue":     "user-123",
+	}, expEvent["properties_json"])
 	require.Equal(t, "go", expEvent["sdk_language"])
-	require.Equal(t, true, expEvent["in_experiment"])
-	require.Equal(t, true, expEvent["hash_used"])
-	require.Equal(t, "id", expEvent["hash_attribute"])
-	require.Equal(t, "user-123", expEvent["hash_value"])
-	// client_key belongs in the batch envelope, not individual events
-	require.Nil(t, expEvent["client_key"], "client_key should not be duplicated in individual events")
+	// "id" is lifted to device_id; nothing remains for context_json.
+	require.Equal(t, "user-123", expEvent["device_id"])
+	require.Contains(t, expEvent, "user_id")
+	require.Nil(t, expEvent["user_id"])
+	require.Equal(t, map[string]any{}, expEvent["context_json"])
+	require.NotContains(t, expEvent, "event_type")
+	require.NotContains(t, expEvent, "client_key")
 
-	require.NotNil(t, featEvent, "expected feature_evaluated event")
-	require.Equal(t, "exp-feature", featEvent["feature_key"])
-	require.Equal(t, "experiment", featEvent["source"])
+	featEvent := byName[EventFeatureEvaluated][0]
+	require.Equal(t, map[string]any{
+		"feature":     "exp-feature",
+		"source":      "experiment",
+		"value":       1.0,
+		"ruleId":      "",
+		"variationId": "1",
+	}, featEvent["properties_json"])
 }
 
 func TestTrackingPluginFeatureEvaluated(t *testing.T) {
@@ -147,19 +172,20 @@ func TestTrackingPluginFeatureEvaluated(t *testing.T) {
 	captured := getRequests(reqs, mu)
 	require.NotEmpty(t, captured)
 
-	var allEvents []trackingEvent
-	for _, batch := range captured {
-		allEvents = append(allEvents, batch.Events...)
-	}
+	byName := eventsByName(t, captured, "sdk-test-key")
+	require.Len(t, byName[EventFeatureEvaluated], 1)
+	require.Empty(t, byName[EventExperimentViewed])
 
-	require.Len(t, allEvents, 1)
-	event := allEvents[0]
-	require.Equal(t, eventFeatureEvaluated, event["event_type"])
-	require.Equal(t, "simple-flag", event["feature_key"])
-	require.Equal(t, true, event["feature_value"])
-	require.Equal(t, "defaultValue", event["source"])
-	require.Equal(t, true, event["on"])
-	require.Equal(t, false, event["off"])
+	event := byName[EventFeatureEvaluated][0]
+	// $default marks defaultValue-sourced evaluations, matching the JS SDK.
+	require.Equal(t, map[string]any{
+		"feature":     "simple-flag",
+		"source":      "defaultValue",
+		"value":       true,
+		"ruleId":      "$default",
+		"variationId": "",
+	}, event["properties_json"])
+	require.Equal(t, "user-456", event["device_id"])
 }
 
 func TestTrackingPluginBatching(t *testing.T) {
@@ -350,13 +376,14 @@ func TestTrackingPluginRunExperiment(t *testing.T) {
 
 	captured := getRequests(reqs, mu)
 	require.Len(t, captured, 1)
+	byName := eventsByName(t, captured, "sdk-test-key")
 
-	allEvents := captured[0].Events
-	// RunExperiment produces exactly one event: experiment_viewed.
-	// feature_evaluated is only emitted by EvalFeature.
-	require.Len(t, allEvents, 1)
-	require.Equal(t, eventExperimentViewed, allEvents[0]["event_type"])
-	require.Equal(t, "my-experiment", allEvents[0]["experiment_id"])
+	// RunExperiment produces exactly one event: Experiment Viewed.
+	// Feature Evaluated is only emitted by EvalFeature.
+	require.Len(t, byName[EventExperimentViewed], 1)
+	require.Empty(t, byName[EventFeatureEvaluated])
+	props := byName[EventExperimentViewed][0]["properties_json"].(map[string]any)
+	require.Equal(t, "my-experiment", props["experimentId"])
 }
 
 func TestTrackingPluginWithExistingCallbacks(t *testing.T) {
@@ -397,21 +424,9 @@ func TestTrackingPluginWithExistingCallbacks(t *testing.T) {
 	require.True(t, callbackCalled, "experiment callback should still fire")
 	require.True(t, featureCbCalled, "feature usage callback should still fire")
 
-	var allEvents []trackingEvent
-	for _, batch := range getRequests(reqs, mu) {
-		allEvents = append(allEvents, batch.Events...)
-	}
-	var hasExpViewed, hasFeatEval bool
-	for _, e := range allEvents {
-		switch e["event_type"] {
-		case eventExperimentViewed:
-			hasExpViewed = true
-		case eventFeatureEvaluated:
-			hasFeatEval = true
-		}
-	}
-	require.True(t, hasExpViewed, "plugin should have sent experiment_viewed")
-	require.True(t, hasFeatEval, "plugin should have sent feature_evaluated")
+	byName := eventsByName(t, getRequests(reqs, mu), "sdk-test-key")
+	require.NotEmpty(t, byName[EventExperimentViewed], "plugin should have sent Experiment Viewed")
+	require.NotEmpty(t, byName[EventFeatureEvaluated], "plugin should have sent Feature Evaluated")
 }
 
 func TestTrackingPluginChildClientSharesPlugin(t *testing.T) {
@@ -648,4 +663,74 @@ func TestTrackingPluginBadPropertyDropsOnlyThatEvent(t *testing.T) {
 	require.Len(t, captured, 1)
 	require.Len(t, captured[0].Events, 1)
 	require.Equal(t, "good_event", captured[0].Events[0]["event_name"])
+}
+
+// Built-in events flow through the event-logger channel, so a WithEventLogger
+// callback receives them even without the tracking plugin — matching the JS
+// SDK, where eventLogger gets "Experiment Viewed"/"Feature Evaluated" too.
+func TestBuiltInEventsReachEventLogger(t *testing.T) {
+	ctx := context.Background()
+	var mu sync.Mutex
+	got := map[string][]EventProperties{}
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "user-123"}),
+		WithEventLogger(func(ctx context.Context, eventName string, properties EventProperties, userCtx *EventUserContext) {
+			mu.Lock()
+			got[eventName] = append(got[eventName], properties)
+			mu.Unlock()
+			require.NotNil(t, userCtx)
+			require.Equal(t, Attributes{"id": "user-123"}, userCtx.Attributes)
+		}),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	featuresJSON := `{
+		"exp-feature": {
+			"defaultValue": 0,
+			"rules": [{"variations": [0, 1]}]
+		}
+	}`
+	require.NoError(t, client.SetJSONFeatures(featuresJSON))
+
+	res := client.EvalFeature(ctx, "exp-feature")
+	require.True(t, res.InExperiment())
+
+	require.Len(t, got[EventFeatureEvaluated], 1)
+	require.Len(t, got[EventExperimentViewed], 1)
+	require.Equal(t, "exp-feature", got[EventExperimentViewed][0]["experimentId"])
+	require.Equal(t, res.ExperimentResult.Key, got[EventExperimentViewed][0]["variationId"])
+}
+
+// Events emitted from a child client's evaluation must carry the child's
+// attributes, not the root client's.
+func TestTrackingPluginChildClientAttributes(t *testing.T) {
+	srv, reqs, mu := newTestIngestor(t)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithClientKey("sdk-test-key"),
+		WithAttributes(Attributes{"id": "parent-user", "user_id": "parent-user"}),
+		WithGrowthBookTracking(TrackingPluginConfig{
+			IngestorHost: srv.URL,
+			BatchSize:    1,
+		}),
+	)
+	require.NoError(t, err)
+
+	featuresJSON := `{"flag": {"defaultValue": true}}`
+	require.NoError(t, client.SetJSONFeatures(featuresJSON))
+
+	child, err := client.WithAttributes(Attributes{"id": "child-user", "user_id": "child-user"})
+	require.NoError(t, err)
+	child.EvalFeature(ctx, "flag")
+
+	require.NoError(t, client.Close())
+
+	byName := eventsByName(t, getRequests(reqs, mu), "sdk-test-key")
+	require.Len(t, byName[EventFeatureEvaluated], 1)
+	event := byName[EventFeatureEvaluated][0]
+	require.Equal(t, "child-user", event["user_id"])
+	require.Equal(t, "child-user", event["device_id"])
 }

--- a/tracking_plugin_test.go
+++ b/tracking_plugin_test.go
@@ -734,3 +734,32 @@ func TestTrackingPluginChildClientAttributes(t *testing.T) {
 	require.Equal(t, "child-user", event["user_id"])
 	require.Equal(t, "child-user", event["device_id"])
 }
+
+// Numeric identifier attributes must stringify into the id fields — the
+// README documents numeric ids (Attributes{"id": 100}), and the SDK already
+// stringifies them for hashing. (The JS plugin nulls non-strings; deliberate
+// divergence.)
+func TestTrackingPluginNumericIdentifiers(t *testing.T) {
+	srv, reqs, mu := newTestIngestor(t)
+	defer srv.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithClientKey("sdk-test-key"),
+		WithAttributes(Attributes{"id": 100, "user_id": 42}),
+		WithGrowthBookTracking(TrackingPluginConfig{
+			IngestorHost: srv.URL,
+			BatchSize:    1,
+		}),
+	)
+	require.NoError(t, err)
+
+	client.LogEvent(ctx, "numeric_ids", nil)
+	require.NoError(t, client.Close())
+
+	byName := eventsByName(t, getRequests(reqs, mu), "sdk-test-key")
+	require.Len(t, byName["numeric_ids"], 1)
+	event := byName["numeric_ids"][0]
+	require.Equal(t, "42", event["user_id"])
+	require.Equal(t, "100", event["device_id"])
+}


### PR DESCRIPTION
## Summary

Update tracking plugin to send events to `/track` GrowthBook ingestor and fix payload structure. 

## Root cause

- Go POSTs `{"client_key":..., "events":[...]}` to `{host}/events` with flat `event_type`-keyed events. The ingestor's only documented endpoint is `POST {host}/track?client_key=...` with a bare JSON array of `EventPayload` objects ([managed-warehouse docs](https://docs.growthbook.io/app/managed-warehouse#ingestion-api)); 
- the back-end warehouse schemas require `event_name` (no `event_type` column exists) and route by the canonical `"Experiment Viewed"`/`"Feature Evaluated"` names with camelCase property columns.

## Behavioral change

- Transport: `POST {IngestorHost}/track?client_key=...`, bare JSON array, `Content-Type: text/plain` (matching JS/Python byte-for-byte in shape).
- Built-ins are `"Experiment Viewed"` (`{experimentId, variationId, hashAttribute, hashValue}`) and `"Feature Evaluated"` (`{feature, source, value, ruleId ("$default" for defaults), variationId}`) in the shared `EventPayload` envelope — `variationId` is the variation key, per the JS SDK.
- Built-ins dispatch through the event-logger channel from `fireTracking`, so they cover everything the tracking pipeline records (passthrough + prerequisite exposures from #84 included) and carry the evaluation-time `TrackingUserContext` — child-client attributes attribute correctly.
- `WithEventLogger` callbacks and `EventLoggerPlugin`s now receive built-ins in addition to custom `LogEvent` events, matching JS `eventLogger` semantics. New `EventExperimentViewed`/`EventFeatureEvaluated` constants for filtering.
- Numeric/boolean identifier attributes (`id`, `user_id`, etc.) are stringified into the payload's id fields instead of emitted as null — the JS plugin nulls non-strings, but Go's README documents numeric ids and the SDK already stringifies them for hashing (deliberate divergence, flagged by review; `TestTrackingPluginNumericIdentifiers` pins it).
- `GrowthBookTrackingPlugin.OnExperimentViewed`/`OnFeatureEvaluated` are now documented no-ops (single intake via `OnEvent`; no double-fire). No compiled-API changes.

## Test plan

- [x] Contract pinned in every plugin test via a shared helper: path `/track`, `client_key` query param, `text/plain`, bare-array body, `event_name` on every event
- [x] Exact payload shapes asserted for both built-ins ($default ruleId, variation-key variationId, device_id fallback, context_json split)
- [x] New: one exposure → exactly one Experiment Viewed (no double-fire); built-ins reach `WithEventLogger` without the plugin; child-client attributes land in events
- [x] E2E against gb-sim-harness's ingestor stub (independent implementation written against real JS traffic): existing live test pointed at it — events accepted, captured jsonl structurally identical to production JS bundle captures, zero bad-body rejections
- [x] `go test -race ./...` green; `go vet`/`gofmt` clean
- [ ] Maintainer live gate: run `GB_CLIENT_KEY=<real key> go test -tags live_tracking_test -run TestLiveTrackingPlugin -v .` against the real ingestor and confirm rows in the dashboard / SQL Explorer
