### PR TITLE
Pre-bandit fixes: variation-index panic, condition marshal fidelity, force:null parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- **Bugfix (JS parity):** a feature rule of `{"force": null}` now serves
+  `null` with source `force`, as the JS SDK does. Previously a null force
+  was indistinguishable from an absent one, so the rule was skipped and the
+  next rule or default value was served.
 - **Fixed:** conditions now retain their parsed content and marshal back to
   JSON instead of collapsing to `{}`, so feature and experiment JSON — the
   deferred-tracking deep copies included — round-trips with targeting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- **Fixed:** an experiment with an empty variations list (a bare
+  `RunExperiment` call or a rule serving zero variations) no longer panics
+  indexing the variations slice; it degrades to a not-in-experiment result.
 - **Added:** `TrackingBuffer` is now an exported, caller-owned type:
   `NewTrackingBuffer()` creates one, `WithTrackingBuffer(buf)` (option and
   child-client method) attaches it, `TrackingCalls()` reads detached copies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- **Fixed:** conditions now retain their parsed content and marshal back to
+  JSON instead of collapsing to `{}`, so feature and experiment JSON — the
+  deferred-tracking deep copies included — round-trips with targeting
+  conditions intact.
 - **Fixed:** an experiment with an empty variations list (a bare
   `RunExperiment` call or a rule serving zero variations) no longer panics
   indexing the variations slice; it degrades to a not-in-experiment result.

--- a/evaluator.go
+++ b/evaluator.go
@@ -344,13 +344,18 @@ func (e *evaluator) getExperimentResult(
 		key = meta.Key
 	}
 
+	var value FeatureValue
+	if variationId < len(exp.Variations) {
+		value = exp.Variations[variationId]
+	}
+
 	res := ExperimentResult{
 		Key:              key,
 		FeatureId:        featureId,
 		InExperiment:     inExperiment,
 		HashUsed:         hashUsed,
 		VariationId:      variationId,
-		Value:            exp.Variations[variationId],
+		Value:            value,
 		HashAttribute:    hashAttribute,
 		HashValue:        hashValue,
 		Bucket:           bucket,

--- a/evaluator.go
+++ b/evaluator.go
@@ -397,7 +397,7 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 		return nil
 	}
 
