### PR TITLE
Caller-owned tracking buffer; collision-free exposure dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file.
 - **Added:** `TrackingBuffer` is now an exported, caller-owned type:
   `NewTrackingBuffer()` creates one, `WithTrackingBuffer(buf)` (option and
   child-client method) attaches it, `TrackingCalls()` reads detached copies
-  without draining, and `Clear()` empties it. Attach one buffer per request
+  without draining, `TakeTrackingCalls()` atomically drains (returns and
+  empties in one step, so concurrent exposures are never cleared without
+  being returned), and `Clear()` empties it. Attach one buffer per request
   or user scope; clones of a client share its attached buffer by design.
   `WithDeferredTracking()` remains supported as the convenience form
   (`WithTrackingBuffer(NewTrackingBuffer())`), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- **Added:** `TrackingBuffer` is now an exported, caller-owned type:
+  `NewTrackingBuffer()` creates one, `WithTrackingBuffer(buf)` (option and
+  child-client method) attaches it, `TrackingCalls()` reads detached copies
+  without draining, and `Clear()` empties it. Attach one buffer per request
+  or user scope; clones of a client share its attached buffer by design.
+  `WithDeferredTracking()` remains supported as the convenience form
+  (`WithTrackingBuffer(NewTrackingBuffer())`), and
+  `Client.DeferredTrackingCalls()` / `ClearDeferredTrackingCalls()` delegate
+  to the attached buffer either way. Nothing breaks: existing code compiles
+  and behaves identically.
+- **Fixed:** exposure deduplication now uses a field-wise comparable key
+  instead of a NUL-delimited string, so two distinct exposures whose
+  attribute values contain the delimiter byte can no longer collide (a
+  collision silently dropped the second exposure from the deferred buffer).
+- **Deprecated:** `TrackingData.DedupeKey()`. It is informational only — the
+  SDK no longer dedupes on its string encoding — and it keeps the collision
+  behavior described above.
 - **Fixed:** the GrowthBook tracking plugin now speaks the ingestor's actual
   wire protocol: `POST {host}/track?client_key=...` with a bare JSON array of
   `EventPayload` objects, and built-in events use the standard

--- a/README.md
+++ b/README.md
@@ -213,38 +213,47 @@ produces — including passthrough assignments and experiments inside
 prerequisite features — so you can read the buffer and forward it, instead of
 intercepting callbacks.
 
-Enable it with `WithDeferredTracking`. The usual pattern is one child client
-per user request; the child acts as the user context, so every request gets
-its own buffer:
+Create a `TrackingBuffer` and attach it with `WithTrackingBuffer`. The usual
+pattern is one buffer and one child client per user request; the child acts
+as the user context, and you hold the buffer handle:
 
 ```go
+buf := gb.NewTrackingBuffer()
 child, _ := client.WithAttributes(gb.Attributes{"id": userID})
-child, _ = child.WithDeferredTracking()
+child, _ = child.WithTrackingBuffer(buf)
 
 child.EvalFeature(ctx, "feature-a")
 child.EvalFeature(ctx, "feature-b")
 
-exposures := child.DeferredTrackingCalls() // []gb.TrackingData
+exposures := buf.TrackingCalls() // []gb.TrackingData
 ```
+
+`WithDeferredTracking()` is the convenience form — it attaches a fresh
+internal buffer, readable through `Client.DeferredTrackingCalls()` and
+cleared with `Client.ClearDeferredTrackingCalls()` (both delegate to the
+attached buffer, whichever way it was attached).
 
 Good to know:
 
 - The buffer keeps one entry per unique assignment (same user, experiment,
   and variation), in the order they were first seen. Reads return detached
-  copies, safe to retain or mutate; `ClearDeferredTrackingCalls` empties the
-  buffer.
+  copies, safe to retain or mutate, and don't drain the buffer; `Clear`
+  empties it, including its dedupe memory.
 - `TrackingData` marshals to the same JSON shape as the JS SDK's tracking
   data — including the `user` context the evaluation ran with — so a
   forwarded list can be passed directly to a JS client's
   `setDeferredTrackingCalls`.
