### PR TITLE
Skip sticky-bucket save cycle in steady state; fix negative bucketVersion key mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes to this project will be documented in this file.
   non-string identifiers, but Go attributes commonly carry numeric ids and
   the SDK already stringifies them for hashing — a deliberate divergence so
   events stay attributable.
+- Fixed: a negative experiment `bucketVersion` saved sticky assignments under
+  a different key than reads looked up (`exp__-1` vs `exp__0`), so the saved
+  assignment was never found again. Keys now normalize negative versions to
+  0 in one place, for reads and saves alike.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ All notable changes to this project will be documented in this file.
   non-string identifiers, but Go attributes commonly carry numeric ids and
   the SDK already stringifies them for hashing — a deliberate divergence so
   events stay attributable.
+- Steady-state evaluations no longer call the sticky bucket service: when
+  the client's assignment cache already holds the exact assignment for the
+  primary hash attribute, the save short-circuits before taking the
+  per-document lock and re-reading the service. Previously every
+  in-experiment evaluation performed one `GetAssignments` round-trip under
+  the doc lock just to discover nothing changed — JS and Python answer this
+  from memory. Fallback-to-primary doc upgrades are unaffected (the check is
+  against the primary doc only).
 - Fixed: a negative experiment `bucketVersion` saved sticky assignments under
   a different key than reads looked up (`exp__-1` vs `exp__0`), so the saved
   assignment was never found again. Keys now normalize negative versions to

--- a/evaluator.go
+++ b/evaluator.go
@@ -273,7 +273,11 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 	// 13. Build the result object
 	result := e.experimentResult(exp, stickyBucketVariation, true, featureId, n, stickyBucketFound)
 