-	if rule.Force != nil {
+	if rule.forcePresent || rule.Force != nil {
 		if !rule.Condition.Eval(e.client.attributes, e.savedGroups) {
 			return nil
 		}

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -38,3 +38,19 @@ func TestExperimentWithMissingAttributeFails(t *testing.T) {
 	require.False(t, res.HashUsed)
 	require.Equal(t, 0, res.Value)
 }
+
+func TestExperimentWithNoVariationsDoesNotPanic(t *testing.T) {
+	exp := Experiment{
+		Key:        "my-test",
+		Variations: []FeatureValue{},
+	}
+
+	c, _ := NewClient(
+		context.TODO(),
+		WithAttributes(Attributes{"id": "user-1"}))
+
+	res := c.RunExperiment(context.TODO(), &exp)
+	require.False(t, res.InExperiment)
+	require.False(t, res.HashUsed)
+	require.Nil(t, res.Value)
+}

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -2,6 +2,7 @@ package growthbook
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -53,4 +54,19 @@ func TestExperimentWithNoVariationsDoesNotPanic(t *testing.T) {
 	require.False(t, res.InExperiment)
 	require.False(t, res.HashUsed)
 	require.Nil(t, res.Value)
+}
+
+func TestConditionlessExperimentJSONRoundTrip(t *testing.T) {
+	// The deferred-tracking deep copy is a JSON round trip; an experiment
+	// with no condition must survive it (zero conditions marshal as {}).
+	var exp Experiment
+	require.NoError(t, json.Unmarshal([]byte(`{"key": "e", "variations": ["a", "b"]}`), &exp))
+
+	b, err := json.Marshal(exp)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"condition":{}`)
+
+	var back Experiment
+	require.NoError(t, json.Unmarshal(b, &back))
+	require.Equal(t, exp.Key, back.Key)
 }

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -87,6 +87,10 @@ func (r FeatureRule) MarshalJSON() ([]byte, error) {
 }
 
 func (r *FeatureRule) UnmarshalJSON(data []byte) error {
+	// Reset first: decoding into a reused rule must replace it wholesale, not
+	// merge — a retained Force from a previous decode would disagree with the
+	// freshly computed forcePresent and serve a stale forced value.
+	*r = FeatureRule{}
 	type alias FeatureRule
 	if err := json.Unmarshal(data, (*alias)(r)); err != nil {
 		return err

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -70,6 +70,22 @@ type FeatureRule struct {
 	forcePresent bool
 }
 
+// MarshalJSON omits an absent force so a marshal/unmarshal round trip does
+// not turn every rule into a force-null rule.
+func (r FeatureRule) MarshalJSON() ([]byte, error) {
+	type alias FeatureRule
+	b, err := json.Marshal(alias(r))
+	if err != nil || r.forcePresent || r.Force != nil {
+		return b, err
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	delete(m, "force")
+	return json.Marshal(m)
+}
+
 func (r *FeatureRule) UnmarshalJSON(data []byte) error {
 	type alias FeatureRule
 	if err := json.Unmarshal(data, (*alias)(r)); err != nil {

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -1,6 +1,10 @@
 package growthbook
 
-import "github.com/growthbook/growthbook-golang/internal/condition"
+import (
+	"encoding/json"
+
+	"github.com/growthbook/growthbook-golang/internal/condition"
+)
 
 type FeatureRule struct {
 	// Optional rule id, reserved for future use
@@ -60,4 +64,23 @@ type FeatureRule struct {
 	// Deprecated: ignored during evaluation. Feature rules never carried a
 	// status in the JS SDK; use Experiment.Status with RunExperiment.
 	Status ExperimentStatus `json:"status"`
+
+	// forcePresent distinguishes {"force": null} from an absent force: the
+	// JS SDK serves the null (it checks key presence), so Go must too.
+	forcePresent bool
+}
+
+func (r *FeatureRule) UnmarshalJSON(data []byte) error {
+	type alias FeatureRule
+	if err := json.Unmarshal(data, (*alias)(r)); err != nil {
+		return err
+	}
+	var probe struct {
+		Force json.RawMessage `json:"force"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+	r.forcePresent = probe.Force != nil
+	return nil
 }

--- a/force_rule_test.go
+++ b/force_rule_test.go
@@ -1,0 +1,51 @@
+package growthbook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForceNullRule(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(`{
+		  "forced-null": {
+		    "defaultValue": "default",
+		    "rules": [{"force": null}, {"force": "second-rule"}]
+		  },
+		  "gated-null": {
+		    "defaultValue": "default",
+		    "rules": [
+		      {"force": null, "condition": {"country": "us"}},
+		      {"force": "second-rule"}
+		    ]
+		  },
+		  "empty-rule": {
+		    "defaultValue": "default",
+		    "rules": [{}]
+		  }
+		}`),
+		WithAttributes(Attributes{"id": "u1", "country": "nz"}),
+	)
+	require.NoError(t, err)
+
+	t.Run("a null force serves null (JS parity)", func(t *testing.T) {
+		res := client.EvalFeature(ctx, "forced-null")
+		require.Nil(t, res.Value)
+		require.Equal(t, ForceResultSource, res.Source)
+		require.True(t, res.Off)
+	})
+
+	t.Run("a null force still honors its condition", func(t *testing.T) {
+		res := client.EvalFeature(ctx, "gated-null")
+		require.Equal(t, "second-rule", res.Value)
+	})
+
+	t.Run("an absent force is not a force rule", func(t *testing.T) {
+		res := client.EvalFeature(ctx, "empty-rule")
+		require.Equal(t, "default", res.Value)
+		require.Equal(t, DefaultValueResultSource, res.Source)
+	})
+}

--- a/force_rule_test.go
+++ b/force_rule_test.go
@@ -81,3 +81,17 @@ func TestFeatureRuleForceRoundTrip(t *testing.T) {
 		require.True(t, back.forcePresent)
 	})
 }