-- Child clients cloned from an armed client share its buffer. Calling
-  `WithDeferredTracking` again gives the new client a fresh, separate buffer.
-- Arming a shared client also works — the buffer is safe for concurrent use
-  and entries carry their user identity — but you lose the per-request
-  boundary, so prefer arming per-request children.
-- Callbacks and plugins are unaffected and keep firing. If you both forward
-  the buffer and track via callbacks, you'll report exposures twice — pick
-  one channel.
+- Child clients cloned from a client with a buffer share it — the attacher
+  chooses the scope. Attaching a different buffer (or nil) detaches the new
+  client from the parent's.
+- Attaching one buffer to a long-lived shared client also works — the buffer
+  is safe for concurrent use and entries carry their user identity — but it
+  grows without bound until cleared, so prefer one buffer per request.
+- Buffering is independent of callbacks and plugins: both always fire. The
+  buffer exists to forward exposures to a client SDK that reports them
+  *there*; if a server-side callback reports to the same analytics
+  destination, that destination sees each exposure twice — route each
+  destination through one channel.
 - Feature usage is not buffered, only experiment exposures. Usage events
   describe where evaluation happened, and remote-evaluation clients report
   their own; on the server they still reach callbacks and plugins.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,10 @@ Good to know:
   client from the parent's.
 - Attaching one buffer to a long-lived shared client also works — the buffer
   is safe for concurrent use and entries carry their user identity — but it
-  grows without bound until cleared, so prefer one buffer per request.
+  grows without bound until drained, so prefer one buffer per request. When
+  draining a shared buffer in a loop, use `TakeTrackingCalls()` (or
+  `Client.TakeDeferredTrackingCalls()`): it returns and empties atomically,
+  so an exposure recorded mid-drain is never cleared without being returned.
 - Buffering is independent of callbacks and plugins: both always fire. The
   buffer exists to forward exposures to a client SDK that reports them
   *there*; if a server-side callback reports to the same analytics

--- a/client.go
+++ b/client.go
@@ -41,9 +41,10 @@ type Client struct {
 	// cloned clients and mutated during evaluation, hence mutex-guarded.
 	stickyBucketAssignments *lockedStickyBucketCache
 
-	// deferredTracks buffers experiment exposures when deferred tracking is
-	// enabled. Shared by reference with cloned clients, hence mutex-guarded.
-	deferredTracks *trackingBuffer
+	// trackingBuffer collects experiment exposures when one is attached (see
+	// WithTrackingBuffer). Shared by reference with cloned clients — the
+	// attacher chose the scope — hence mutex-guarded.
+	trackingBuffer *TrackingBuffer
 }
 
 // ForcedVariationsMap is a map that forces an Experiment to always assign a specific variation. Useful for QA.