-	// 13.5 Save sticky bucket assignment if in experiment and sticky bucketing is enabled
+	// 13.5 Save sticky bucket assignment if in experiment and sticky bucketing is enabled.
+	// saveStickyBucketAssignment short-circuits from the client cache when
+	// the primary doc already holds this assignment; the check must be
+	// against the primary doc, not the sticky match, because a match found
+	// via the fallback doc still needs upgrading into the hash-attribute doc.
 	if e.client.stickyBucketService != nil && !exp.DisableStickyBucketing && result.InExperiment {
 		// Create the sticky bucket assignment and save it
 		saveStickyBucketAssignment(

--- a/sticky_bucket.go
+++ b/sticky_bucket.go
@@ -540,11 +540,15 @@ func saveStickyBucketAssignment(
 
 	// Only save if a change was detected
 	if data.Doc != nil && data.Changed {
-		// Update cache if provided
+		// Persist first, cache second: the cache feeds the fast path above,
+		// so it must only hold assignments the service accepted — caching a
+		// failed write would stop every future evaluation from retrying it.
+		if err := service.SaveAssignments(data.Doc); err != nil {
+			return err
+		}
 		if cache != nil {
 			cache.set(data.Key, data.Doc)
 		}
-		return service.SaveAssignments(data.Doc)
 	}
 
 	return nil

--- a/sticky_bucket.go
+++ b/sticky_bucket.go
@@ -503,6 +503,21 @@ func saveStickyBucketAssignment(
 
 	experimentVersionKey := getStickyBucketExperimentKey(experimentKey, bucketVersion)
 
+	// Fast path: when the client cache already holds this exact assignment,
+	// the save is a guaranteed no-op — skip the doc lock and the service
+	// read that GenerateStickyBucketAssignmentDoc would make to compute
+	// Changed == false. This matches JS/Python, which answer "unchanged?"
+	// from memory without touching the store (sdk-js core.ts
+	// generateStickyBucketAssignmentDoc). Falls through on a cache miss
+	// (e.g. LRU eviction).
+	if cache != nil {
+		if doc, ok := cache.get(getKey(attributeName, attributeValue)); ok && doc != nil {
+			if existing, ok := doc.Assignments[experimentVersionKey]; ok && existing == variationKey {
+				return nil
+			}
+		}
+	}
+
 	// Saving is a read-modify-write cycle: serialize it per document so
 	// concurrent saves for the same user merge instead of the last write
 	// dropping the other's assignment.

--- a/sticky_bucket.go
+++ b/sticky_bucket.go
@@ -245,8 +245,15 @@ func (s *InMemoryStickyBucketService) Destroy() {
 
 // Helper functions for sticky bucketing
 
-// getStickyBucketExperimentKey generates a key for storing experiment assignments
+// getStickyBucketExperimentKey generates a key for storing experiment
+// assignments. Negative versions normalize to 0 here, in the one place keys
+// are built, so reads (which already defaulted negatives to 0) and saves
+// agree on the key — previously a negative BucketVersion read "exp__0" but
+// saved "exp__-1", so the saved assignment was never found again.
 func getStickyBucketExperimentKey(experimentKey string, bucketVersion int) string {
+	if bucketVersion < 0 {
+		bucketVersion = 0
+	}
 	return fmt.Sprintf("%s__%d", experimentKey, bucketVersion)
 }
 
@@ -494,6 +501,8 @@ func saveStickyBucketAssignment(
 		return nil
 	}
 
+	experimentVersionKey := getStickyBucketExperimentKey(experimentKey, bucketVersion)
+
 	// Saving is a read-modify-write cycle: serialize it per document so
 	// concurrent saves for the same user merge instead of the last write
 	// dropping the other's assignment.
@@ -504,7 +513,6 @@ func saveStickyBucketAssignment(
 
 	// Create assignment map with the experiment key and variation key
 	assignments := make(map[string]string)
-	experimentVersionKey := getStickyBucketExperimentKey(experimentKey, bucketVersion)
 	assignments[experimentVersionKey] = variationKey
 
 	// Generate the sticky bucket assignment document

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -759,3 +759,37 @@ func TestStickyBucketFalsyFallbackAttributeIgnored(t *testing.T) {
 	require.False(t, res.ExperimentResult.StickyBucketUsed,
 		"sticky doc keyed by falsy fallback value must not be applied")
 }
+
+// A negative bucketVersion must read and write the same assignment key.
+// Previously the read normalized -1 to 0 ("exp__0") while the save wrote
+// "exp__-1", so the saved assignment was never found again.
+func TestStickyBucketNegativeBucketVersionRoundTrip(t *testing.T) {
+	ctx := context.TODO()
+	service := NewInMemoryStickyBucketService()
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "neg-user"}),
+		WithStickyBucketService(service),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	exp := &Experiment{
+		Key:           "neg-exp",
+		Variations:    []FeatureValue{"control", "treatment"},
+		Meta:          []VariationMeta{{Key: "0"}, {Key: "1"}},
+		BucketVersion: -1,
+	}
+
+	res1 := client.RunExperiment(ctx, exp)
+	require.True(t, res1.InExperiment)
+
+	doc, err := service.GetAssignments("id", "neg-user")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Contains(t, doc.Assignments, "neg-exp__0",
+		"negative bucketVersion must normalize to 0 in the saved key")
+
+	res2 := client.RunExperiment(ctx, exp)
+	require.True(t, res2.StickyBucketUsed,
+		"second run must find the assignment saved by the first")
+}

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -760,6 +760,51 @@ func TestStickyBucketFalsyFallbackAttributeIgnored(t *testing.T) {
 		"sticky doc keyed by falsy fallback value must not be applied")
 }
 
+// Steady state: once an assignment is saved and cached, repeat evaluations
+// must not touch the sticky bucket service at all — JS/Python answer
+// "unchanged?" from memory, and the save is skipped entirely when the
+// variation came from the sticky bucket (evaluator step 13.5).
+func TestStickyBucketSteadyStateNoServiceCalls(t *testing.T) {
+	ctx := context.TODO()
+	var calls atomic.Int32
+	svc := &mockStickyBucketService{
+		InMemoryStickyBucketService: NewInMemoryStickyBucketService(),
+		onGetAssignments: func(_, _ string) {
+			calls.Add(1)
+		},
+	}
+
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "steady-user"}),
+		WithFeatures(FeatureMap{
+			"feature": {
+				DefaultValue: 0,
+				Rules: []FeatureRule{{
+					Variations: []FeatureValue{0, 1},
+					Meta:       []VariationMeta{{Key: "0"}, {Key: "1"}},
+				}},
+			},
+		}),
+		WithStickyBucketService(svc),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	// First evaluation: read miss + save cycle both hit the service.
+	res1 := client.EvalFeature(ctx, "feature")
+	require.True(t, res1.InExperiment())
+	require.Positive(t, calls.Load())
+
+	// Steady state: everything answered from the client cache.
+	calls.Store(0)
+	res2 := client.EvalFeature(ctx, "feature")
+	require.True(t, res2.InExperiment())
+	require.True(t, res2.ExperimentResult.StickyBucketUsed)
+	require.Equal(t, res1.Value, res2.Value)
+	require.Equal(t, int32(0), calls.Load(),
+		"steady-state evaluation must not call the sticky bucket service")
+}
+
 // A negative bucketVersion must read and write the same assignment key.
 // Previously the read normalized -1 to 0 ("exp__0") while the save wrote
 // "exp__-1", so the saved assignment was never found again.

--- a/sticky_bucket_test.go
+++ b/sticky_bucket_test.go
@@ -838,3 +838,67 @@ func TestStickyBucketNegativeBucketVersionRoundTrip(t *testing.T) {
 	require.True(t, res2.StickyBucketUsed,
 		"second run must find the assignment saved by the first")
 }
+
+// failingSaveService fails SaveAssignments on demand, counting attempts.
+type failingSaveService struct {
+	*InMemoryStickyBucketService
+	failSaves atomic.Bool
+	saveCalls atomic.Int32
+}
+
+func (s *failingSaveService) SaveAssignments(doc *StickyBucketAssignmentDoc) error {
+	s.saveCalls.Add(1)
+	if s.failSaves.Load() {
+		return fmt.Errorf("service unavailable")
+	}
+	return s.InMemoryStickyBucketService.SaveAssignments(doc)
+}
+
+// A failed SaveAssignments must not populate the cache: the fast path would
+// then treat the assignment as persisted and no evaluation would ever retry
+// the missing durable write.
+func TestStickyBucketFailedSaveRetries(t *testing.T) {
+	ctx := context.TODO()
+	svc := &failingSaveService{InMemoryStickyBucketService: NewInMemoryStickyBucketService()}
+	svc.failSaves.Store(true)
+
+	client, err := NewClient(ctx,
+		WithAttributes(Attributes{"id": "retry-user"}),
+		WithFeatures(FeatureMap{
+			"feature": {
+				DefaultValue: 0,
+				Rules: []FeatureRule{{
+					Variations: []FeatureValue{0, 1},
+					Meta:       []VariationMeta{{Key: "0"}, {Key: "1"}},
+				}},
+			},
+		}),
+		WithStickyBucketService(svc),
+		withSilentTestLogger(),
+	)
+	require.NoError(t, err)
+
+	// First evaluation: the save is attempted and fails.
+	res1 := client.EvalFeature(ctx, "feature")
+	require.True(t, res1.InExperiment())
+	require.Equal(t, int32(1), svc.saveCalls.Load())
+
+	// The failed write must be retried, not treated as persisted.
+	client.EvalFeature(ctx, "feature")
+	require.Equal(t, int32(2), svc.saveCalls.Load(),
+		"failed save must be retried on the next evaluation")
+
+	// Service recovers: the retry persists the assignment...
+	svc.failSaves.Store(false)
+	client.EvalFeature(ctx, "feature")
+	require.Equal(t, int32(3), svc.saveCalls.Load())
+	doc, err := svc.GetAssignments("id", "retry-user")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Contains(t, doc.Assignments, "feature__0")
+
+	// ...and only then does the steady-state fast path kick in.
+	client.EvalFeature(ctx, "feature")
+	require.Equal(t, int32(3), svc.saveCalls.Load(),
+		"persisted assignment must not be re-saved")
+}


### PR DESCRIPTION
## Summary

Removes the sticky-bucket service round-trip from steady-state evaluations, and fixes a latent key mismatch for negative `bucketVersion` values found while auditing the save path.

## Root cause

- Every in-experiment evaluation with a sticky bucket service ran the full save cycle: take the per-document lock, `service.GetAssignments` (the `Changed` comparison lives behind that read), then skip the write on `Changed == false`. In steady state that is one backend read per evaluation, held under the per-user doc lock — concurrent evaluations of the same user serialize behind each other's service I/O. Go was the only SDK doing this: JS (`core.ts generateStickyBucketAssignmentDoc`) and Python compute `changed` from memory and never touch the store on the no-op path.
- Separately: reads normalize `bucketVersion < 0` to 0 but the save didn't, so a negative version saved `exp__-1` while lookups asked for `exp__0` — the assignment was never found again.

## Behavioral change

- `saveStickyBucketAssignment` short-circuits before locking when the client's cached **primary** doc already maps the experiment-version key to this variation key. Cache miss (e.g. LRU eviction) falls through to the full cycle unchanged. The check is deliberately against the primary doc only — an assignment matched via the fallback doc still runs the save so the fallback→hashAttribute upgrade keeps working (the conformance corpus's upgrade case caught the broader skip during development and pins this).
- Steady-state cost drops from 1 service read + doc lock per in-experiment evaluation to a single LRU lookup.
- The cache is now written only after `SaveAssignments` succeeds (previously before), so a failed write is retried on the next evaluation instead of the fast path treating it as persisted — cache entries always reflect service-accepted state (flagged by review; `TestStickyBucketFailedSaveRetries` pins retry-until-success then fast-path).
- `getStickyBucketExperimentKey` normalizes negative versions in the one place keys are built.

## Test plan

- [x] New `TestStickyBucketSteadyStateNoServiceCalls` — second evaluation performs zero service calls (failed pre-fix: 1 call per eval)
- [x] New `TestStickyBucketNegativeBucketVersionRoundTrip` — assignment saved under `exp__0` and found on re-run (failed pre-fix)
- [x] Conformance corpus unchanged and green, including `upgrades a sticky bucket doc from a fallbackAttribute to a hashAttribute`
- [x] `go test -race ./...` green; `go vet`/`gofmt` clean

## Follow-ups

Deliberately not included: making the rare real write fire-and-forget like JS/Python (needs error-visibility and Close/drain design). The short-circuit removes the steady-state cost, which was the hot-path issue.