+
+func TestFeatureRuleDecodeReplacesWholesale(t *testing.T) {
+	// Decoding into a reused rule must not merge with previous contents: a
+	// retained Force alongside a reset forcePresent would serve a stale
+	// forced value.
+	var rule FeatureRule
+	require.NoError(t, json.Unmarshal([]byte(`{"force": "stale"}`), &rule))
+	require.True(t, rule.forcePresent)
+
+	require.NoError(t, json.Unmarshal([]byte(`{"variations": ["a", "b"], "weights": [1, 0], "coverage": 1}`), &rule))
+	require.Nil(t, rule.Force, "the previous decode's force must not survive")
+	require.False(t, rule.forcePresent)
+	require.Equal(t, []FeatureValue{"a", "b"}, rule.Variations)
+}

--- a/force_rule_test.go
+++ b/force_rule_test.go
@@ -2,6 +2,7 @@ package growthbook
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -47,5 +48,36 @@ func TestForceNullRule(t *testing.T) {
 		res := client.EvalFeature(ctx, "empty-rule")
 		require.Equal(t, "default", res.Value)
 		require.Equal(t, DefaultValueResultSource, res.Source)
+	})
+}
+
+func TestFeatureRuleForceRoundTrip(t *testing.T) {
+	t.Run("an absent force stays absent through a marshal round trip", func(t *testing.T) {
+		var rule FeatureRule
+		require.NoError(t, json.Unmarshal([]byte(`{"variations": ["a", "b"], "weights": [1, 0], "coverage": 1}`), &rule))
+		require.False(t, rule.forcePresent)
+
+		b, err := json.Marshal(rule)
+		require.NoError(t, err)
+		require.NotContains(t, string(b), `"force"`)
+
+		var back FeatureRule
+		require.NoError(t, json.Unmarshal(b, &back))
+		require.False(t, back.forcePresent,
+			"a round trip must not turn a variations rule into a forced-null rule")
+	})
+
+	t.Run("an explicit null force survives a marshal round trip", func(t *testing.T) {
+		var rule FeatureRule
+		require.NoError(t, json.Unmarshal([]byte(`{"force": null}`), &rule))
+		require.True(t, rule.forcePresent)
+
+		b, err := json.Marshal(rule)
+		require.NoError(t, err)
+		require.Contains(t, string(b), `"force":null`)
+
+		var back FeatureRule
+		require.NoError(t, json.Unmarshal(b, &back))
+		require.True(t, back.forcePresent)
 	})
 }