@@ -241,10 +242,10 @@ func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *Exper
 // exposures. Plugin panics are recovered so plugins never interrupt
 // evaluation.
 func (client *Client) fireTracking(ctx context.Context, e *evaluator) {
-	if client.deferredTracks != nil {
+	if client.trackingBuffer != nil {
 		// Detach before buffering: this runs on the evaluating goroutine, so
 		// nothing the caller later mutates can reach the buffer.
-		client.deferredTracks.add(client.detachTrackingData(e.experiments))
+		client.trackingBuffer.add(detachTrackingData(e.experiments, client.logger))
 	}
 	plugins := client.data.getPlugins()
 	// Built-in events flow through the event-logger channel alongside the
@@ -344,7 +345,7 @@ func (client *Client) evaluator(ctx context.Context) *evaluator {
 		client:      client,
 		ctx:         ctx,
 		recording: client.experimentCallback != nil || client.featureUsageCallback != nil ||
-			client.eventLogger != nil || client.deferredTracks != nil || len(client.data.plugins) > 0,
+			client.eventLogger != nil || client.trackingBuffer != nil || len(client.data.plugins) > 0,
 	}
 	client.data.mu.RUnlock()
 	return &e

--- a/client_option.go
+++ b/client_option.go
@@ -219,15 +219,26 @@ func WithGrowthBookTracking(config TrackingPluginConfig) ClientOption {
 	}
 }
 
-// WithDeferredTracking buffers every experiment exposure produced by
-// evaluation (passthrough and prerequisite assignments included) for later
-// retrieval with Client.DeferredTrackingCalls. Callbacks and plugins still
-// fire; clients cloned from this one share its buffer.
-func WithDeferredTracking() ClientOption {
+// WithTrackingBuffer attaches a caller-owned buffer that collects every
+// experiment exposure produced by evaluation (passthrough and prerequisite
+// assignments included) for forwarding to a client SDK — read it with
+// TrackingBuffer.TrackingCalls or Client.DeferredTrackingCalls. Buffering is
+// independent of callbacks and plugins, which still fire. Clients cloned
+// from this one share the attached buffer — attach a fresh buffer per
+// request or user scope. A nil buffer detaches.
+func WithTrackingBuffer(b *TrackingBuffer) ClientOption {
 	return func(c *Client) error {
-		c.deferredTracks = newTrackingBuffer()
+		c.trackingBuffer = b
 		return nil
 	}
+}
+
+// WithDeferredTracking buffers every experiment exposure produced by
+// evaluation for later retrieval with Client.DeferredTrackingCalls. It is
+// the convenience form of WithTrackingBuffer(NewTrackingBuffer()) — use that
+// form to hold the buffer handle yourself.
+func WithDeferredTracking() ClientOption {
+	return WithTrackingBuffer(NewTrackingBuffer())
 }
 
 // Child client instance options
@@ -294,8 +305,16 @@ func (c *Client) WithEventLogger(cb EventLogger) (*Client, error) {
 	return c.cloneWith(WithEventLogger(cb))
 }
 
+// WithTrackingBuffer creates a child client that collects exposures into the
+// given caller-owned buffer (nil detaches). Attach a fresh buffer per
+// request or user scope; the child's own clones share it.
+func (c *Client) WithTrackingBuffer(b *TrackingBuffer) (*Client, error) {
+	return c.cloneWith(WithTrackingBuffer(b))
+}
+
 // WithDeferredTracking creates child client with deferred tracking enabled
-// and a fresh buffer.
+// and a fresh internal buffer — the convenience form of
+// WithTrackingBuffer(NewTrackingBuffer()).
 func (c *Client) WithDeferredTracking() (*Client, error) {
 	return c.cloneWith(WithDeferredTracking())
 }

--- a/evaluator.go
+++ b/evaluator.go
@@ -19,7 +19,7 @@ type evaluator struct {
 	userCtx            *TrackingUserContext
 	experiments        []TrackingData
 	featureUsage       []featureUsage
-	trackedExperiments map[string]bool
+	trackedExperiments map[trackingKey]bool
 	trackedFeatures    map[string]string
 }
 

--- a/tracking.go
+++ b/tracking.go
@@ -3,6 +3,7 @@ package growthbook
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"sync"
 )
@@ -60,21 +61,28 @@ type featureUsage struct {
 	result *FeatureResult
 }
 
-// trackingBuffer accumulates exposures across evaluations, deduped by
-// trackingKey, keeping first-seen order.
-type trackingBuffer struct {
+// TrackingBuffer accumulates experiment exposures across evaluations,
+// deduplicated for the buffer's lifetime, in first-seen order. Attach one to
+// a client with WithTrackingBuffer; every client sharing the buffer (clones
+// included) collects into it. Safe for concurrent use; the zero value is
+// ready to use.
+type TrackingBuffer struct {
 	mu   sync.Mutex
 	seen map[trackingKey]bool
 	data []TrackingData
 }
 
-func newTrackingBuffer() *trackingBuffer {
-	return &trackingBuffer{seen: make(map[trackingKey]bool)}
+// NewTrackingBuffer creates an empty tracking buffer.
+func NewTrackingBuffer() *TrackingBuffer {
+	return &TrackingBuffer{}
 }
 
-func (b *trackingBuffer) add(data []TrackingData) {
+func (b *TrackingBuffer) add(data []TrackingData) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.seen == nil {
+		b.seen = make(map[trackingKey]bool)
+	}
 	for _, d := range data {
 		key := dedupeKey(d.Experiment, d.Result)
 		if b.seen[key] {
@@ -85,27 +93,48 @@ func (b *trackingBuffer) add(data []TrackingData) {
 	}
 }
 
-// DeferredTrackingCalls returns the experiment exposures buffered so far —
-// passthrough and prerequisite assignments included, deduped by DedupeKey,
-// in first-seen order — as detached copies in the SDK's JSON shape, safe to
-// retain or mutate without affecting the buffer. Returns nil unless deferred
-// tracking is enabled (see WithDeferredTracking).
-func (client *Client) DeferredTrackingCalls() []TrackingData {
-	if client.deferredTracks == nil {
+// TrackingCalls returns the exposures buffered so far — passthrough and
+// prerequisite assignments included, in first-seen order — as detached
+// copies in the SDK's JSON shape, safe to retain or mutate without affecting
+// the buffer. It does not drain the buffer; pair with Clear.
+func (b *TrackingBuffer) TrackingCalls() []TrackingData {
+	if b == nil {
 		return nil
 	}
-	b := client.deferredTracks
 	b.mu.Lock()
 	shared := append([]TrackingData(nil), b.data...)
 	b.mu.Unlock()
-	return client.detachTrackingData(shared)
+	// Entries were proven serializable when buffered, so this detach cannot
+	// drop any; a nil logger is fine.
+	return detachTrackingData(shared, nil)
+}
+
+// Clear empties the buffer, including its dedupe memory: a subsequent
+// exposure identical to one seen before Clear is recorded again. For the
+// intended request-scoped lifecycle (one buffer per request, read once,
+// then cleared or dropped) this never matters.
+func (b *TrackingBuffer) Clear() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.seen = nil
+	b.data = nil
+}
+
+// DeferredTrackingCalls returns the exposures collected by the client's
+// attached tracking buffer (see TrackingBuffer.TrackingCalls). Returns nil
+// when no buffer is attached.
+func (client *Client) DeferredTrackingCalls() []TrackingData {
+	return client.trackingBuffer.TrackingCalls()
 }
 
 // detachTrackingData deep-copies entries via a JSON round-trip, dropping
-// (and logging) any entry that cannot be serialized — such an exposure
-// could not be forwarded anyway, and returning it aliased would break the
-// detached-copy guarantee.
-func (client *Client) detachTrackingData(data []TrackingData) []TrackingData {
+// (and logging, when a logger is given) any entry that cannot be
+// serialized — such an exposure could not be forwarded anyway, and
+// returning it aliased would break the detached-copy guarantee.
+func detachTrackingData(data []TrackingData, logger *slog.Logger) []TrackingData {
 	if len(data) == 0 {
 		return nil
 	}
@@ -119,22 +148,18 @@ func (client *Client) detachTrackingData(data []TrackingData) []TrackingData {
 				continue
 			}
 		}
-		client.logger.Warn("Dropping unserializable exposure from deferred tracking",
-			"experiment", d.Experiment.Key, "error", err)
+		if logger != nil {
+			logger.Warn("Dropping unserializable exposure from deferred tracking",
+				"experiment", d.Experiment.Key, "error", err)
+		}
 	}
 	return out
 }
 
-// ClearDeferredTrackingCalls empties the deferred tracking buffer.
+// ClearDeferredTrackingCalls empties the client's attached tracking buffer
+// (see TrackingBuffer.Clear). No-op when no buffer is attached.
 func (client *Client) ClearDeferredTrackingCalls() {
-	if client.deferredTracks == nil {
-		return
-	}
-	b := client.deferredTracks
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.seen = make(map[trackingKey]bool)
-	b.data = nil
+	client.trackingBuffer.Clear()
 }
 
 func (client *Client) trackingUserContext() *TrackingUserContext {

--- a/tracking.go
+++ b/tracking.go
@@ -66,6 +66,11 @@ type featureUsage struct {
 // a client with WithTrackingBuffer; every client sharing the buffer (clones
 // included) collects into it. Safe for concurrent use; the zero value is
 // ready to use.
+//
+// A TrackingBuffer must not be copied after first use: a copy would share
+// the buffered state while holding an independent mutex. Share it by
+// pointer, as WithTrackingBuffer does (`go vet`'s copylocks check flags
+// value copies).
 type TrackingBuffer struct {
 	mu   sync.Mutex
 	seen map[trackingKey]bool

--- a/tracking.go
+++ b/tracking.go
@@ -25,10 +25,34 @@ type TrackingData struct {
 }
 
 // DedupeKey identifies an exposure by hash attribute, hash value, experiment
-// key, and variation. Exposures are deduplicated by this key within a single
-// evaluation and in the deferred tracking buffer.
+// key, and variation.
+//
+// Deprecated: informational only. The SDK no longer dedupes on this string —
+// field values containing the NUL delimiter can make two distinct exposures
+// share a key. Internal deduplication uses a field-wise comparable key that
+// cannot collide.
 func (t TrackingData) DedupeKey() string {
 	return t.Result.HashAttribute + "\x00" + t.Result.HashValue + "\x00" + t.Experiment.Key + "\x00" + strconv.Itoa(t.Result.VariationId)
+}
+
+// trackingKey is the exposure identity used for deduplication, within a
+// single evaluation and across a tracking buffer's lifetime. A comparable
+// struct rather than a joined string: no delimiter means no cross-field
+// collisions when values contain the delimiter byte.
+type trackingKey struct {
+	hashAttribute string
+	hashValue     string
+	experimentKey string
+	variationId   int
+}
+
+func dedupeKey(exp *Experiment, res *ExperimentResult) trackingKey {
+	return trackingKey{
+		hashAttribute: res.HashAttribute,
+		hashValue:     res.HashValue,
+		experimentKey: exp.Key,
+		variationId:   res.VariationId,
+	}
 }
 
 type featureUsage struct {
@@ -37,22 +61,22 @@ type featureUsage struct {
 }
 
 // trackingBuffer accumulates exposures across evaluations, deduped by
-// DedupeKey, keeping first-seen order.
+// trackingKey, keeping first-seen order.
 type trackingBuffer struct {
 	mu   sync.Mutex
-	seen map[string]bool
+	seen map[trackingKey]bool
 	data []TrackingData
 }
 
 func newTrackingBuffer() *trackingBuffer {
-	return &trackingBuffer{seen: make(map[string]bool)}
+	return &trackingBuffer{seen: make(map[trackingKey]bool)}
 }
 
 func (b *trackingBuffer) add(data []TrackingData) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, d := range data {
-		key := d.DedupeKey()
+		key := dedupeKey(d.Experiment, d.Result)
 		if b.seen[key] {
 			continue
 		}
@@ -109,7 +133,7 @@ func (client *Client) ClearDeferredTrackingCalls() {
 	b := client.deferredTracks
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.seen = make(map[string]bool)
+	b.seen = make(map[trackingKey]bool)
 	b.data = nil
 }
 
@@ -128,12 +152,12 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 	if !e.recording {
 		return
 	}
-	key := TrackingData{Experiment: exp, Result: res}.DedupeKey()
+	if e.trackedExperiments == nil {
+		e.trackedExperiments = make(map[trackingKey]bool)
+	}
+	key := dedupeKey(exp, res)
 	if e.trackedExperiments[key] {
 		return
-	}
-	if e.trackedExperiments == nil {
-		e.trackedExperiments = make(map[string]bool)
 	}
 	e.trackedExperiments[key] = true
 	if e.userCtx == nil {
@@ -149,12 +173,12 @@ func (e *evaluator) recordFeatureUsage(key string, res *FeatureResult) {
 	if !e.recording {
 		return
 	}
+	if e.trackedFeatures == nil {
+		e.trackedFeatures = make(map[string]string)
+	}
 	stringified := stringifyFeatureValue(res.Value)
 	if prev, ok := e.trackedFeatures[key]; ok && prev == stringified {
 		return
-	}
-	if e.trackedFeatures == nil {
-		e.trackedFeatures = make(map[string]string)
 	}
 	e.trackedFeatures[key] = stringified
 	e.featureUsage = append(e.featureUsage, featureUsage{key: key, result: res})

--- a/tracking.go
+++ b/tracking.go
@@ -114,6 +114,26 @@ func (b *TrackingBuffer) TrackingCalls() []TrackingData {
 	return detachTrackingData(shared, nil)
 }
 
+// TakeTrackingCalls atomically returns the buffered exposures and empties
+// the buffer — the drain form of TrackingCalls followed by Clear. Unlike
+// calling those two separately, an exposure recorded concurrently can never
+// be cleared without having been returned, so a long-lived shared buffer can
+// be drained in a loop without losing exposures. Like Clear, it forgets the
+// dedupe memory: a later identical exposure is recorded again.
+func (b *TrackingBuffer) TakeTrackingCalls() []TrackingData {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	taken := b.data
+	b.seen = nil
+	b.data = nil
+	b.mu.Unlock()
+	// Entries were proven serializable when buffered, so this detach cannot
+	// drop any; a nil logger is fine.
+	return detachTrackingData(taken, nil)
+}
+
 // Clear empties the buffer, including its dedupe memory: a subsequent
 // exposure identical to one seen before Clear is recorded again. For the
 // intended request-scoped lifecycle (one buffer per request, read once,
@@ -159,6 +179,13 @@ func detachTrackingData(data []TrackingData, logger *slog.Logger) []TrackingData
 		}
 	}
 	return out
+}
+
+// TakeDeferredTrackingCalls atomically drains the client's attached tracking
+// buffer (see TrackingBuffer.TakeTrackingCalls). Returns nil when no buffer
+// is attached.
+func (client *Client) TakeDeferredTrackingCalls() []TrackingData {
+	return client.trackingBuffer.TakeTrackingCalls()
 }
 
 // ClearDeferredTrackingCalls empties the client's attached tracking buffer

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -365,6 +365,25 @@ func TestDeferredTracking(t *testing.T) {
 		require.Equal(t, "user-1", calls[0].User.Attributes["id"])
 		require.Equal(t, "user-2", calls[1].User.Attributes["id"])
 	})
+
+	t.Run("distinct exposures whose fields collide under delimiter joining are both kept", func(t *testing.T) {
+		shared, _, _ := newTrackingTestClient(t)
+		user1, err := shared.WithAttributes(Attributes{"id": "u\x001exp"})
+		require.NoError(t, err)
+		user2, err := shared.WithAttributes(Attributes{"id": "u"})
+		require.NoError(t, err)
+
+		one := 1.0
+		expA := Experiment{Key: "x", Variations: []FeatureValue{"a", "b"}, Weights: []float64{1, 0}, Coverage: &one}
+		expB := Experiment{Key: "1exp\x00x", Variations: []FeatureValue{"a", "b"}, Weights: []float64{1, 0}, Coverage: &one}
+
+		require.True(t, user1.RunExperiment(ctx, &expA).InExperiment)
+		require.True(t, user2.RunExperiment(ctx, &expB).InExperiment)
+
+		// Both NUL-joined keys read "id\x00u\x001exp\x00x\x000"; a string-keyed
+		// buffer would silently drop the second user's exposure.
+		require.Len(t, shared.DeferredTrackingCalls(), 2)
+	})
 }
 
 func TestExperimentCallbackUserContext(t *testing.T) {
@@ -541,6 +560,21 @@ func TestTrackingDataShape(t *testing.T) {
 			Result:     &ExperimentResult{HashAttribute: "id", HashValue: "u", VariationId: 2},
 		}
 		require.NotEqual(t, td.DedupeKey(), other.DedupeKey())
+	})
+
+	t.Run("internal dedupe key is field-wise: delimiter bytes in values cannot collide", func(t *testing.T) {
+		a := TrackingData{
+			Experiment: &Experiment{Key: "x"},
+			Result:     &ExperimentResult{HashAttribute: "id", HashValue: "u\x001exp", VariationId: 0},
+		}
+		b := TrackingData{
+			Experiment: &Experiment{Key: "1exp\x00x"},
+			Result:     &ExperimentResult{HashAttribute: "id", HashValue: "u", VariationId: 0},
+		}
+		// The deprecated string encoding collides on exactly this pair...
+		require.Equal(t, a.DedupeKey(), b.DedupeKey())
+		// ...the struct key the SDK dedupes on does not.
+		require.NotEqual(t, dedupeKey(a.Experiment, a.Result), dedupeKey(b.Experiment, b.Result))
 	})
 
 	t.Run("exposures with namespaces, ranges, and filters detach losslessly", func(t *testing.T) {

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -757,3 +757,80 @@ func TestConcurrentSharedTrackingBuffer(t *testing.T) {
 
 	require.Len(t, buf.TrackingCalls(), 20, "one exposure per user, no cross-user dedupe")
 }
+
+func TestTakeTrackingCalls(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("drains atomically and forgets dedupe memory", func(t *testing.T) {
+		buf := NewTrackingBuffer()
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithTrackingBuffer(buf),
+		)
+		require.NoError(t, err)
+
+		client.EvalFeature(ctx, "ramped-treatment")
+		taken := buf.TakeTrackingCalls()
+		require.Len(t, taken, 1)
+		require.Empty(t, buf.TrackingCalls(), "take must empty the buffer")
+
+		client.EvalFeature(ctx, "ramped-treatment")
+		require.Len(t, buf.TakeTrackingCalls(), 1, "dedupe memory is forgotten, like Clear")
+
+		require.Empty(t, client.TakeDeferredTrackingCalls(), "an empty drain returns nothing")
+	})
+
+	t.Run("client accessor delegates", func(t *testing.T) {
+		client, _, _ := newTrackingTestClient(t)
+		client.EvalFeature(ctx, "ramped")
+		require.Len(t, client.TakeDeferredTrackingCalls(), 1)
+		require.Empty(t, client.DeferredTrackingCalls())
+	})
+
+	t.Run("nothing recorded concurrently is cleared without being returned", func(t *testing.T) {
+		base, err := NewClient(ctx, WithJsonFeatures(trackingFeaturesJSON))
+		require.NoError(t, err)
+		buf := NewTrackingBuffer()
+		one := 1.0
+
+		const producers = 8
+		const perProducer = 25
+		var wg sync.WaitGroup
+		for p := 0; p < producers; p++ {
+			wg.Add(1)
+			go func(p int) {
+				defer wg.Done()
+				for i := 0; i < perProducer; i++ {
+					child, err := base.WithAttributes(Attributes{"id": fmt.Sprintf("u-%d-%d", p, i)})
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					child, err = child.WithTrackingBuffer(buf)
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					exp := Experiment{Key: "exp", Variations: []FeatureValue{"a", "b"}, Weights: []float64{1, 0}, Coverage: &one}
+					child.RunExperiment(ctx, &exp)
+				}
+			}(p)
+		}
+
+		drained := 0
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		for {
+			drained += len(buf.TakeTrackingCalls())
+			select {
+			case <-done:
+				drained += len(buf.TakeTrackingCalls())
+				require.Equal(t, producers*perProducer, drained,
+					"every exposure must be returned by exactly one drain")
+				return
+			default:
+			}
+		}
+	})
+}

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -3,6 +3,7 @@ package growthbook
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -126,7 +127,7 @@ func newTrackingTestClient(t *testing.T, extra ...ClientOption) (*Client, *track
 	opts := []ClientOption{
 		WithJsonFeatures(trackingFeaturesJSON),
 		WithAttributes(Attributes{"id": "user-1"}),
-		WithDeferredTracking(),
+		WithTrackingBuffer(NewTrackingBuffer()),
 		WithExperimentCallback(func(ctx context.Context, exp *Experiment, res *ExperimentResult, _ *TrackingUserContext, _ any) {
 			callbacks.OnExperimentViewed(ctx, exp, res)
 		}),
@@ -347,6 +348,77 @@ func TestDeferredTracking(t *testing.T) {
 		child.EvalFeature(ctx, "ramped")
 		require.Len(t, child.DeferredTrackingCalls(), 1)
 		require.Empty(t, parent.DeferredTrackingCalls())
+	})
+
+	t.Run("attaching a different buffer detaches from the parent's", func(t *testing.T) {
+		parent, _, _ := newTrackingTestClient(t)
+		buf := NewTrackingBuffer()
+		child, err := parent.WithTrackingBuffer(buf)
+		require.NoError(t, err)
+
+		child.EvalFeature(ctx, "ramped")
+		require.Len(t, buf.TrackingCalls(), 1)
+		require.Empty(t, parent.DeferredTrackingCalls())
+	})
+
+	t.Run("attaching nil stops buffering", func(t *testing.T) {
+		parent, _, _ := newTrackingTestClient(t)
+		child, err := parent.WithTrackingBuffer(nil)
+		require.NoError(t, err)
+
+		child.EvalFeature(ctx, "ramped")
+		require.Nil(t, child.DeferredTrackingCalls())
+		require.Empty(t, parent.DeferredTrackingCalls())
+	})
+
+	t.Run("client accessors delegate to the attached buffer", func(t *testing.T) {
+		buf := NewTrackingBuffer()
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithTrackingBuffer(buf),
+		)
+		require.NoError(t, err)
+
+		client.EvalFeature(ctx, "ramped")
+		require.Equal(t, buf.TrackingCalls(), client.DeferredTrackingCalls())
+		require.Len(t, buf.TrackingCalls(), 1)
+
+		client.ClearDeferredTrackingCalls()
+		require.Empty(t, buf.TrackingCalls())
+	})
+
+	t.Run("buffer lifecycle: reads are non-destructive, Clear forgets dedupe memory", func(t *testing.T) {
+		buf := NewTrackingBuffer()
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithTrackingBuffer(buf),
+		)
+		require.NoError(t, err)
+
+		client.EvalFeature(ctx, "ramped-treatment")
+		require.Len(t, buf.TrackingCalls(), 1)
+		require.Len(t, buf.TrackingCalls(), 1, "reading must not drain the buffer")
+
+		buf.Clear()
+		require.Empty(t, buf.TrackingCalls())
+
+		client.EvalFeature(ctx, "ramped-treatment")
+		require.Len(t, buf.TrackingCalls(), 1, "Clear forgets dedupe memory, so the exposure records again")
+	})
+
+	t.Run("the zero-value buffer is usable", func(t *testing.T) {
+		var buf TrackingBuffer
+		client, err := NewClient(ctx,
+			WithJsonFeatures(trackingFeaturesJSON),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithTrackingBuffer(&buf),
+		)
+		require.NoError(t, err)
+
+		client.EvalFeature(ctx, "ramped")
+		require.Len(t, buf.TrackingCalls(), 1)
 	})
 
 	t.Run("a shared armed client accumulates all users without cross-user dedupe", func(t *testing.T) {
@@ -600,7 +672,7 @@ func TestTrackingDataShape(t *testing.T) {
 		require.Equal(t, []BucketRange{{Min: 0, Max: 1}, {Min: 0, Max: 0}}, got.Ranges)
 		require.Equal(t, exp.Filters, got.Filters)
 
-		require.Len(t, client.detachTrackingData(calls), 1)
+		require.Len(t, detachTrackingData(calls, client.logger), 1)
 
 		b, err := json.Marshal(calls[0])
 		require.NoError(t, err)
@@ -651,4 +723,37 @@ func TestConcurrentDeferredTracking(t *testing.T) {
 		{"parent-exp", 0, false, "parent"},
 		{"ramp", 1, true, "ramped"},
 	}, exposures(t, client.DeferredTrackingCalls()))
+}
+
+func TestConcurrentSharedTrackingBuffer(t *testing.T) {
+	ctx := context.Background()
+	base, err := NewClient(ctx, WithJsonFeatures(trackingFeaturesJSON))
+	require.NoError(t, err)
+
+	buf := NewTrackingBuffer()
+	one := 1.0
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			child, err := base.WithAttributes(Attributes{"id": fmt.Sprintf("user-%d", i)})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			child, err = child.WithTrackingBuffer(buf)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			exp := Experiment{Key: "exp", Variations: []FeatureValue{"a", "b"}, Weights: []float64{1, 0}, Coverage: &one}
+			child.RunExperiment(ctx, &exp)
+			buf.TrackingCalls() // concurrent reads must not race with writes
+		}(i)
+	}
+	wg.Wait()
+
+	require.Len(t, buf.TrackingCalls(), 20, "one exposure per user, no cross-user dedupe")
 }


### PR DESCRIPTION
## Summary

Reworks the deferred-tracking buffer from #84 around explicit, caller-owned scope, and fixes a dedupe-key collision. No breaking changes: v0.4.0 code compiles and behaves identically.

## Behavioral change

- Internal exposure dedupe now uses a field-wise comparable struct key. The NUL-joined string collided across field boundaries when attribute values contain the delimiter byte (`hashValue "u\x001exp" + key "x"` vs `"u" + "1exp\x00x"`), silently dropping the second exposure from the buffer. `TrackingData.DedupeKey()` keeps its exact signature and output, deprecated as informational.
- New exported `TrackingBuffer` (`NewTrackingBuffer`, `TrackingCalls`, `Clear`) plus `WithTrackingBuffer` (option and child-client method): attach one buffer per request/user scope; clones share the attached buffer by design — the attacher picks the scope. `WithDeferredTracking()` stays as the convenience form (`WithTrackingBuffer(NewTrackingBuffer())`); `DeferredTrackingCalls`/`ClearDeferredTrackingCalls` delegate to the attached buffer.
- README: buffering is independent of callbacks/plugins (both always fire); the double-report warning is reframed per analytics destination.

## Perf

`BenchmarkEvalFeature_Warm`: 169.5 ns/op, 240 B/op, 3 allocs/op on both main and this branch (count=6). The struct key also removes per-exposure string building on the armed path.

## Test plan

- [x] `go test ./...` and `go test -race ./...` — green
- [x] Collision test proven load-bearing: with the old string key the buffer keeps 1 of 2 distinct exposures
- [x] Conformance corpus results byte-identical (dedupe change is internal only)