--- a/internal/condition/marshal.go
+++ b/internal/condition/marshal.go
@@ -11,6 +11,7 @@ import (
 
 type Base struct {
 	cond Condition
+	raw  json.RawMessage
 }
 
 func (base Base) Eval(actual value.Value, groups SavedGroups) bool {
@@ -26,13 +27,26 @@ func (base *Base) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	json := value.New(m)
-	cond, err := buildBaseCond(json)
+	val := value.New(m)
+	cond, err := buildBaseCond(val)
 	if err != nil {
 		return err
 	}
-	*base = Base{cond}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	*base = Base{cond: cond, raw: raw}
 	return nil
+}
+
+// MarshalJSON emits the parsed condition in canonical form, so conditions
+// survive a marshal/unmarshal round trip instead of collapsing to {}.
+func (base Base) MarshalJSON() ([]byte, error) {
+	if base.raw == nil {
+		return []byte("null"), nil
+	}
+	return base.raw, nil
 }
 
 func buildBaseCond(json value.Value) (Condition, error) {

--- a/internal/condition/marshal.go
+++ b/internal/condition/marshal.go
@@ -41,10 +41,12 @@ func (base *Base) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON emits the parsed condition in canonical form, so conditions
-// survive a marshal/unmarshal round trip instead of collapsing to {}.
+// survive a marshal/unmarshal round trip instead of collapsing to {}. A zero
+// Base marshals as {} — the always-true condition, matching its Eval — which
+// is also what it marshaled as before conditions carried their raw form.
 func (base Base) MarshalJSON() ([]byte, error) {
 	if base.raw == nil {
-		return []byte("null"), nil
+		return []byte("{}"), nil
 	}
 	return base.raw, nil
 }

--- a/internal/condition/marshal_test.go
+++ b/internal/condition/marshal_test.go
@@ -169,9 +169,15 @@ func TestConditionMarshalRoundTrip(t *testing.T) {
 		require.False(t, again.Eval(value.New(map[string]any{"age": 10, "name": "Ann"}), nil))
 	})
 
-	t.Run("the zero value marshals as null", func(t *testing.T) {
+	t.Run("the zero value marshals as {}, its always-true Eval form", func(t *testing.T) {
 		out, err := json.Marshal(Base{})
 		require.NoError(t, err)
-		require.Equal(t, "null", string(out))
+		require.Equal(t, "{}", string(out))
+	})
+
+	t.Run("a null condition unmarshals as the always-true zero value", func(t *testing.T) {
+		var b Base
+		require.NoError(t, json.Unmarshal([]byte("null"), &b))
+		require.True(t, b.Eval(value.New(map[string]any{"x": 1}), nil))
 	})
 }

--- a/internal/condition/marshal_test.go
+++ b/internal/condition/marshal_test.go
@@ -148,3 +148,30 @@ func TestCaseInsensitiveOperators(t *testing.T) {
 		require.False(t, b.Eval(value.New(map[string]any{"tags": []string{"python", "django"}}), nil))
 	})
 }
+
+func TestConditionMarshalRoundTrip(t *testing.T) {
+	t.Run("conditions survive a marshal round trip", func(t *testing.T) {
+		src := `{"$or": [{"age": {"$gte": 18}}, {"name": "Bob"}]}`
+		var b Base
+		require.NoError(t, json.Unmarshal([]byte(src), &b))
+
+		out, err := json.Marshal(b)
+		require.NoError(t, err)
+
+		var got, want map[string]any
+		require.NoError(t, json.Unmarshal(out, &got))
+		require.NoError(t, json.Unmarshal([]byte(src), &want))
+		require.Equal(t, want, got)
+
+		var again Base
+		require.NoError(t, json.Unmarshal(out, &again))
+		require.True(t, again.Eval(value.New(map[string]any{"age": 20}), nil))
+		require.False(t, again.Eval(value.New(map[string]any{"age": 10, "name": "Ann"}), nil))
+	})
+
+	t.Run("the zero value marshals as null", func(t *testing.T) {
+		out, err := json.Marshal(Base{})
+		require.NoError(t, err)
+		require.Equal(t, "null", string(out))
+	})
+}


### PR DESCRIPTION
## Summary

The condition-marshal fix is a prerequisite of truthful deferred-tracking JSON in the contextual bandits PR.

Three independent bug fixes extracted from #85 (original author: @bryce-fitzsimons) & Stacked on #88 . 

## Root cause

- **Variation-index panic**: `getExperimentResult` clamps an out-of-range `variationId` to 0, then indexes `exp.Variations[variationId]` — an empty variations slice still panics. Now degrades to a not-in-experiment result with a nil value. (The Python SDK has the same live crash; being fixed there separately.)
- **Conditions collapsed to `{}`**: `condition.Base` had no `MarshalJSON`, so every marshaled condition lost its content — including `detachTrackingData`'s JSON round trip, a gap #84 disclosed. Conditions now retain their parsed content in canonical form.
- **`{"force": null}` skipped**: indistinguishable from an absent force, so the rule was skipped; the JS SDK checks key presence and serves the null. `FeatureRule` records force presence during unmarshaling.

## Test plan

- [x] Empty-variations regression test: panics without the guard, passes with it
- [x] Condition round-trip test: fails without `MarshalJSON` (marshals as `{}`), passes with it
- [x] `force_rule_test.go`; full suite + `-race` green