### PR TITLE
Add contextual bandit support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- **Fixed:** partial payload updates no longer wipe omitted sections. A
+  payload carrying only `contextualBandits` used to clear `features` and
+  `savedGroups`; every section now follows the same rule — absent preserves
+  the previous data, explicit empty clears it (Python `set_payload` parity).
 - Added contextual bandit support (JS parity): feature rules carrying a
   `contextualBanditRef` now evaluate using the per-context variation weights
   from the payload's `contextualBandits` definitions (encrypted payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ All notable changes to this project will be documented in this file.
   aggregate weights apply under a fallback leaf. Assignments carry `leafId`,
   `variationWeights`, and `banditVersion` on `ExperimentResult` — and on
   forwarded deferred-tracking data. Definitions decode leniently and never
-  block the feature update they arrived with: a malformed definition is
-  dropped (its rules fall back to aggregate weights), and a malformed
-  context within a definition is dropped while its siblings are kept.
-  Previously bandit rules were skipped and served the next rule or the
-  default value.
+  block the feature update they arrived with; malformed pieces degrade at
+  evaluation time instead (see the divergences entry below). An absent
+  `contextualBandits` payload section preserves the previous definitions;
+  an explicit empty one clears them; a section that fails to decrypt is
+  ignored, keeping the previous definitions. Previously bandit rules were
+  skipped and served the next rule or the default value.
 - **Bugfix (JS parity):** a feature rule of `{"force": null}` now serves
   `null` with source `force`, as the JS SDK does. Previously a null force
   was indistinguishable from an absent one, so the rule was skipped and the
@@ -85,14 +86,27 @@ All notable changes to this project will be documented in this file.
   a different key than reads looked up (`exp__-1` vs `exp__0`), so the saved
   assignment was never found again. Keys now normalize negative versions to
   0 in one place, for reads and saves alike.
-- Deliberate divergences from the JS SDK, all in favor of truthful bandit
-  exposures: sticky-bucketed assignments on bandit rules carry no bandit
-  attribution (the leaf weights did not produce the assignment; GrowthBook
-  disables sticky bucketing on bandit rules, so served payloads never hit
-  this path); reported `variationWeights` are the sanitized weights the
-  assignment actually used, where the JS SDK reports raw invalid weights;
-  and a type-malformed context is dropped rather than routed with junk
-  attribution.
+- Deliberate divergences from the JS SDK (shared with the Python SDK), all
+  in favor of truthful bandit exposures:
+  - Sticky-bucketed assignments on bandit rules carry no bandit attribution:
+    the leaf weights did not produce the assignment. GrowthBook disables
+    sticky bucketing on bandit rules server-side, so served payloads never
+    hit this path.
+  - Weight vectors are validated strictly (right length, finite,
+    non-negative, summing to ~1) and fall back to equal weights everywhere,
+    where the JS SDK checks only length and sum and buckets on the inverted
+    ranges a vector like `[1.2, -0.2]` produces.
+  - A matched leaf with a junk `leafId` or unusable weights demotes to the
+    fallback leaf (-1) with the rule's aggregate weights, rather than
+    repairing the weights while keeping the leaf's identity — reported
+    propensities always describe the vector bucketing used.
+  - A type-malformed context aborts leaf selection (later leaves are not
+    consulted): evaluation cannot know whether it would have matched.
+  - A rule pairing explicit `ranges` with a `contextualBanditRef` buckets on
+    the ranges (identical assignment to the JS SDK) but reports no bandit
+    metadata, since no truthful propensity vector exists.
+  - `RunExperiment` evaluates a copy of the caller's experiment and notifies
+    subscribers with unused bandit attribution stripped.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Added contextual bandit support (JS parity): feature rules carrying a
+  `contextualBanditRef` now evaluate using the per-context variation weights
+  from the payload's `contextualBandits` definitions (encrypted payloads
+  supported, plus a `WithContextualBandits` option and
+  `SetContextualBandits` for manual setup). The first context whose
+  condition matches the user supplies the weights; with no match, the rule's
+  aggregate weights apply under a fallback leaf. Assignments carry `leafId`,
+  `variationWeights`, and `banditVersion` on `ExperimentResult` — and on
+  forwarded deferred-tracking data. Definitions decode leniently and never
+  block the feature update they arrived with: a malformed definition is
+  dropped (its rules fall back to aggregate weights), and a malformed
+  context within a definition is dropped while its siblings are kept.
+  Previously bandit rules were skipped and served the next rule or the
+  default value.
 - **Bugfix (JS parity):** a feature rule of `{"force": null}` now serves
   `null` with source `force`, as the JS SDK does. Previously a null force
   was indistinguishable from an absent one, so the rule was skipped and the
@@ -71,6 +85,14 @@ All notable changes to this project will be documented in this file.
   a different key than reads looked up (`exp__-1` vs `exp__0`), so the saved
   assignment was never found again. Keys now normalize negative versions to
   0 in one place, for reads and saves alike.
+- Deliberate divergences from the JS SDK, all in favor of truthful bandit
+  exposures: sticky-bucketed assignments on bandit rules carry no bandit
+  attribution (the leaf weights did not produce the assignment; GrowthBook
+  disables sticky bucketing on bandit rules, so served payloads never hit
+  this path); reported `variationWeights` are the sanitized weights the
+  assignment actually used, where the JS SDK reports raw invalid weights;
+  and a type-malformed context is dropped rather than routed with junk
+  attribution.
 
 ## [v0.4.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.4.0) - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,42 @@ Implement the `StickyBucketService` interface for custom storage:
 
 For more details, see the [official documentation](https://docs.growthbook.io/app/sticky-bucketing).
 
+### Contextual Bandits
+
+GrowthBook contextual bandits (an Enterprise feature) learn per-segment
+variation weights server-side — the SDK evaluates no model. A bandit rule
+references a set of targeting contexts ("leaves"); the SDK routes the user to
+the first leaf whose condition matches and buckets with that leaf's weights.
+Definitions arrive in the SDK payload alongside features (encrypted payloads
+supported), so no extra configuration is needed. For manual setups there are
+`WithContextualBandits(...)` at construction and `SetContextualBandits(...)`
+at runtime.
+
+```go
+res := client.EvalFeature(ctx, "my-bandit-feature")
+r := res.ExperimentResult
+// r.LeafId, r.VariationWeights, r.BanditVersion — log these with the
+// exposure so the bandit keeps learning.
+```
+
+Good to know:
+
+- `ExperimentResult` carries `LeafId`, `VariationWeights`, and
+  `BanditVersion` only for real hashed assignments (never for forced
+  variations, QA mode, or sticky-bucketed users). Log them in your tracking
+  callback — the bandit reweights outcomes by these propensities.
+- Weights change as the bandit learns, so a user may be re-bucketed between
+  payload refreshes. That is by design: GrowthBook disables sticky bucketing
+  on bandit rules and attributes each user to their first exposure at
+  analysis time.
+- Bandit rules carry their variations under `contextualVariations`, so older
+  SDK versions without bandit support skip the rule and serve the feature's
+  default value.
+- Malformed bandit data degrades safely — fallback leaf `-1` with the rule's
+  aggregate weights — and never blocks the feature update it arrived with.
+- Deferred tracking forwards bandit attribution too: buffered `TrackingData`
+  carries the same fields.
+
 ---
 
 ## Documentation

--- a/bucket_range.go
+++ b/bucket_range.go
@@ -25,24 +25,7 @@ func (c *Client) getBucketRanges(numVariations int, coverage float64, weights []
 		coverage = 1
 	}
 
-	// Default to equal weights if missing or invalid
-	if len(weights) == 0 {
-		weights = getEqualWeights(numVariations)
-	}
-	if len(weights) != numVariations {
-		c.logger.Warn("Experiment weights and variations arrays must be the same length")
-		weights = getEqualWeights(numVariations)
-	}
-
-	// If weights don't add up to 1 (or close to it), default to equal weights
-	totalWeight := 0.0
-	for i := range weights {
-		totalWeight += weights[i]
-	}
-	if totalWeight < 0.99 || totalWeight > 1.01 {
-		c.logger.Warn("Experiment weights must add up to 1")
-		weights = getEqualWeights(numVariations)
-	}
+	weights = c.effectiveWeights(numVariations, weights)
 
 	// Cast weights to ranges
 	cumulative := 0.0
@@ -53,6 +36,27 @@ func (c *Client) getBucketRanges(numVariations int, coverage float64, weights []
 		ranges[i] = BucketRange{start, start + coverage*weights[i]}
 	}
 	return ranges
+}
+
+// effectiveWeights returns the weights assignment will actually use: equal
+// weights when missing, the wrong length, or not summing to ~1.
+func (c *Client) effectiveWeights(numVariations int, weights []float64) []float64 {
+	if len(weights) == 0 {
+		return getEqualWeights(numVariations)
+	}
+	if len(weights) != numVariations {
+		c.logger.Warn("Experiment weights and variations arrays must be the same length")
+		return getEqualWeights(numVariations)
+	}
+	totalWeight := 0.0
+	for i := range weights {
+		totalWeight += weights[i]
+	}
+	if totalWeight < 0.99 || totalWeight > 1.01 {
+		c.logger.Warn("Experiment weights must add up to 1")
+		return getEqualWeights(numVariations)
+	}
+	return weights
 }
 
 // Given a hash and bucket ranges, assigns one of the bucket ranges.

--- a/bucket_range.go
+++ b/bucket_range.go
@@ -1,6 +1,10 @@
 package growthbook
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"log/slog"
+	"math"
+)
 
 // BucketRange represents a single bucket range.
 type BucketRange struct {
@@ -25,7 +29,7 @@ func (c *Client) getBucketRanges(numVariations int, coverage float64, weights []
 		coverage = 1
 	}
 
-	weights = c.effectiveWeights(numVariations, weights)
+	weights = normalizedWeights(numVariations, weights, c.logger)
 
 	// Cast weights to ranges
 	cumulative := 0.0
@@ -38,25 +42,44 @@ func (c *Client) getBucketRanges(numVariations int, coverage float64, weights []
 	return ranges
 }
 
-// effectiveWeights returns the weights assignment will actually use: equal
-// weights when missing, the wrong length, or not summing to ~1.
-func (c *Client) effectiveWeights(numVariations int, weights []float64) []float64 {
+// isValidWeightVector reports whether weights is a usable propensity vector
+// for numVariations variations: right length, every element finite and
+// non-negative, and summing to ~1. Deliberately stricter than the JS SDK,
+// which checks only length and sum and buckets on inverted ranges for
+// vectors like [1.2, -0.2]; the Python SDK applies this same rule.
+func isValidWeightVector(weights []float64, numVariations int) bool {
+	if len(weights) == 0 || len(weights) != numVariations {
+		return false
+	}
+	total := 0.0
+	for _, w := range weights {
+		if math.IsNaN(w) || math.IsInf(w, 0) || w < 0 {
+			return false
+		}
+		total += w
+	}
+	return total >= 0.99 && total <= 1.01
+}
+
+// normalizedWeights returns the weights bucketing will actually use: the
+// input when it is a valid vector, equal weights otherwise. Reported bandit
+// propensities come from the same function, so they always describe the
+// vector bucketing used. A nil logger skips the warnings.
+func normalizedWeights(numVariations int, weights []float64, logger *slog.Logger) []float64 {
 	if len(weights) == 0 {
 		return getEqualWeights(numVariations)
 	}
-	if len(weights) != numVariations {
-		c.logger.Warn("Experiment weights and variations arrays must be the same length")
-		return getEqualWeights(numVariations)
+	if isValidWeightVector(weights, numVariations) {
+		return weights
 	}
-	totalWeight := 0.0
-	for i := range weights {
-		totalWeight += weights[i]
+	if logger != nil {
+		if len(weights) != numVariations {
+			logger.Warn("Experiment weights and variations arrays must be the same length")
+		} else {
+			logger.Warn("Experiment weights must be finite, non-negative, and add up to 1")
+		}
 	}
-	if totalWeight < 0.99 || totalWeight > 1.01 {
-		c.logger.Warn("Experiment weights must add up to 1")
-		return getEqualWeights(numVariations)
-	}
-	return weights
+	return getEqualWeights(numVariations)
 }
 
 // Given a hash and bucket ranges, assigns one of the bucket ranges.

--- a/bucket_range_test.go
+++ b/bucket_range_test.go
@@ -3,6 +3,7 @@ package growthbook
 import (
 	"context"
 	"log/slog"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -45,7 +46,34 @@ func TestGetBucketRangesWarnsAndFallsBackForInvalidInputs(t *testing.T) {
 			coverage: 1,
 			weights:  []float64{0.4, 0.1},
 			want:     []BucketRange{{0, 0.5}, {0.5, 1}},
-			warnings: []string{"Experiment weights must add up to 1"},
+			warnings: []string{"Experiment weights must be finite, non-negative, and add up to 1"},
+		},
+		{
+			name:     "NaN weight",
+			num:      2,
+			coverage: 1,
+			weights:  []float64{math.NaN(), 1},
+			want:     []BucketRange{{0, 0.5}, {0.5, 1}},
+			warnings: []string{"Experiment weights must be finite, non-negative, and add up to 1"},
+		},
+		{
+			name:     "infinite weight",
+			num:      2,
+			coverage: 1,
+			weights:  []float64{math.Inf(1), 1},
+			want:     []BucketRange{{0, 0.5}, {0.5, 1}},
+			warnings: []string{"Experiment weights must be finite, non-negative, and add up to 1"},
+		},
+		{
+			// The JS SDK buckets on the inverted ranges this vector produces;
+			// rejecting negative entries is a disclosed, deliberate divergence
+			// shared with the Python SDK.
+			name:     "negative weight summing to one",
+			num:      2,
+			coverage: 1,
+			weights:  []float64{1.2, -0.2},
+			want:     []BucketRange{{0, 0.5}, {0.5, 1}},
+			warnings: []string{"Experiment weights must be finite, non-negative, and add up to 1"},
 		},
 		{
 			name:     "valid approximate weights",

--- a/cases.json
+++ b/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.7.1",
+  "specVersion": "0.8.0",
   "evalCondition": [
     [
       "$not - pass",
@@ -63,32 +63,24 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "a"
-              }
+              "$elemMatch": { "$eq": "a" }
             }
           },
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "b"
-              }
+              "$elemMatch": { "$eq": "b" }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "c"
-                  }
+                  "$elemMatch": { "$eq": "c" }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "e"
-                  }
+                  "$elemMatch": { "$eq": "e" }
                 }
               }
             ]
@@ -96,30 +88,21 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "f"
-                }
+                "$elemMatch": { "$eq": "f" }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "g"
-                }
+                "$elemMatch": { "$eq": "g" }
               }
             }
           }
         ]
       },
       {
-        "$groups": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "$groups": ["a", "b", "c", "d"]
       },
       true
     ],
@@ -129,32 +112,24 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "a"
-              }
+              "$elemMatch": { "$eq": "a" }
             }
           },
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "b"
-              }
+              "$elemMatch": { "$eq": "b" }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "c"
-                  }
+                  "$elemMatch": { "$eq": "c" }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "e"
-                  }
+                  "$elemMatch": { "$eq": "e" }
                 }
               }
             ]
@@ -162,30 +137,21 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "d"
-                }
+                "$elemMatch": { "$eq": "d" }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "g"
-                }
+                "$elemMatch": { "$eq": "g" }
               }
             }
           }
         ]
       },
       {
-        "$groups": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "$groups": ["a", "b", "c", "d"]
       },
       false
     ],
@@ -423,11 +389,7 @@
       "$in - pass",
       {
         "num": {
-          "$in": [
-            1,
-            2,
-            3
-          ]
+          "$in": [1, 2, 3]
         }
       },
       {
@@ -439,11 +401,7 @@
       "$in - fail",
       {
         "num": {
-          "$in": [
-            1,
-            2,
-            3
-          ]
+          "$in": [1, 2, 3]
         }
       },
       {
@@ -467,18 +425,11 @@
       "$in - array pass 1",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "a"
-        ]
+        "tags": ["d", "e", "a"]
       },
       true
     ],
@@ -486,18 +437,11 @@
       "$in - array pass 2",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       true
     ],
@@ -505,18 +449,11 @@
       "$in - array pass 3",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "a"
-        ]
+        "tags": ["d", "b", "a"]
       },
       true
     ],
@@ -524,18 +461,11 @@
       "$in - array fail 1",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       false
     ],
@@ -543,10 +473,7 @@
       "$in - array fail 2",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
@@ -558,10 +485,7 @@
       "$in - fail (case sensitive mismatch)",
       {
         "country": {
-          "$in": [
-            "us",
-            "uk"
-          ]
+          "$in": ["us", "uk"]
         }
       },
       {
@@ -573,11 +497,7 @@
       "$nin - pass",
       {
         "num": {
-          "$nin": [
-            1,
-            2,
-            3
-          ]
+          "$nin": [1, 2, 3]
         }
       },
       {
@@ -589,11 +509,7 @@
       "$nin - fail",
       {
         "num": {
-          "$nin": [
-            1,
-            2,
-            3
-          ]
+          "$nin": [1, 2, 3]
         }
       },
       {
@@ -617,18 +533,11 @@
       "$nin - array fail 1",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "a"
-        ]
+        "tags": ["d", "e", "a"]
       },
       false
     ],
@@ -636,18 +545,11 @@
       "$nin - array fail 2",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       false
     ],
@@ -655,18 +557,11 @@
       "$nin - array fail 3",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "a"
-        ]
+        "tags": ["d", "b", "a"]
       },
       false
     ],
@@ -674,18 +569,11 @@
       "$nin - array pass 1",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       true
     ],
@@ -693,10 +581,7 @@
       "$nin - array pass 2",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
@@ -708,10 +593,7 @@
       "$nin - pass (case sensitive mismatch)",
       {
         "country": {
-          "$nin": [
-            "us",
-            "uk"
-          ]
+          "$nin": ["us", "uk"]
         }
       },
       {
@@ -723,10 +605,7 @@
       "$ini - pass (case insensitive match)",
       {
         "country": {
-          "$ini": [
-            "us",
-            "uk"
-          ]
+          "$ini": ["us", "uk"]
         }
       },
       {
@@ -738,10 +617,7 @@
       "$ini - pass (uppercase pattern, lowercase value)",
       {
         "country": {
-          "$ini": [
-            "US",
-            "UK"
-          ]
+          "$ini": ["US", "UK"]
         }
       },
       {
@@ -753,10 +629,7 @@
       "$ini - pass (mixed case)",
       {
         "country": {
-          "$ini": [
-            "Us",
-            "Uk"
-          ]
+          "$ini": ["Us", "Uk"]
         }
       },
       {
@@ -768,10 +641,7 @@
       "$ini - fail (no match)",
       {
         "country": {
-          "$ini": [
-            "us",
-            "uk"
-          ]
+          "$ini": ["us", "uk"]
         }
       },
       {
@@ -783,18 +653,11 @@
       "$ini - array pass 1",
       {
         "tags": {
-          "$ini": [
-            "a",
-            "b"
-          ]
+          "$ini": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "A"
-        ]
+        "tags": ["d", "e", "A"]
       },
       true
     ],
@@ -802,18 +665,11 @@
       "$ini - array pass 2",
       {
         "tags": {
-          "$ini": [
-            "A",
-            "B"
-          ]
+          "$ini": ["A", "B"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       true
     ],
@@ -821,18 +677,11 @@
       "$ini - array fail",
       {
         "tags": {
-          "$ini": [
-            "a",
-            "b"
-          ]
+          "$ini": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       false
     ],
@@ -852,10 +701,7 @@
       "$nini - pass (case insensitive match)",
       {
         "country": {
-          "$nini": [
-            "us",
-            "uk"
-          ]
+          "$nini": ["us", "uk"]
         }
       },
       {
@@ -867,10 +713,7 @@
       "$nini - fail (case insensitive match)",
       {
         "country": {
-          "$nini": [
-            "us",
-            "uk"
-          ]
+          "$nini": ["us", "uk"]
         }
       },
       {
@@ -882,10 +725,7 @@
       "$nini - fail (uppercase pattern, lowercase value)",
       {
         "country": {
-          "$nini": [
-            "US",
-            "UK"
-          ]
+          "$nini": ["US", "UK"]
         }
       },
       {
@@ -897,18 +737,11 @@
       "$nini - array pass",
       {
         "tags": {
-          "$nini": [
-            "a",
-            "b"
-          ]
+          "$nini": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       true
     ],
@@ -916,18 +749,11 @@
       "$nini - array fail 1",
       {
         "tags": {
-          "$nini": [
-            "a",
-            "b"
-          ]
+          "$nini": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "A"
-        ]
+        "tags": ["d", "e", "A"]
       },
       false
     ],
@@ -935,18 +761,11 @@
       "$nini - array fail 2",
       {
         "tags": {
-          "$nini": [
-            "A",
-            "B"
-          ]
+          "$nini": ["A", "B"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       false
     ],
@@ -972,12 +791,7 @@
         }
       },
       {
-        "nums": [
-          0,
-          5,
-          -20,
-          15
-        ]
+        "nums": [0, 5, -20, 15]
       },
       true
     ],
@@ -991,12 +805,7 @@
         }
       },
       {
-        "nums": [
-          0,
-          5,
-          -20,
-          8
-        ]
+        "nums": [0, 5, -20, 8]
       },
       false
     ],
@@ -1004,9 +813,7 @@
       "missing attribute - fail",
       {
         "pets.dog.name": {
-          "$in": [
-            "fido"
-          ]
+          "$in": ["fido"]
         }
       },
       {
@@ -1508,10 +1315,7 @@
         }
       },
       {
-        "a": [
-          1,
-          2
-        ]
+        "a": [1, 2]
       },
       true
     ],
@@ -1566,9 +1370,7 @@
     [
       "$size empty - pass",
       {
-        "tags": {
-          "$size": 0
-        }
+        "tags": { "$size": 0 }
       },
       {
         "tags": []
@@ -1578,14 +1380,10 @@
     [
       "$size empty - fail",
       {
-        "tags": {
-          "$size": 0
-        }
+        "tags": { "$size": 0 }
       },
       {
-        "tags": [
-          10
-        ]
+        "tags": [10]
       },
       false
     ],
@@ -1597,11 +1395,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b",
-          "c"
-        ]
+        "tags": ["a", "b", "c"]
       },
       true
     ],
@@ -1613,10 +1407,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b"
-        ]
+        "tags": ["a", "b"]
       },
       false
     ],
@@ -1628,12 +1419,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "tags": ["a", "b", "c", "d"]
       },
       false
     ],
@@ -1659,11 +1445,7 @@
         }
       },
       {
-        "tags": [
-          0,
-          1,
-          2
-        ]
+        "tags": [0, 1, 2]
       },
       true
     ],
@@ -1677,10 +1459,7 @@
         }
       },
       {
-        "tags": [
-          0,
-          1
-        ]
+        "tags": [0, 1]
       },
       false
     ],
@@ -1694,9 +1473,7 @@
         }
       },
       {
-        "tags": [
-          0
-        ]
+        "tags": [0]
       },
       false
     ],
@@ -1710,11 +1487,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "bar",
-          "baz"
-        ]
+        "tags": ["foo", "bar", "baz"]
       },
       true
     ],
@@ -1728,10 +1501,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "baz"
-        ]
+        "tags": ["foo", "baz"]
       },
       false
     ],
@@ -1740,19 +1510,12 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": [
-              "a",
-              "b"
-            ]
+            "$in": ["a", "b"]
           }
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "b"
-        ]
+        "tags": ["d", "e", "b"]
       },
       true
     ],
@@ -1761,19 +1524,12 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": [
-              "a",
-              "b"
-            ]
+            "$in": ["a", "b"]
           }
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       false
     ],
@@ -1789,10 +1545,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "baz"
-        ]
+        "tags": ["foo", "baz"]
       },
       true
     ],
@@ -1808,11 +1561,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "bar",
-          "baz"
-        ]
+        "tags": ["foo", "bar", "baz"]
       },
       false
     ],
@@ -1913,18 +1662,11 @@
       "$all - pass",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "one",
-          "two",
-          "three"
-        ]
+        "tags": ["one", "two", "three"]
       },
       true
     ],
@@ -1932,18 +1674,11 @@
       "$all - fail",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "one",
-          "two",
-          "four"
-        ]
+        "tags": ["one", "two", "four"]
       },
       false
     ],
@@ -1951,10 +1686,7 @@
       "$all - fail not array",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
@@ -1966,18 +1698,11 @@
       "$all - fail (case sensitive mismatch)",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "ONE",
-          "two",
-          "THREE"
-        ]
+        "tags": ["ONE", "two", "THREE"]
       },
       false
     ],
@@ -1985,18 +1710,11 @@
       "$alli - pass (case insensitive match)",
       {
         "tags": {
-          "$alli": [
-            "one",
-            "three"
-          ]
+          "$alli": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "ONE",
-          "two",
-          "THREE"
-        ]
+        "tags": ["ONE", "two", "THREE"]
       },
       true
     ],
@@ -2004,18 +1722,11 @@
       "$alli - pass (uppercase pattern, lowercase value)",
       {
         "tags": {
-          "$alli": [
-            "ONE",
-            "THREE"
-          ]
+          "$alli": ["ONE", "THREE"]
         }
       },
       {
-        "tags": [
-          "one",
-          "two",
-          "three"
-        ]
+        "tags": ["one", "two", "three"]
       },
       true
     ],
@@ -2023,18 +1734,11 @@
       "$alli - pass (mixed case)",
       {
         "tags": {
-          "$alli": [
-            "One",
-            "Three"
-          ]
+          "$alli": ["One", "Three"]
         }
       },
       {
-        "tags": [
-          "ONE",
-          "two",
-          "three"
-        ]
+        "tags": ["ONE", "two", "three"]
       },
       true
     ],
@@ -2042,18 +1746,11 @@
       "$alli - fail (case insensitive, missing value)",
       {
         "tags": {
-          "$alli": [
-            "one",
-            "three"
-          ]
+          "$alli": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "ONE",
-          "two",
-          "four"
-        ]
+        "tags": ["ONE", "two", "four"]
       },
       false
     ],
@@ -2061,10 +1758,7 @@
       "$alli - fail not array",
       {
         "tags": {
-          "$alli": [
-            "one",
-            "three"
-          ]
+          "$alli": ["one", "three"]
         }
       },
       {
@@ -2155,74 +1849,47 @@
     [
       "equals array - pass",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       true
     ],
     [
       "equals array - fail order",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "world",
-          "hello"
-        ]
+        "tags": ["world", "hello"]
       },
       false
     ],
     [
       "equals array - fail missing item",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello"
-        ]
+        "tags": ["hello"]
       },
       false
     ],
     [
       "equals array - fail extra item",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello",
-          "world",
-          "foo"
-        ]
+        "tags": ["hello", "world", "foo"]
       },
       false
     ],
     [
       "equals array - fail type mismatch",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
         "tags": "hello world"
@@ -2351,9 +2018,7 @@
     [
       "false strict condition - missing attribute",
       {
-        "userId": {
-          "$eq": false
-        }
+        "userId": { "$eq": false }
       },
       {},
       false
@@ -3464,14 +3129,7 @@
     [
       "$or pass but second condition fail",
       {
-        "$or": [
-          {
-            "foo": 1
-          },
-          {
-            "bar": 1
-          }
-        ],
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
         "baz": 2
       },
       {
@@ -3484,14 +3142,7 @@
     [
       "$or and second condition both pass",
       {
-        "$or": [
-          {
-            "foo": 1
-          },
-          {
-            "bar": 1
-          }
-        ],
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
         "baz": 2
       },
       {
@@ -3504,22 +3155,8 @@
     [
       "$and condition pass but $or fail",
       {
-        "$and": [
-          {
-            "foo": 1
-          },
-          {
-            "bar": 1
-          }
-        ],
-        "$or": [
-          {
-            "baz": 1
-          },
-          {
-            "empty": 1
-          }
-        ]
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
       },
       {
         "foo": 1,
@@ -3531,22 +3168,8 @@
     [
       "$and and $or both pass",
       {
-        "$and": [
-          {
-            "foo": 1
-          },
-          {
-            "bar": 1
-          }
-        ],
-        "$or": [
-          {
-            "baz": 1
-          },
-          {
-            "empty": 1
-          }
-        ]
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
       },
       {
         "foo": 1,
@@ -3559,529 +3182,202 @@
     [
       "$inGroup passes for member of known group id",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup fails for non-member of known group id",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": 5
-      },
+      { "id": 5 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup fails for unknown group id",
       {
-        "id": {
-          "$inGroup": "unknowngroup_id"
-        }
+        "id": { "$inGroup": "unknowngroup_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup fails for member of known group id",
       {
-        "id": {
-          "$notInGroup": "group_id"
-        }
+        "id": { "$notInGroup": "group_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup passes for non-member of known group id",
       {
-        "id": {
-          "$notInGroup": "group_id"
-        }
+        "id": { "$notInGroup": "group_id" }
       },
-      {
-        "id": 5
-      },
+      { "id": 5 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup passes for unknown group id",
       {
-        "id": {
-          "$notInGroup": "unknowngroup_id"
-        }
+        "id": { "$notInGroup": "unknowngroup_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup passes for properly typed data",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": "2"
-      },
+      { "id": "2" },
       true,
-      {
-        "group_id": [
-          1,
-          "2",
-          3
-        ]
-      }
+      { "group_id": [1, "2", 3] }
     ],
     [
       "$inGroup fails for improperly typed data",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": "3"
-      },
+      { "id": "3" },
       false,
-      {
-        "group_id": [
-          1,
-          "2",
-          3
-        ]
-      }
+      { "group_id": [1, "2", 3] }
     ]
   ],
   "hash": [
-    [
-      "",
-      "a",
-      1,
-      0.22
-    ],
-    [
-      "",
-      "b",
-      1,
-      0.077
-    ],
-    [
-      "b",
-      "a",
-      1,
-      0.946
-    ],
-    [
-      "ef",
-      "d",
-      1,
-      0.652
-    ],
-    [
-      "asdf",
-      "8952klfjas09ujk",
-      1,
-      0.549
-    ],
-    [
-      "",
-      "123",
-      1,
-      0.011
-    ],
-    [
-      "",
-      "___)((*\":&",
-      1,
-      0.563
-    ],
-    [
-      "seed",
-      "a",
-      2,
-      0.0505
-    ],
-    [
-      "seed",
-      "b",
-      2,
-      0.2696
-    ],
-    [
-      "foo",
-      "ab",
-      2,
-      0.2575
-    ],
-    [
-      "foo",
-      "def",
-      2,
-      0.2019
-    ],
-    [
-      "89123klj",
-      "8952klfjas09ujkasdf",
-      2,
-      0.124
-    ],
-    [
-      "90850943850283058242805",
-      "123",
-      2,
-      0.7516
-    ],
-    [
-      "()**(%$##$%#$#",
-      "___)((*\":&",
-      2,
-      0.0128
-    ],
-    [
-      "abc",
-      "def",
-      99,
-      null
-    ]
+    ["", "a", 1, 0.22],
+    ["", "b", 1, 0.077],
+    ["b", "a", 1, 0.946],
+    ["ef", "d", 1, 0.652],
+    ["asdf", "8952klfjas09ujk", 1, 0.549],
+    ["", "123", 1, 0.011],
+    ["", "___)((*\":&", 1, 0.563],
+    ["seed", "a", 2, 0.0505],
+    ["seed", "b", 2, 0.2696],
+    ["foo", "ab", 2, 0.2575],
+    ["foo", "def", 2, 0.2019],
+    ["89123klj", "8952klfjas09ujkasdf", 2, 0.124],
+    ["90850943850283058242805", "123", 2, 0.7516],
+    ["()**(%$##$%#$#", "___)((*\":&", 2, 0.0128],
+    ["abc", "def", 99, null]
   ],
   "getBucketRange": [
     [
       "normal 50/50",
+      [2, 1, null],
       [
-        2,
-        1,
-        null
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "reduced coverage",
+      [2, 0.5, null],
       [
-        2,
-        0.5,
-        null
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ]
     ],
     [
       "zero coverage",
+      [2, 0, null],
       [
-        2,
-        0,
-        null
-      ],
-      [
-        [
-          0,
-          0
-        ],
-        [
-          0.5,
-          0.5
-        ]
+        [0, 0],
+        [0.5, 0.5]
       ]
     ],
     [
       "4 variations",
+      [4, 1, null],
       [
-        4,
-        1,
-        null
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.25,
-          0.5
-        ],
-        [
-          0.5,
-          0.75
-        ],
-        [
-          0.75,
-          1
-        ]
+        [0, 0.25],
+        [0.25, 0.5],
+        [0.5, 0.75],
+        [0.75, 1]
       ]
     ],
     [
       "uneven weights",
+      [2, 1, [0.4, 0.6]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.6
-        ]
-      ],
-      [
-        [
-          0,
-          0.4
-        ],
-        [
-          0.4,
-          1
-        ]
+        [0, 0.4],
+        [0.4, 1]
       ]
     ],
     [
       "uneven weights, 3 variations",
+      [3, 1, [0.2, 0.3, 0.5]],
       [
-        3,
-        1,
-        [
-          0.2,
-          0.3,
-          0.5
-        ]
-      ],
-      [
-        [
-          0,
-          0.2
-        ],
-        [
-          0.2,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.2],
+        [0.2, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "uneven weights, reduced coverage, 3 variations",
+      [3, 0.2, [0.2, 0.3, 0.5]],
       [
-        3,
-        0.2,
-        [
-          0.2,
-          0.3,
-          0.5
-        ]
-      ],
-      [
-        [
-          0,
-          0.04
-        ],
-        [
-          0.2,
-          0.26
-        ],
-        [
-          0.5,
-          0.6
-        ]
+        [0, 0.04],
+        [0.2, 0.26],
+        [0.5, 0.6]
       ]
     ],
     [
       "negative coverage",
+      [2, -0.2, null],
       [
-        2,
-        -0.2,
-        null
-      ],
-      [
-        [
-          0,
-          0
-        ],
-        [
-          0.5,
-          0.5
-        ]
+        [0, 0],
+        [0.5, 0.5]
       ]
     ],
     [
       "coverage above 1",
+      [2, 1.5, null],
       [
-        2,
-        1.5,
-        null
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights sum below 1",
+      [2, 1, [0.4, 0.1]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.1
-        ]
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights sum above 1",
+      [2, 1, [0.7, 0.6]],
       [
-        2,
-        1,
-        [
-          0.7,
-          0.6
-        ]
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights.length not equal to num variations",
+      [4, 1, [0.4, 0.4, 0.2]],
       [
-        4,
-        1,
-        [
-          0.4,
-          0.4,
-          0.2
-        ]
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.25,
-          0.5
-        ],
-        [
-          0.5,
-          0.75
-        ],
-        [
-          0.75,
-          1
-        ]
+        [0, 0.25],
+        [0.25, 0.5],
+        [0.5, 0.75],
+        [0.75, 1]
       ]
     ],
     [
       "weights sum almost equals 1",
+      [2, 1, [0.4, 0.5999]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.5999
-        ]
-      ],
-      [
-        [
-          0,
-          0.4
-        ],
-        [
-          0.4,
-          0.9999
-        ]
+        [0, 0.4],
+        [0.4, 0.9999]
       ]
     ]
   ],
@@ -4100,11 +3396,7 @@
     ],
     [
       "defaults when empty",
-      {
-        "features": {
-          "feature": {}
-        }
-      },
+      { "features": { "feature": {} } },
       "feature",
       {
         "value": null,
@@ -4116,13 +3408,7 @@
     ],
     [
       "uses defaultValue - number",
-      {
-        "features": {
-          "feature": {
-            "defaultValue": 1
-          }
-        }
-      },
+      { "features": { "feature": { "defaultValue": 1 } } },
       "feature",
       {
         "value": 1,
@@ -4134,13 +3420,7 @@
     ],
     [
       "uses custom values - string",
-      {
-        "features": {
-          "feature": {
-            "defaultValue": "yes"
-          }
-        }
-      },
+      { "features": { "feature": { "defaultValue": "yes" } } },
       "feature",
       {
         "value": "yes",
@@ -4369,12 +3649,7 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": {
-                    "$in": [
-                      "US",
-                      "CA"
-                    ]
-                  },
+                  "country": { "$in": ["US", "CA"] },
                   "browser": "firefox"
                 }
               }
@@ -4405,12 +3680,7 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": {
-                    "$in": [
-                      "US",
-                      "CA"
-                    ]
-                  },
+                  "country": { "$in": ["US", "CA"] },
                   "browser": "firefox"
                 }
               }
@@ -4516,9 +3786,7 @@
       {
         "features": {
           "feature": {
-            "rules": [
-              {}
-            ]
+            "rules": [{}]
           }
         }
       },
@@ -4541,11 +3809,7 @@
           "feature": {
             "rules": [
               {
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -4558,11 +3822,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4591,11 +3851,7 @@
             "rules": [
               {
                 "id": "id",
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -4608,11 +3864,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4640,11 +3892,7 @@
           "feature": {
             "rules": [
               {
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -4657,11 +3905,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4697,14 +3941,8 @@
                 "name": "Test",
                 "phase": "1",
                 "ranges": [
-                  [
-                    0,
-                    0.1
-                  ],
-                  [
-                    0.1,
-                    1.0
-                  ]
+                  [0, 0.1],
+                  [0.1, 1.0]
                 ],
                 "meta": [
                   {
@@ -4720,31 +3958,14 @@
                   {
                     "attribute": "anonId",
                     "seed": "pricing",
-                    "ranges": [
-                      [
-                        0,
-                        1
-                      ]
-                    ]
+                    "ranges": [[0, 1]]
                   }
                 ],
-                "namespace": [
-                  "pricing",
-                  0,
-                  1
-                ],
+                "namespace": ["pricing", 0, 1],
                 "key": "hello",
-                "variations": [
-                  true,
-                  false
-                ],
-                "weights": [
-                  0.1,
-                  0.9
-                ],
-                "condition": {
-                  "premium": true
-                },
+                "variations": [true, false],
+                "weights": [0.1, 0.9],
+                "condition": { "premium": true },
                 "foo": "bar"
               }
             ]
@@ -4760,14 +3981,8 @@
         "experiment": {
           "coverage": 0.99,
           "ranges": [
-            [
-              0,
-              0.1
-            ],
-            [
-              0.1,
-              1.0
-            ]
+            [0, 0.1],
+            [0.1, 1.0]
           ],
           "meta": [
             {
@@ -4783,12 +3998,7 @@
             {
               "attribute": "anonId",
               "seed": "pricing",
-              "ranges": [
-                [
-                  0,
-                  1
-                ]
-              ]
+              "ranges": [[0, 1]]
             }
           ],
           "name": "Test",
@@ -4796,23 +4006,11 @@
           "seed": "feature",
           "hashVersion": 2,
           "hashAttribute": "anonId",
-          "namespace": [
-            "pricing",
-            0,
-            1
-          ],
+          "namespace": ["pricing", 0, 1],
           "key": "hello",
-          "variations": [
-            true,
-            false
-          ],
-          "weights": [
-            0.1,
-            0.9
-          ],
-          "condition": {
-            "premium": true
-          }
+          "variations": [true, false],
+          "weights": [0.1, 0.9],
+          "condition": { "premium": true }
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4842,21 +4040,15 @@
             "rules": [
               {
                 "force": 1,
-                "condition": {
-                  "browser": "chrome"
-                }
+                "condition": { "browser": "chrome" }
               },
               {
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4884,23 +4076,17 @@
               {
                 "force": 1,
                 "id": "1",
-                "condition": {
-                  "browser": "chrome"
-                }
+                "condition": { "browser": "chrome" }
               },
               {
                 "id": "2",
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
                 "id": "3",
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4927,21 +4113,15 @@
             "rules": [
               {
                 "force": 1,
-                "condition": {
-                  "browser": "chrome"
-                }
+                "condition": { "browser": "chrome" }
               },
               {
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4959,20 +4139,13 @@
     [
       "skips experiment on coverage",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "coverage": 0.01
               },
               {
@@ -4994,25 +4167,14 @@
     [
       "skips experiment on namespace",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
-                "namespace": [
-                  "pricing",
-                  0,
-                  0.01
-                ]
+                "variations": [0, 1, 2, 3],
+                "namespace": ["pricing", 0, 0.01]
               },
               {
                 "force": 3
@@ -5033,18 +4195,13 @@
     [
       "handles integer hashAttribute",
       {
-        "attributes": {
-          "id": 123
-        },
+        "attributes": { "id": 123 },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1
-                ]
+                "variations": [0, 1]
               }
             ]
           }
@@ -5058,10 +4215,7 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [
-            0,
-            1
-          ]
+          "variations": [0, 1]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -5081,20 +4235,13 @@
     [
       "skip experiment on missing hashAttribute",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "hashAttribute": "company"
               },
               {
@@ -5116,9 +4263,7 @@
     [
       "include experiments when forced",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "forcedVariations": {
           "feature": 1
         },
@@ -5127,12 +4272,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ]
+                "variations": [0, 1, 2, 3]
               },
               {
                 "force": 3
@@ -5149,12 +4289,7 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [
-            0,
-            1,
-            2,
-            3
-          ]
+          "variations": [0, 1, 2, 3]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -5183,10 +4318,7 @@
               {
                 "force": 2,
                 "coverage": 0.01,
-                "range": [
-                  0,
-                  0.99
-                ]
+                "range": [0, 0.99]
               }
             ]
           }
@@ -5214,10 +4346,7 @@
               {
                 "force": 2,
                 "hashVersion": 2,
-                "range": [
-                  0.96,
-                  0.97
-                ]
+                "range": [0.96, 0.97]
               }
             ]
           }
@@ -5244,10 +4373,7 @@
             "rules": [
               {
                 "force": 2,
-                "range": [
-                  0,
-                  0.01
-                ]
+                "range": [0, 0.01]
               }
             ]
           }
@@ -5277,12 +4403,7 @@
                 "filters": [
                   {
                     "seed": "seed",
-                    "ranges": [
-                      [
-                        0,
-                        0.01
-                      ]
-                    ]
+                    "ranges": [[0, 0.01]]
                   }
                 ]
               }
@@ -5311,10 +4432,7 @@
             "rules": [
               {
                 "force": 2,
-                "range": [
-                  0,
-                  0.5
-                ],
+                "range": [0, 0.5],
                 "seed": "fjdslafdsa",
                 "hashVersion": 2
               }
@@ -5343,20 +4461,11 @@
             "rules": [
               {
                 "key": "holdout",
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.01
-                  ],
-                  [
-                    0.01,
-                    1.0
-                  ]
+                  [0, 0.01],
+                  [0.01, 1.0]
                 ],
                 "meta": [
                   {},
@@ -5367,20 +4476,11 @@
               },
               {
                 "key": "experiment",
-                "variations": [
-                  3,
-                  4
-                ],
+                "variations": [3, 4],
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5396,19 +4496,10 @@
         "experiment": {
           "key": "experiment",
           "hashVersion": 2,
-          "variations": [
-            3,
-            4
-          ],
+          "variations": [3, 4],
           "ranges": [
-            [
-              0,
-              0.5
-            ],
-            [
-              0.5,
-              1.0
-            ]
+            [0, 0.5],
+            [0.5, 1.0]
           ]
         },
         "experimentResult": {
@@ -5439,19 +4530,10 @@
               {
                 "key": "holdout",
                 "hashVersion": 2,
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "ranges": [
-                  [
-                    0,
-                    0.99
-                  ],
-                  [
-                    0.99,
-                    1.0
-                  ]
+                  [0, 0.99],
+                  [0.99, 1.0]
                 ],
                 "meta": [
                   {},
@@ -5463,19 +4545,10 @@
               {
                 "key": "experiment",
                 "hashVersion": 2,
-                "variations": [
-                  3,
-                  4
-                ],
+                "variations": [3, 4],
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5491,14 +4564,8 @@
         "experiment": {
           "hashVersion": 2,
           "ranges": [
-            [
-              0,
-              0.99
-            ],
-            [
-              0.99,
-              1.0
-            ]
+            [0, 0.99],
+            [0.99, 1.0]
           ],
           "meta": [
             {},
@@ -5507,10 +4574,7 @@
             }
           ],
           "key": "holdout",
-          "variations": [
-            1,
-            2
-          ]
+          "variations": [1, 2]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -5540,20 +4604,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5565,17 +4620,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5607,17 +4658,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5646,20 +4693,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5671,17 +4709,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5710,20 +4744,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5732,9 +4757,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": {
-                  "id": "123"
-                },
+                "condition": { "id": "123" },
                 "force": 2
               }
             ]
@@ -5746,9 +4769,7 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
@@ -5757,19 +4778,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": {
-                      "value": {
-                        "$gt": 1
-                      }
-                    },
+                    "condition": { "value": { "$gt": 1 } },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5801,30 +4816,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": {
-                      "value": {
-                        "$gt": 1
-                      }
-                    },
+                    "condition": { "value": { "$gt": 1 } },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5833,9 +4835,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": {
-                  "id": "123"
-                },
+                "condition": { "id": "123" },
                 "force": 2
               }
             ]
@@ -5847,17 +4847,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5887,21 +4883,12 @@
             "rules": [
               {
                 "key": "experiment",
-                "variations": [
-                  0,
-                  1
-                ],
+                "variations": [0, 1],
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5913,17 +4900,13 @@
                 "parentConditions": [
                   {
                     "id": "parentExperimentFlag",
-                    "condition": {
-                      "value": 1
-                    },
+                    "condition": { "value": 1 },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5953,21 +4936,12 @@
             "rules": [
               {
                 "key": "experiment",
-                "variations": [
-                  0,
-                  1
-                ],
+                "variations": [0, 1],
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5979,17 +4953,13 @@
                 "parentConditions": [
                   {
                     "id": "parentExperimentFlag",
-                    "condition": {
-                      "value": 0
-                    },
+                    "condition": { "value": 0 },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -6019,9 +4989,7 @@
                 "parentConditions": [
                   {
                     "id": "flag2",
-                    "condition": {
-                      "value": true
-                    },
+                    "condition": { "value": true },
                     "gate": true
                   }
                 ]
@@ -6035,9 +5003,7 @@
                 "parentConditions": [
                   {
                     "id": "flag1",
-                    "condition": {
-                      "value": true
-                    },
+                    "condition": { "value": true },
                     "gate": true
                   }
                 ]
@@ -6070,18 +5036,12 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": {
-                        "$ne": false
-                      }
-                    },
+                    "condition": { "value": { "$ne": false } },
                     "gate": true
                   },
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": true
-                    },
+                    "condition": { "value": true },
                     "gate": true
                   }
                 ]
@@ -6093,25 +5053,19 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": true
-                    }
+                    "condition": { "value": true }
                   }
                 ],
                 "force": "C"
               },
               {
                 "condition": {
-                  "browser": {
-                    "$ne": "safari"
-                  }
+                  "browser": { "$ne": "safari" }
                 },
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": true
-                    }
+                    "condition": { "value": true }
                   }
                 ],
                 "force": "T"
@@ -6144,20 +5098,13 @@
             "rules": [
               {
                 "force": true,
-                "condition": {
-                  "id": {
-                    "$inGroup": "group_id"
-                  }
-                }
+                "condition": { "id": { "$inGroup": "group_id" } }
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [
-            123,
-            456
-          ]
+          "group_id": [123, 456]
         }
       },
       "inGroup_force_rule",
@@ -6181,35 +5128,19 @@
             "rules": [
               {
                 "key": "experiment",
-                "condition": {
-                  "id": {
-                    "$inGroup": "group_id"
-                  }
-                },
+                "condition": { "id": { "$inGroup": "group_id" } },
                 "hashVersion": 2,
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [
-            123,
-            456
-          ]
+          "group_id": [123, 456]
         }
       },
       "inGroup_experiment_rule",
@@ -6220,24 +5151,11 @@
         "source": "experiment",
         "experiment": {
           "hashVersion": 2,
-          "condition": {
-            "id": {
-              "$inGroup": "group_id"
-            }
-          },
-          "variations": [
-            1,
-            2
-          ],
+          "condition": { "id": { "$inGroup": "group_id" } },
+          "variations": [1, 2],
           "ranges": [
-            [
-              0,
-              0.5
-            ],
-            [
-              0.5,
-              1.0
-            ]
+            [0, 0.5],
+            [0.5, 1.0]
           ],
           "key": "experiment"
         },
@@ -6257,6 +5175,258 @@
       }
     ],
     [
+      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [1, 0],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [1, 0],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0, 1],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
       "multi-armed-bandit type is treated as a standard experiment",
       {
         "attributes": {
@@ -6271,14 +5441,8 @@
                 "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
-                "variations": [
-                  "control",
-                  "treatment"
-                ],
-                "weights": [
-                  0.5,
-                  0.5
-                ],
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
                 "meta": [
                   {
                     "key": "0"
@@ -6301,16 +5465,10 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "variations": [
-            "control",
-            "treatment"
-          ],
+          "variations": ["control", "treatment"],
           "key": "bandit-exp",
           "coverage": 1,
-          "weights": [
-            0.5,
-            0.5
-          ],
+          "weights": [0.5, 0.5],
           "meta": [
             {
               "key": "0"
@@ -6351,14 +5509,8 @@
                 "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
-                "variations": [
-                  "control",
-                  "treatment"
-                ],
-                "weights": [
-                  0.5,
-                  0.5
-                ],
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
                 "meta": [
                   {
                     "key": "0"
@@ -6381,16 +5533,10 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "variations": [
-            "control",
-            "treatment"
-          ],
+          "variations": ["control", "treatment"],
           "key": "bandit-exp",
           "coverage": 1,
-          "weights": [
-            0.5,
-            0.5
-          ],
+          "weights": [0.5, 0.5],
           "meta": [
             {
               "key": "0"
@@ -6431,14 +5577,8 @@
                 "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
-                "variations": [
-                  "control",
-                  "treatment"
-                ],
-                "weights": [
-                  0.5,
-                  0.5
-                ],
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
                 "meta": [
                   {
                     "key": "0"
@@ -6461,16 +5601,10 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "variations": [
-            "control",
-            "treatment"
-          ],
+          "variations": ["control", "treatment"],
           "key": "bandit-exp",
           "coverage": 1,
-          "weights": [
-            0.5,
-            0.5
-          ],
+          "weights": [0.5, 0.5],
           "meta": [
             {
               "key": "0"
@@ -6497,1447 +5631,410 @@
       }
     ],
     [
-      "force rules - coverage rollout uses seed (included)",
-      {
-        "attributes": {
-          "id": "2"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5,
-                "seed": "s1"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "source": "force",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage rollout uses seed (excluded)",
-      {
-        "attributes": {
-          "id": "5"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5,
-                "seed": "s1"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage rollout respects filters (filtered out)",
-      {
-        "attributes": {
-          "id": "5"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5,
-                "filters": [
-                  {
-                    "seed": "s2",
-                    "ranges": [
-                      [
-                        0,
-                        0.5
-                      ]
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage rollout respects filters (in filter range)",
-      {
-        "attributes": {
-          "id": "3"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5,
-                "filters": [
-                  {
-                    "seed": "s2",
-                    "ranges": [
-                      [
-                        0,
-                        0.5
-                      ]
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "source": "force",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage boundary is inclusive (n == coverage)",
-      {
-        "attributes": {
-          "id": "3152"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.5
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "source": "force",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - skip if hashAttribute missing and no sticky bucketing (fallbackAttribute set)",
+      "CB rule with empty contexts is overridden by forced variation like a normal experiment",
       {
         "attributes": {
           "id": "1",
-          "deviceId": "d123"
+          "plan": "pro"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
         },
         "features": {
-          "feature": {
-            "defaultValue": 0,
+          "bandit-feature": {
+            "defaultValue": "default",
             "rules": [
               {
-                "force": 1,
-                "coverage": 1,
-                "hashAttribute": "email",
-                "fallbackAttribute": "deviceId"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - skip if hashAttribute missing (no fallback to id)",
-      {
-        "attributes": {
-          "id": "1"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 1,
-                "hashAttribute": "email"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - hashAttribute present is used for coverage",
-      {
-        "attributes": {
-          "id": "1",
-          "email": "a@b.c"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 1,
-                "hashAttribute": "email"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "source": "force",
-        "ruleId": ""
-      }
-    ],
-    [
-      "object value with hashValue key is not coerced",
-      {
-        "attributes": {
-          "id": "1"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": {
-              "hashValue": 123
-            }
-          }
-        }
-      },
-      "feature",
-      {
-        "value": {
-          "hashValue": 123
-        },
-        "on": true,
-        "off": false,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - hashAttribute value of 0 is falsy, experiment skipped",
-      {
-        "attributes": {
-          "id": 0
-        },
-        "features": {
-          "feature": {
-            "defaultValue": "def",
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "def",
-        "on": true,
-        "off": false,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - hashAttribute value of false is falsy, experiment skipped",
-      {
-        "attributes": {
-          "id": false
-        },
-        "features": {
-          "feature": {
-            "defaultValue": "def",
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "def",
-        "on": true,
-        "off": false,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "force rules - coverage rollout skipped when hashAttribute value is 0 (falsy)",
-      {
-        "attributes": {
-          "id": 0
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "force": 1,
-                "coverage": 0.99
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - parentConditions are not copied onto the experiment",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "features": {
-          "parent": {
-            "defaultValue": "on"
-          },
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  0,
-                  1
-                ],
-                "parentConditions": [
-                  {
-                    "id": "parent",
-                    "condition": {
-                      "value": "on"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": 1,
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            0,
-            1
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": 1,
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - rule status is not copied onto the experiment (draft rule still runs)",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ],
-                "status": "draft"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "b",
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            "a",
-            "b"
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": "b",
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - urlPatterns are not copied onto the experiment",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "url": "http://example.com/",
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ],
-                "urlPatterns": [
-                  {
-                    "type": "simple",
-                    "pattern": "http://other.com",
-                    "include": true
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "b",
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            "a",
-            "b"
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": "b",
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - groups are not copied onto the experiment",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ],
-                "groups": [
-                  "internal"
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "b",
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            "a",
-            "b"
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": "b",
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - legacy url is not copied onto the experiment",
-      {
-        "attributes": {
-          "id": "123"
-        },
-        "url": "http://example.com/",
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  "a",
-                  "b"
-                ],
-                "url": "^/pricing$"
-              }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "value": "b",
-        "on": true,
-        "off": false,
-        "experiment": {
-          "key": "feature",
-          "variations": [
-            "a",
-            "b"
-          ]
-        },
-        "experimentResult": {
-          "featureId": "feature",
-          "value": "b",
-          "variationId": 1,
-          "inExperiment": true,
-          "hashUsed": true,
-          "hashAttribute": "id",
-          "hashValue": "123",
-          "bucket": 0.863,
-          "key": "1",
-          "stickyBucketUsed": false
-        },
-        "source": "experiment",
-        "ruleId": ""
-      }
-    ],
-    [
-      "experiment rules - fallbackAttribute ignored without sticky bucket service",
-      {
-        "attributes": {
-          "anonymousId": "123"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
-                "fallbackAttribute": "anonymousId"
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
         }
       },
-      "feature",
+      "bandit-feature",
       {
-        "value": 0,
-        "on": false,
-        "off": true,
-        "source": "defaultValue",
-        "ruleId": ""
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
       }
     ]
   ],
   "run": [
     [
       "default weights - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "coverage - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       1,
       true,
       true
     ],
     [
       "coverage - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       1,
       true,
       true
     ],
     [
       "coverage - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "three way test - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       1,
       true,
       true
     ],
     [
       "three way test - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       1,
       true,
       true
     ],
     [
       "three way test - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "test name - my-test",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "test name - my-test-3",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test-3",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test-3", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "empty id",
-      {
-        "attributes": {
-          "id": ""
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "null id",
-      {
-        "attributes": {
-          "id": null
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": null } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "missing id",
-      {
-        "attributes": {}
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": {} },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
@@ -7945,68 +6042,31 @@
     [
       "missing attributes",
       {},
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "single variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0] },
       0,
       false,
       false
     ],
     [
       "negative forced variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "force": -8
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "force": -8 },
       0,
       false,
       false
     ],
     [
       "high forced variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "force": 25
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "force": 25 },
       0,
       false,
       false
@@ -8021,10 +6081,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "condition": {
           "browser": "firefox"
         }
@@ -8043,10 +6100,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "condition": {
           "browser": "firefox"
         }
@@ -8065,10 +6119,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "hashAttribute": "companyId"
       },
       1,
@@ -8085,10 +6136,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -8104,10 +6152,7 @@
       },
       {
         "key": "forced-test-qs",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8123,10 +6168,7 @@
       {
         "key": "my-test",
         "active": true,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8142,10 +6184,7 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -8162,10 +6201,7 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8182,10 +6218,7 @@
         "key": "my-test",
         "force": 1,
         "coverage": 0.01,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -8221,19 +6254,12 @@
     [
       "Force variation from context",
       {
-        "attributes": {
-          "id": "1"
-        },
-        "forcedVariations": {
-          "my-test": 0
-        }
+        "attributes": { "id": "1" },
+        "forcedVariations": { "my-test": 0 }
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       true,
@@ -8242,17 +6268,12 @@
     [
       "Skips experiments in QA mode",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -8261,20 +6282,13 @@
     [
       "Works in QA mode if forced in context",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true,
-        "forcedVariations": {
-          "my-test": 1
-        }
+        "forcedVariations": { "my-test": 1 }
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8283,17 +6297,12 @@
     [
       "Works in QA mode if forced in experiment",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "force": 1
       },
       1,
@@ -8309,15 +6318,8 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "namespace": [
-          "namespace",
-          0.1,
-          1
-        ]
+        "variations": [0, 1],
+        "namespace": ["namespace", 0.1, 1]
       },
       1,
       true,
@@ -8332,15 +6334,8 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "namespace": [
-          "namespace",
-          0,
-          0.1
-        ]
+        "variations": [0, 1],
+        "namespace": ["namespace", 0, 0.1]
       },
       0,
       false,
@@ -8355,10 +6350,7 @@
       },
       {
         "key": "no-coverage",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "coverage": 0
       },
       0,
@@ -8375,33 +6367,19 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [
-              [
-                0.8,
-                1.0
-              ]
-            ]
+            "ranges": [[0.8, 1.0]]
           }
         ]
       },
@@ -8419,33 +6397,19 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [
-              [
-                0.6,
-                0.8
-              ]
-            ]
+            "ranges": [[0.6, 0.8]]
           }
         ]
       },
@@ -8462,30 +6426,17 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           }
         ],
-        "namespace": [
-          "test",
-          0,
-          0.001
-        ]
+        "namespace": ["test", 0, 0.001]
       },
       1,
       true,
@@ -8500,25 +6451,13 @@
       },
       {
         "key": "ranges",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0.99,
-            1.0
-          ],
-          [
-            0.0,
-            0.99
-          ]
+          [0.99, 1.0],
+          [0.0, 0.99]
         ],
         "coverage": 0.01,
-        "weights": [
-          0.99,
-          0.01
-        ]
+        "weights": [0.99, 0.01]
       },
       1,
       true,
@@ -8533,19 +6472,10 @@
       },
       {
         "key": "configs",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0,
-            0.1
-          ],
-          [
-            0.9,
-            1.0
-          ]
+          [0, 0.1],
+          [0.9, 1.0]
         ]
       },
       0,
@@ -8563,19 +6493,10 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0,
-            0.5
-          ],
-          [
-            0.5,
-            1.0
-          ]
+          [0, 0.5],
+          [0.5, 1.0]
         ]
       },
       1,
@@ -8593,10 +6514,7 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -8613,14 +6531,8 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.5,
-          0.5
-        ],
+        "variations": [0, 1],
+        "weights": [0.5, 0.5],
         "coverage": 0.99
       },
       1,
@@ -8630,9 +6542,7 @@
     [
       "Prerequisite condition passes",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "features": {
           "parentFlag": {
             "defaultValue": true
@@ -8641,10 +6551,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -8661,9 +6568,7 @@
     [
       "Prerequisite condition fails",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "features": {
           "parentFlag": {
             "defaultValue": false
@@ -8672,10 +6577,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -8692,29 +6594,15 @@
     [
       "SavedGroups correctly pulled from context for experiment",
       {
-        "attributes": {
-          "id": "4"
-        },
-        "savedGroups": {
-          "group_id": [
-            "4",
-            "5",
-            "6"
-          ]
-        }
+        "attributes": { "id": "4" },
+        "savedGroups": { "group_id": ["4", "5", "6"] }
       },
       {
         "key": "group-filtered-test",
         "condition": {
-          "id": {
-            "$inGroup": "group_id"
-          }
+          "id": { "$inGroup": "group_id" }
         },
-        "variations": [
-          0,
-          1,
-          2
-        ]
+        "variations": [0, 1, 2]
       },
       0,
       true,
@@ -8726,14 +6614,8 @@
       "even range, 0.2",
       0.2,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -8741,14 +6623,8 @@
       "even range, 0.4",
       0.4,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -8756,14 +6632,8 @@
       "even range, 0.6",
       0.6,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -8771,14 +6641,8 @@
       "even range, 0.8",
       0.8,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -8786,14 +6650,8 @@
       "even range, 0",
       0,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -8801,14 +6659,8 @@
       "even range, 0.5",
       0.5,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -8816,14 +6668,8 @@
       "reduced range, 0.2",
       0.2,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       0
     ],
@@ -8831,14 +6677,8 @@
       "reduced range, 0.4",
       0.4,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -8846,14 +6686,8 @@
       "reduced range, 0.6",
       0.6,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       1
     ],
@@ -8861,14 +6695,8 @@
       "reduced range, 0.8",
       0.8,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -8876,14 +6704,8 @@
       "reduced range, 0.25",
       0.25,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -8891,14 +6713,8 @@
       "reduced range, 0.5",
       0.5,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       1
     ],
@@ -8906,44 +6722,17 @@
       "zero range",
       0.5,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 0.5],
+        [0.5, 1]
       ],
       2
     ]
   ],
   "getQueryStringOverride": [
-    [
-      "empty url",
-      "my-test",
-      "",
-      2,
-      null
-    ],
-    [
-      "no query string",
-      "my-test",
-      "http://example.com",
-      2,
-      null
-    ],
-    [
-      "empty query string",
-      "my-test",
-      "http://example.com?",
-      2,
-      null
-    ],
+    ["empty url", "my-test", "", 2, null],
+    ["no query string", "my-test", "http://example.com", 2, null],
+    ["empty query string", "my-test", "http://example.com?", 2, null],
     [
       "no query string match",
       "my-test",
@@ -8951,62 +6740,14 @@
       2,
       null
     ],
-    [
-      "invalid query string",
-      "my-test",
-      "http://example.com??&&&?#",
-      2,
-      null
-    ],
-    [
-      "simple match 0",
-      "my-test",
-      "http://example.com?my-test=0",
-      2,
-      0
-    ],
-    [
-      "simple match 1",
-      "my-test",
-      "http://example.com?my-test=1",
-      2,
-      1
-    ],
-    [
-      "negative variation",
-      "my-test",
-      "http://example.com?my-test=-1",
-      2,
-      null
-    ],
-    [
-      "float",
-      "my-test",
-      "http://example.com?my-test=2.054",
-      2,
-      null
-    ],
-    [
-      "string",
-      "my-test",
-      "http://example.com?my-test=foo",
-      2,
-      null
-    ],
-    [
-      "variation too high",
-      "my-test",
-      "http://example.com?my-test=5",
-      2,
-      null
-    ],
-    [
-      "high numVariations",
-      "my-test",
-      "http://example.com?my-test=5",
-      6,
-      5
-    ],
+    ["invalid query string", "my-test", "http://example.com??&&&?#", 2, null],
+    ["simple match 0", "my-test", "http://example.com?my-test=0", 2, 0],
+    ["simple match 1", "my-test", "http://example.com?my-test=1", 2, 1],
+    ["negative variation", "my-test", "http://example.com?my-test=-1", 2, null],
+    ["float", "my-test", "http://example.com?my-test=2.054", 2, null],
+    ["string", "my-test", "http://example.com?my-test=foo", 2, null],
+    ["variation too high", "my-test", "http://example.com?my-test=5", 2, null],
+    ["high numVariations", "my-test", "http://example.com?my-test=5", 6, 5],
     [
       "equal to numVariations",
       "my-test",
@@ -9028,215 +6769,33 @@
       2,
       1
     ],
-    [
-      "anchor",
-      "my-test",
-      "http://example.com?my-test=1#foo",
-      2,
-      1
-    ]
+    ["anchor", "my-test", "http://example.com?my-test=1#foo", 2, 1]
   ],
   "inNamespace": [
-    [
-      "user 1, namespace1, 1",
-      "1",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 1, namespace1, 2",
-      "1",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 1, namespace2, 1",
-      "1",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 1, namespace2, 2",
-      "1",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 2, namespace1, 1",
-      "2",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 2, namespace1, 2",
-      "2",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 2, namespace2, 1",
-      "2",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 2, namespace2, 2",
-      "2",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 3, namespace1, 1",
-      "3",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 3, namespace1, 2",
-      "3",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 3, namespace2, 1",
-      "3",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      true
-    ],
-    [
-      "user 3, namespace2, 2",
-      "3",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      false
-    ],
-    [
-      "user 4, namespace1, 1",
-      "4",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 4, namespace1, 2",
-      "4",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 4, namespace2, 1",
-      "4",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      true
-    ],
-    [
-      "user 4, namespace2, 2",
-      "4",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      false
-    ]
+    ["user 1, namespace1, 1", "1", ["namespace1", 0, 0.4], false],
+    ["user 1, namespace1, 2", "1", ["namespace1", 0.4, 1], true],
+    ["user 1, namespace2, 1", "1", ["namespace2", 0, 0.4], false],
+    ["user 1, namespace2, 2", "1", ["namespace2", 0.4, 1], true],
+    ["user 2, namespace1, 1", "2", ["namespace1", 0, 0.4], false],
+    ["user 2, namespace1, 2", "2", ["namespace1", 0.4, 1], true],
+    ["user 2, namespace2, 1", "2", ["namespace2", 0, 0.4], false],
+    ["user 2, namespace2, 2", "2", ["namespace2", 0.4, 1], true],
+    ["user 3, namespace1, 1", "3", ["namespace1", 0, 0.4], false],
+    ["user 3, namespace1, 2", "3", ["namespace1", 0.4, 1], true],
+    ["user 3, namespace2, 1", "3", ["namespace2", 0, 0.4], true],
+    ["user 3, namespace2, 2", "3", ["namespace2", 0.4, 1], false],
+    ["user 4, namespace1, 1", "4", ["namespace1", 0, 0.4], false],
+    ["user 4, namespace1, 2", "4", ["namespace1", 0.4, 1], true],
+    ["user 4, namespace2, 1", "4", ["namespace2", 0, 0.4], true],
+    ["user 4, namespace2, 2", "4", ["namespace2", 0.4, 1], false]
   ],
   "getEqualWeights": [
-    [
-      -1,
-      []
-    ],
-    [
-      0,
-      []
-    ],
-    [
-      1,
-      [
-        1
-      ]
-    ],
-    [
-      2,
-      [
-        0.5,
-        0.5
-      ]
-    ],
-    [
-      3,
-      [
-        0.33333333,
-        0.33333333,
-        0.33333333
-      ]
-    ],
-    [
-      4,
-      [
-        0.25,
-        0.25,
-        0.25,
-        0.25
-      ]
-    ]
+    [-1, []],
+    [0, []],
+    [1, [1]],
+    [2, [0.5, 0.5]],
+    [3, [0.33333333, 0.33333333, 0.33333333]],
+    [4, [0.25, 0.25, 0.25, 0.25]]
   ],
   "decrypt": [
     [
@@ -9304,20 +6863,13 @@
     [
       "use fallbackAttribute when missing hashAttribute",
       {
-        "attributes": {
-          "anonymousId": "123"
-        },
+        "attributes": { "anonymousId": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "hashAttribute": "id",
                 "fallbackAttribute": "anonymousId"
               }
@@ -9341,9 +6893,7 @@
       },
       {
         "anonymousId||123": {
-          "assignments": {
-            "feature__0": "3"
-          },
+          "assignments": { "feature__0": "3" },
           "attributeName": "anonymousId",
           "attributeValue": "123"
         }
@@ -9369,31 +6919,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9417,9 +6947,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -9445,31 +6973,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9500,9 +7008,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "2"
-          },
+          "assignments": { "feature-exp__0": "2" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -9528,31 +7034,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9583,9 +7069,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -9611,31 +7095,11 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9666,16 +7130,12 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -9701,31 +7161,11 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9763,16 +7203,12 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": {
-            "feature-exp__0": "2"
-          },
+          "assignments": { "feature-exp__0": "2" },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -9797,31 +7233,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9830,9 +7246,7 @@
       },
       [
         {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -9881,31 +7295,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -9914,9 +7308,7 @@
       },
       [
         {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -9954,31 +7346,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10009,9 +7381,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__3": "2"
-          },
+          "assignments": { "feature-exp__3": "2" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -10038,31 +7408,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10082,9 +7432,7 @@
       null,
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__2": "2"
-          },
+          "assignments": { "feature-exp__2": "2" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -10111,31 +7459,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10196,31 +7524,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 4,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10280,31 +7588,11 @@
                 "hashVersion": 2,
                 "bucketVersion": 1,
                 "disableStickyBucketing": true,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -10315,9 +7603,7 @@
         {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": {
-            "feature-exp__0": "1"
-          }
+          "assignments": { "feature-exp__0": "1" }
         }
       ],
       "exp1",
@@ -10337,58 +7623,7 @@
         "id||i123": {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": {
-            "feature-exp__0": "1"
-          }
-        }
-      }
-    ],
-    [
-      "falsy hashAttribute value (0) falls through to fallbackAttribute",
-      {
-        "attributes": {
-          "id": 0,
-          "anonymousId": "123"
-        },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
-                "hashAttribute": "id",
-                "fallbackAttribute": "anonymousId"
-              }
-            ]
-          }
-        }
-      },
-      [],
-      "feature",
-      {
-        "bucket": 0.863,
-        "featureId": "feature",
-        "hashAttribute": "anonymousId",
-        "hashUsed": true,
-        "hashValue": "123",
-        "inExperiment": true,
-        "key": "3",
-        "stickyBucketUsed": false,
-        "value": 3,
-        "variationId": 3
-      },
-      {
-        "anonymousId||123": {
-          "assignments": {
-            "feature__0": "3"
-          },
-          "attributeName": "anonymousId",
-          "attributeValue": "123"
+          "assignments": { "feature-exp__0": "1" }
         }
       }
     ]
@@ -10397,9 +7632,7 @@
     [
       "redirects correctly without query strings",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -10411,10 +7644,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10435,9 +7665,7 @@
     [
       "redirects with query string on original url and persistQueryString enabled",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home?color=blue&food=sushi",
         "experiments": [
           {
@@ -10449,10 +7677,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10474,9 +7699,7 @@
     [
       "merges query strings on original url & redirect url with param conflicts correctly when persistQueryString enabled",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home?color=blue&food=sushi&title=original",
         "experiments": [
           {
@@ -10488,10 +7711,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10513,9 +7733,7 @@
     [
       "only performs a redirect for first eligible experiment when there are multiple eligible experiments",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -10527,10 +7745,7 @@
                 "pattern": "http://www.example.com/"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10547,10 +7762,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10567,10 +7779,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -10587,6 +7796,3030 @@
           "urlWithParams": "http://www.example.com/home-new-new"
         }
       ]
+    ]
+  ],
+  "contextualBandit": [
+    [
+      "single catch-all leaf routes and sets CB result fields",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "anything"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "matches the first (specific) leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "falls through to the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $in matches",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free",
+          "cartValue": 100
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": ["free", "basic"]
+                  }
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $gte matches second leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "cartValue": 600
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": ["free", "basic"]
+                  }
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "first-match-wins when multiple leaf conditions match",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "pro"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "country": "US"
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "missing attribute used by a leaf condition falls into the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule outer condition fails, a following force rule applies",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "condition": {
+                  "country": "US"
+                },
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              },
+              {
+                "force": "forced"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "forced",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition fails - CB rule skipped",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage excludes user even though a leaf matched",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.01,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "three-arm CB leaf routes with positional weights",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["c0", "c1", "c2"],
+                "weights": [0.34, 0.33, 0.33],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [0, 0, 1]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0.34, 0.33, 0.33]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "c2",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["c0", "c1", "c2"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            },
+            {
+              "key": "2"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0, 0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "2",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 2,
+          "value": "c2",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0, 0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule as a later rule in the list",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "first",
+                "seed": "first",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "CA"
+                }
+              },
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 2",
+      {
+        "attributes": {
+          "id": "2"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "2",
+          "stickyBucketUsed": false,
+          "bucket": 0.9374,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 3",
+      {
+        "attributes": {
+          "id": "3"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "3",
+          "stickyBucketUsed": false,
+          "bucket": 0.8606,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.1, 0.9]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.1, 0.9],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0.1, 0.9],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 4",
+      {
+        "attributes": {
+          "id": "4"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.1, 0.9]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.1, 0.9],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "4",
+          "stickyBucketUsed": false,
+          "bucket": 0.4818,
+          "leafId": 1,
+          "variationWeights": [0.1, 0.9],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB empty hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": "",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB null hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": null,
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB missing hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB buckets on a custom hashAttribute",
+      {
+        "attributes": {
+          "anonId": "123",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "anonId",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "anonId",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "anonId",
+          "hashValue": "123",
+          "stickyBucketUsed": false,
+          "bucket": 0.0484,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "forcedVariations from context overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "querystring force overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "url": "https://example.com/?bandit-exp=1",
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB skipped in QA mode",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB in QA mode if forced in context",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "forcedVariations": {
+          "bandit-exp": 0
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB rule when globally disabled",
+      {
+        "enabled": false,
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "JSON variation values with CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": {
+              "color": "none"
+            },
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "green"
+                  }
+                ],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": {
+          "color": "blue"
+        },
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            {
+              "color": "blue"
+            },
+            {
+              "color": "green"
+            }
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": {
+            "color": "blue"
+          },
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "single-variation CB rule is invalid - not in experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control"],
+                "weights": [1],
+                "meta": [
+                  {
+                    "key": "0"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition passes - CB routes",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "condition": {
+            "country": "US"
+          },
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 8",
+      {
+        "attributes": {
+          "id": "8",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 0.5,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "8",
+          "stickyBucketUsed": false,
+          "bucket": 0.011,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "dangling contextualBanditRef uses marginal weights with no CB metadata",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "empty contexts array uses marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "banditVersion omitted from definition is absent from result",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0]
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0]
+        }
+      }
+    ],
+    [
+      "required attribute present but no leaf matches - fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
     ]
   ]
 }

--- a/cases_test.go
+++ b/cases_test.go
@@ -30,6 +30,7 @@ type cases struct {
 	GetEqualWeights        JsonTuples[getEqualWeightsCase]        `json:"getEqualWeights"`
 	Decrypt                JsonTuples[decryptCase]                `json:"decrypt"`
 	StickyBucket           JsonTuples[stickyBucketTestCase]       `json:"stickyBucket"`
+	ContextualBandit       JsonTuples[featureCase]                `json:"contextualBandit"`
 }
 
 type evalConditionCase struct {
@@ -153,13 +154,14 @@ type stickyBucketTestCase struct {
 }
 
 type env struct {
-	Attributes       Attributes            `json:"attributes"`
-	Features         FeatureMap            `json:"features"`
-	Enabled          *bool                 `json:"enabled"`
-	Url              string                `json:"url"`
-	ForcedVariations ForcedVariationsMap   `json:"forcedVariations"`
-	QaMode           *bool                 `json:"qaMode"`
-	SavedGroups      condition.SavedGroups `json:"savedGroups"`
+	Attributes        Attributes                  `json:"attributes"`
+	Features          FeatureMap                  `json:"features"`
+	Enabled           *bool                       `json:"enabled"`
+	Url               string                      `json:"url"`
+	ForcedVariations  ForcedVariationsMap         `json:"forcedVariations"`
+	QaMode            *bool                       `json:"qaMode"`
+	SavedGroups       condition.SavedGroups       `json:"savedGroups"`
+	ContextualBandits ContextualBanditDefinitions `json:"contextualBandits"`
 }
 
 type JsonTuple[T any] struct {
@@ -216,6 +218,7 @@ func TestCasesJson(t *testing.T) {
 	cases.GetEqualWeights.run("getEqualWeights", t)
 	cases.Decrypt.run("decrypt", t)
 	cases.StickyBucket.run("stickyBucket", t)
+	cases.ContextualBandit.run("contextualBandit", t)
 }
 
 // stringifyTopLevelHashValue converts a numeric top-level "hashValue" in an
@@ -415,6 +418,7 @@ func (e *env) client() (*Client, error) {
 		WithForcedVariations(e.ForcedVariations),
 		WithFeatures(e.Features),
 		WithSavedGroups(e.SavedGroups),
+		WithContextualBandits(e.ContextualBandits),
 		withSilentTestLogger(),
 	)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -256,9 +256,10 @@ func (client *Client) RefreshFeatures(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if resp.Features == nil && resp.EncryptedFeatures == "" {
-		return nil
-	}
+	// Apply partial responses too: UpdateFromApiResponse preserves omitted
+	// sections, so a bandit-only or saved-groups-only response updates just
+	// what it carries. (An early return on absent features predated that
+	// gating and left manual-mode clients with stale bandit definitions.)
 	return client.UpdateFromApiResponse(resp)
 }
 

--- a/client.go
+++ b/client.go
@@ -247,6 +247,10 @@ func (client *Client) EvalFeature(ctx context.Context, key string) *FeatureResul
 }
 
 func (client *Client) RunExperiment(ctx context.Context, exp *Experiment) *ExperimentResult {
+	// Copy: evaluation may adjust bandit metadata (propensity resync, strip
+	// of unused attribution) and must never mutate the caller's experiment.
+	expCopy := *exp
+	exp = &expCopy
 	e := client.evaluator(ctx)
 	res := e.runExperiment(exp, "")
 	client.fireTracking(ctx, e)

--- a/client.go
+++ b/client.go
@@ -182,20 +182,30 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 	} else {
 		features = resp.Features
 	}
+	// Section-presence semantics: an absent contextualBandits section
+	// preserves the previous definitions, an explicit empty (or null)
+	// section clears them, and a section that fails to decrypt is ignored
+	// like an absent one — the previous coherent map stays active rather
+	// than being wiped by a broken update (Python SDK parity).
 	bandits := resp.ContextualBandits
+	banditsPresent := bandits != nil
 	if resp.EncryptedContextualBandits != "" {
 		banditsJSON, err := client.data.decrypt(resp.EncryptedContextualBandits)
 		if err == nil {
 			err = json.Unmarshal([]byte(banditsJSON), &bandits)
 		}
 		if err != nil {
-			client.logger.Warn("Ignoring undecodable encrypted contextual bandits, applying the rest of the payload", "error", err)
+			client.logger.Warn("Ignoring undecodable encrypted contextual bandits, keeping the previous definitions", "error", err)
+		} else {
+			banditsPresent = true
 		}
 	}
 	client.data.withLock(func(d *data) error {
 		d.features = features
 		d.savedGroups = resp.SavedGroups
-		d.contextualBandits = bandits
+		if banditsPresent {
+			d.contextualBandits = bandits
+		}
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})

--- a/client.go
+++ b/client.go
@@ -131,6 +131,15 @@ func (client *Client) SetFeatures(features FeatureMap) error {
 	return nil
 }
 
+// SetContextualBandits updates the shared contextual bandit definitions.
+func (client *Client) SetContextualBandits(bandits ContextualBanditDefinitions) error {
+	client.data.withLock(func(d *data) error {
+		d.contextualBandits = bandits
+		return nil
+	})
+	return nil
+}
+
 // SetJSONFeatures updates shared features from JSON
 func (client *Client) SetJSONFeatures(featuresJSON string) error {
 	var features FeatureMap
@@ -173,9 +182,20 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 	} else {
 		features = resp.Features
 	}
+	bandits := resp.ContextualBandits
+	if resp.EncryptedContextualBandits != "" {
+		banditsJSON, err := client.data.decrypt(resp.EncryptedContextualBandits)
+		if err == nil {
+			err = json.Unmarshal([]byte(banditsJSON), &bandits)
+		}
+		if err != nil {
+			client.logger.Warn("Ignoring undecodable encrypted contextual bandits, applying the rest of the payload", "error", err)
+		}
+	}
 	client.data.withLock(func(d *data) error {
 		d.features = features
 		d.savedGroups = resp.SavedGroups
+		d.contextualBandits = bandits
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
@@ -340,10 +360,11 @@ func (client *Client) Logger() *slog.Logger {
 func (client *Client) evaluator(ctx context.Context) *evaluator {
 	client.data.mu.RLock()
 	e := evaluator{
-		features:    client.data.features,
-		savedGroups: client.data.savedGroups,
-		client:      client,
-		ctx:         ctx,
+		features:          client.data.features,
+		savedGroups:       client.data.savedGroups,
+		contextualBandits: client.data.contextualBandits,
+		client:            client,
+		ctx:               ctx,
 		recording: client.experimentCallback != nil || client.featureUsageCallback != nil ||
 			client.eventLogger != nil || client.trackingBuffer != nil || len(client.data.plugins) > 0,
 	}

--- a/client.go
+++ b/client.go
@@ -172,16 +172,26 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 			"dataUpdated", dataUpdated, "apiUdpated", apiUpdated)
 		return nil
 	}
+	// Section-presence semantics (Python setPayload parity): a partial
+	// payload — e.g. a bandit-only update — must never wipe sections it did
+	// not carry. An absent section preserves the previous data; an explicit
+	// empty section clears it. For features and savedGroups a JSON null
+	// section decodes to a nil map and counts as absent; contextualBandits
+	// additionally treats explicit null as a clear via its custom decoder.
 	var features FeatureMap
 	var err error
+	featuresPresent := false
 	if resp.EncryptedFeatures != "" {
 		features, err = client.DecryptFeatures(resp.EncryptedFeatures)
 		if err != nil {
 			return err
 		}
-	} else {
+		featuresPresent = true
+	} else if resp.Features != nil {
 		features = resp.Features
+		featuresPresent = true
 	}
+	savedGroupsPresent := resp.SavedGroups != nil
 	// Section-presence semantics: an absent contextualBandits section
 	// preserves the previous definitions, an explicit empty (or null)
 	// section clears them, and a section that fails to decrypt is ignored
@@ -201,8 +211,12 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 		}
 	}
 	client.data.withLock(func(d *data) error {
-		d.features = features
-		d.savedGroups = resp.SavedGroups
+		if featuresPresent {
+			d.features = features
+		}
+		if savedGroupsPresent {
+			d.savedGroups = resp.SavedGroups
+		}
 		if banditsPresent {
 			d.contextualBandits = bandits
 		}

--- a/client_data.go
+++ b/client_data.go
@@ -9,20 +9,21 @@ import (
 )
 
 type data struct {
-	mu            sync.RWMutex
-	features      FeatureMap
-	savedGroups   condition.SavedGroups
-	dateUpdated   time.Time
-	apiHost       string
-	clientKey     string
-	decryptionKey string
-	httpClient    *http.Client
-	dataSource    DataSource
-	dsStarted     bool
-	dsStartWait   chan struct{}
-	dsStartErr    error
-	plugins       []Plugin
-	subscribers   subscriberRegistry
+	mu                sync.RWMutex
+	features          FeatureMap
+	savedGroups       condition.SavedGroups
+	contextualBandits ContextualBanditDefinitions
+	dateUpdated       time.Time
+	apiHost           string
+	clientKey         string
+	decryptionKey     string
+	httpClient        *http.Client
+	dataSource        DataSource
+	dsStarted         bool
+	dsStartWait       chan struct{}
+	dsStartErr        error
+	plugins           []Plugin
+	subscribers       subscriberRegistry
 }
 
 func newData() *data {

--- a/client_option.go
+++ b/client_option.go
@@ -52,6 +52,15 @@ func WithAttributes(attributes Attributes) ClientOption {
 	}
 }
 
+// WithContextualBandits sets contextual bandit definitions, normally
+// delivered in the SDK payload.
+func WithContextualBandits(bandits ContextualBanditDefinitions) ClientOption {
+	return func(c *Client) error {
+		c.data.contextualBandits = bandits
+		return nil
+	}
+}
+
 // WithSavedGroups sets saved groups used to target the same group of users across multiple features and experiments.
 func WithSavedGroups(savedGroups condition.SavedGroups) ClientOption {
 	return func(c *Client) error {

--- a/client_test.go
+++ b/client_test.go
@@ -207,6 +207,32 @@ func TestRefreshFeatures(t *testing.T) {
 		require.Equal(t, expectedFeatures, client.Features())
 	})
 
+	t.Run("A bandit-only response updates definitions and preserves features", func(t *testing.T) {
+		ts := startServer(http.StatusOK, []byte(`{
+			"contextualBandits": {
+				"cb-1": {"contexts": [{"leafId": 10, "condition": {}, "weights": [1, 0]}]}
+			},
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		defer ts.http.Close()
+		client, err := NewClient(ctx,
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithJsonFeatures(`{"bandit-flag": {"defaultValue": "default", "rules": [{
+				"key": "bandit-exp", "coverage": 1, "contextualBanditRef": "cb-1",
+				"contextualVariations": ["a", "b"], "weights": [0.5, 0.5]
+			}]}}`),
+			WithAttributes(Attributes{"id": "u1"}),
+		)
+		require.Nil(t, err)
+
+		require.Nil(t, client.RefreshFeatures(ctx))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res.InExperiment(), "features must survive a bandit-only refresh")
+		require.Equal(t, 10, *res.ExperimentResult.LeafId, "the refreshed definitions must apply")
+	})
+
 	t.Run("Returns error on non-200 response", func(t *testing.T) {
 		ts := startServer(http.StatusNotFound, []byte(""))
 		defer ts.http.Close()

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -1,0 +1,115 @@
+package growthbook
+
+import (
+	"encoding/json"
+
+	"github.com/growthbook/growthbook-golang/internal/condition"
+)
+
+// ContextualBanditContext is one leaf of a contextual bandit definition: a
+// targeting condition and the variation weights to use when it matches.
+type ContextualBanditContext struct {
+	LeafId    int            `json:"leafId"`
+	Condition condition.Base `json:"condition"`
+	Weights   []float64      `json:"weights"`
+}
+
+// ContextualBanditDefinition holds the per-context variation weights for one
+// contextual bandit, as served in the SDK payload.
+type ContextualBanditDefinition struct {
+	BanditVersion *int                      `json:"banditVersion"`
+	Contexts      []ContextualBanditContext `json:"contexts"`
+}
+
+// UnmarshalJSON drops malformed contexts instead of erroring, so one bad
+// leaf does not discard a definition's parseable ones.
+func (d *ContextualBanditDefinition) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		BanditVersion *int              `json:"banditVersion"`
+		Contexts      []json.RawMessage `json:"contexts"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	d.BanditVersion = raw.BanditVersion
+	d.Contexts = nil
+	for _, rawCtx := range raw.Contexts {
+		var c ContextualBanditContext
+		if err := json.Unmarshal(rawCtx, &c); err != nil {
+			continue
+		}
+		d.Contexts = append(d.Contexts, c)
+	}
+	return nil
+}
+
+// ContextualBanditDefinitions maps bandit refs to their definitions.
+type ContextualBanditDefinitions map[string]ContextualBanditDefinition
+
+// UnmarshalJSON decodes leniently, dropping malformed definitions instead of
+// erroring: a bandit blob the SDK cannot parse (e.g. a future schema) must
+// not block the feature update it arrived with. Affected rules fall back to
+// their aggregate weights.
+func (defs *ContextualBanditDefinitions) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		*defs = nil
+		return nil
+	}
+	out := make(ContextualBanditDefinitions, len(raw))
+	for ref, rawDef := range raw {
+		var def ContextualBanditDefinition
+		if err := json.Unmarshal(rawDef, &def); err != nil {
+			continue
+		}
+		out[ref] = def
+	}
+	*defs = out
+	return nil
+}
+
+// CBContext is the contextual bandit context an assignment was made with.
+type CBContext struct {
+	LeafId           int       `json:"leafId"`
+	VariationWeights []float64 `json:"variationWeights"`
+	BanditVersion    *int      `json:"banditVersion,omitempty"`
+}
+
+const contextualBanditFallbackLeafId = -1
+
+// buildContextualBanditExperiment applies a bandit definition to exp: the
+// first leaf whose condition passes supplies the variation weights; with no
+// matching leaf the aggregate weights stay and the exposure is attributed to
+// the fallback leaf. A missing definition leaves exp untouched.
+func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string, featureId string) {
+	def, ok := e.contextualBandits[ref]
+	if !ok {
+		e.client.logger.DebugContext(e.ctx, "Contextual bandit ref not found in payload, using aggregate weights",
+			"id", featureId, "contextualBanditRef", ref)
+		return
+	}
+
+	for _, leaf := range def.Contexts {
+		if !leaf.Condition.Eval(e.client.attributes, e.savedGroups) {
+			continue
+		}
+		// Sanitize so the reported weights always equal the weights the
+		// assignment uses — bandit analysis reweights by these propensities.
+		weights := e.client.effectiveWeights(len(exp.Variations), leaf.Weights)
+		exp.Weights = weights
+		exp.ContextualBandit = &CBContext{
+			LeafId:           leaf.LeafId,
+			VariationWeights: weights,
+			BanditVersion:    def.BanditVersion,
+		}
+		return
+	}
+
+	e.client.logger.DebugContext(e.ctx, "Contextual bandit: no matching leaf, using fallback weights",
+		"id", featureId, "contextualBanditRef", ref)
+	exp.ContextualBandit = &CBContext{
+		LeafId:           contextualBanditFallbackLeafId,
+		VariationWeights: e.client.effectiveWeights(len(exp.Variations), exp.Weights),
+		BanditVersion:    def.BanditVersion,
+	}
+}

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -98,7 +98,7 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 		}
 		// Sanitize so the reported weights always equal the weights the
 		// assignment uses — bandit analysis reweights by these propensities.
-		weights := e.client.effectiveWeights(len(exp.Variations), leaf.Weights)
+		weights := normalizedWeights(len(exp.Variations), leaf.Weights, e.client.logger)
 		exp.Weights = weights
 		exp.ContextualBandit = &ContextualBanditAssignment{
 			LeafId:           leaf.LeafId,
@@ -112,7 +112,7 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 		"id", featureId, "contextualBanditRef", ref)
 	exp.ContextualBandit = &ContextualBanditAssignment{
 		LeafId:           contextualBanditFallbackLeafId,
-		VariationWeights: e.client.effectiveWeights(len(exp.Variations), exp.Weights),
+		VariationWeights: normalizedWeights(len(exp.Variations), exp.Weights, e.client.logger),
 		BanditVersion:    def.BanditVersion,
 	}
 }

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -160,6 +160,18 @@ type ContextualBanditAssignment struct {
 
 const contextualBanditFallbackLeafId = -1
 
+// clonedBanditVersion detaches a bandit version from its owner: assignments
+// must not share the pointer with the client-wide definitions map, and
+// results must not share it with the experiment's assignment — a consumer
+// writing through one must never corrupt what another observes.
+func clonedBanditVersion(v *int) *int {
+	if v == nil {
+		return nil
+	}
+	c := *v
+	return &c
+}
+
 // buildContextualBanditExperiment applies a bandit definition to exp: the
 // first leaf whose condition passes supplies the variation weights; with no
 // matching (valid) leaf the aggregate weights stay and the exposure is
@@ -192,7 +204,7 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 		exp.ContextualBandit = &ContextualBanditAssignment{
 			LeafId:           *leaf.LeafId,
 			VariationWeights: weights,
-			BanditVersion:    def.BanditVersion,
+			BanditVersion:    clonedBanditVersion(def.BanditVersion),
 		}
 		return
 	}
@@ -202,7 +214,7 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 	exp.ContextualBandit = &ContextualBanditAssignment{
 		LeafId:           contextualBanditFallbackLeafId,
 		VariationWeights: slices.Clone(normalizedWeights(len(exp.Variations), exp.Weights, e.client.logger)),
-		BanditVersion:    def.BanditVersion,
+		BanditVersion:    clonedBanditVersion(def.BanditVersion),
 	}
 }
 

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -24,13 +24,30 @@ type ContextualBanditContext struct {
 	// routing cannot know whether it would have matched, so reaching it
 	// aborts leaf selection (Python SDK parity).
 	malformed bool
+	// raw is the original payload form, kept so marshaling round-trips
+	// byte-faithfully — a malformed context must stay malformed, not
+	// re-decode as a valid catch-all leaf.
+	raw json.RawMessage
+}
+
+// MarshalJSON emits the original payload form when the context was decoded
+// from JSON, so the tolerant decoder's routing state (malformed markers)
+// survives a round trip. Contexts built programmatically marshal from their
+// fields; a decoded context mutated afterwards still marshals its original
+// form.
+func (c ContextualBanditContext) MarshalJSON() ([]byte, error) {
+	if c.raw != nil {
+		return c.raw, nil
+	}
+	type alias ContextualBanditContext
+	return json.Marshal(alias(c))
 }
 
 // UnmarshalJSON never fails: field-level junk zeroes the field, and a
 // non-object context (or one with an unparseable condition) is kept as a
 // malformed marker instead of being dropped, so routing order is preserved.
 func (c *ContextualBanditContext) UnmarshalJSON(data []byte) error {
-	*c = ContextualBanditContext{}
+	*c = ContextualBanditContext{raw: append(json.RawMessage(nil), data...)}
 	var raw struct {
 		LeafId    json.RawMessage `json:"leafId"`
 		Condition json.RawMessage `json:"condition"`
@@ -72,13 +89,30 @@ type ContextualBanditDefinition struct {
 	// (dangling ref, no bandit metadata), where truthy junk takes the
 	// fallback-leaf path.
 	falsy bool
+	// raw is the original payload form, kept so marshaling round-trips
+	// byte-faithfully — a falsy definition must stay falsy (dangling ref),
+	// not re-decode as an empty fallback definition.
+	raw json.RawMessage
+}
+
+// MarshalJSON emits the original payload form when the definition was
+// decoded from JSON, so the tolerant decoder's state (falsy markers, junk
+// fields) survives a round trip. Definitions built programmatically marshal
+// from their fields; a decoded definition mutated afterwards still marshals
+// its original form.
+func (d ContextualBanditDefinition) MarshalJSON() ([]byte, error) {
+	if d.raw != nil {
+		return d.raw, nil
+	}
+	type alias ContextualBanditDefinition
+	return json.Marshal(alias(d))
 }
 
 // UnmarshalJSON never fails: a junk banditVersion is omitted without
 // dropping the definition, junk contexts decode to none, and a non-object
 // definition is kept, distinguishing JS-falsy values from truthy junk.
 func (d *ContextualBanditDefinition) UnmarshalJSON(data []byte) error {
-	*d = ContextualBanditDefinition{}
+	*d = ContextualBanditDefinition{raw: append(json.RawMessage(nil), data...)}
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 || trimmed[0] != '{' {
 		// Not an object. JS-falsy values behave like a missing definition

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -3,6 +3,7 @@ package growthbook
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"slices"
 
 	"github.com/growthbook/growthbook-golang/internal/condition"
@@ -165,11 +166,29 @@ func (d *ContextualBanditDefinition) UnmarshalJSON(data []byte) error {
 // ContextualBanditDefinitions maps bandit refs to their definitions.
 type ContextualBanditDefinitions map[string]ContextualBanditDefinition
 
+// ParseContextualBandits strictly parses a contextual bandit definitions
+// blob for manual configuration: unlike the tolerant UnmarshalJSON — which
+// exists for the payload-ingestion boundary, where a bandit blob must never
+// block the feature update it arrived with — a top-level shape that is not a
+// JSON object is reported as an error instead of degrading to an empty map.
+// Definition- and context-level junk still degrades per entry at evaluation
+// time, exactly as payload-served definitions do.
+func ParseContextualBandits(data []byte) (ContextualBanditDefinitions, error) {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return nil, fmt.Errorf("contextual bandit definitions must be a JSON object keyed by ref: %w", err)
+	}
+	var defs ContextualBanditDefinitions
+	_ = json.Unmarshal(data, &defs) // the tolerant decoder cannot fail on an object
+	return defs, nil
+}
+
 // UnmarshalJSON decodes leniently: a bandit blob the SDK cannot parse (e.g.
 // a future schema) must not block the feature update it arrived with.
 // Definition- and context-level junk degrades per entry at evaluation time;
 // map-level junk yields an empty map, so every ref dangles (debug-logged at
-// use).
+// use). Manual callers who want a top-level shape error instead should use
+// ParseContextualBandits.
 func (defs *ContextualBanditDefinitions) UnmarshalJSON(data []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -178,6 +178,10 @@ func ParseContextualBandits(data []byte) (ContextualBanditDefinitions, error) {
 	if err := json.Unmarshal(data, &probe); err != nil {
 		return nil, fmt.Errorf("contextual bandit definitions must be a JSON object keyed by ref: %w", err)
 	}
+	if probe == nil {
+		// json.Unmarshal accepts null into a map as a successful no-op.
+		return nil, fmt.Errorf("contextual bandit definitions must be a JSON object keyed by ref, got null")
+	}
 	var defs ContextualBanditDefinitions
 	_ = json.Unmarshal(data, &defs) // the tolerant decoder cannot fail on an object
 	return defs, nil

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -24,19 +24,19 @@ type ContextualBanditContext struct {
 	// routing cannot know whether it would have matched, so reaching it
 	// aborts leaf selection (Python SDK parity).
 	malformed bool
-	// raw is the original payload form, kept so marshaling round-trips
-	// byte-faithfully — a malformed context must stay malformed, not
-	// re-decode as a valid catch-all leaf.
+	// raw is the original payload form, retained only while malformed is set:
+	// a malformed context has no truthful field representation, so it
+	// serializes as its original junk instead of a valid-looking leaf.
 	raw json.RawMessage
 }
 
-// MarshalJSON emits the original payload form when the context was decoded
-// from JSON, so the tolerant decoder's routing state (malformed markers)
-// survives a round trip. Contexts built programmatically marshal from their
-// fields; a decoded context mutated afterwards still marshals its original
-// form.
+// MarshalJSON emits the context's current fields, so values modified after
+// decoding serialize what evaluation would use. The one exception is a
+// malformed context: evaluation ignores its fields (leaf selection aborts at
+// it), so serialization preserves the original junk — emitting fields would
+// launder it into a valid catch-all leaf and change routing on re-decode.
 func (c ContextualBanditContext) MarshalJSON() ([]byte, error) {
-	if c.raw != nil {
+	if c.malformed {
 		return c.raw, nil
 	}
 	type alias ContextualBanditContext
@@ -48,6 +48,11 @@ func (c ContextualBanditContext) MarshalJSON() ([]byte, error) {
 // malformed marker instead of being dropped, so routing order is preserved.
 func (c *ContextualBanditContext) UnmarshalJSON(data []byte) error {
 	*c = ContextualBanditContext{raw: append(json.RawMessage(nil), data...)}
+	defer func() {
+		if !c.malformed {
+			c.raw = nil
+		}
+	}()
 	var raw struct {
 		LeafId    json.RawMessage `json:"leafId"`
 		Condition json.RawMessage `json:"condition"`
@@ -57,7 +62,9 @@ func (c *ContextualBanditContext) UnmarshalJSON(data []byte) error {
 		c.malformed = true
 		return nil
 	}
-	if raw.LeafId != nil {
+	// Guard against JSON null explicitly: json.Unmarshal treats null as a
+	// successful no-op, which would turn "leafId": null into leaf 0.
+	if raw.LeafId != nil && string(raw.LeafId) != "null" {
 		var id int
 		if err := json.Unmarshal(raw.LeafId, &id); err == nil {
 			c.LeafId = &id
@@ -89,20 +96,16 @@ type ContextualBanditDefinition struct {
 	// (dangling ref, no bandit metadata), where truthy junk takes the
 	// fallback-leaf path.
 	falsy bool
-	// raw is the original payload form, kept so marshaling round-trips
-	// byte-faithfully — a falsy definition must stay falsy (dangling ref),
-	// not re-decode as an empty fallback definition.
-	raw json.RawMessage
 }
 
-// MarshalJSON emits the original payload form when the definition was
-// decoded from JSON, so the tolerant decoder's state (falsy markers, junk
-// fields) survives a round trip. Definitions built programmatically marshal
-// from their fields; a decoded definition mutated afterwards still marshals
-// its original form.
+// MarshalJSON emits the definition's current fields, so values modified
+// after decoding serialize what evaluation would use. A falsy definition is
+// the exception: evaluation treats it as missing regardless of its fields,
+// so it serializes as its canonical falsy form, null — emitting fields would
+// turn a dangling ref into a fallback definition on re-decode.
 func (d ContextualBanditDefinition) MarshalJSON() ([]byte, error) {
-	if d.raw != nil {
-		return d.raw, nil
+	if d.falsy {
+		return []byte("null"), nil
 	}
 	type alias ContextualBanditDefinition
 	return json.Marshal(alias(d))
@@ -112,7 +115,7 @@ func (d ContextualBanditDefinition) MarshalJSON() ([]byte, error) {
 // dropping the definition, junk contexts decode to none, and a non-object
 // definition is kept, distinguishing JS-falsy values from truthy junk.
 func (d *ContextualBanditDefinition) UnmarshalJSON(data []byte) error {
-	*d = ContextualBanditDefinition{raw: append(json.RawMessage(nil), data...)}
+	*d = ContextualBanditDefinition{}
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 || trimmed[0] != '{' {
 		// Not an object. JS-falsy values behave like a missing definition
@@ -141,7 +144,9 @@ func (d *ContextualBanditDefinition) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(trimmed, &raw); err != nil {
 		return nil
 	}
-	if raw.BanditVersion != nil {
+	// Guard against JSON null explicitly: json.Unmarshal treats null as a
+	// successful no-op, which would turn "banditVersion": null into version 0.
+	if raw.BanditVersion != nil && string(raw.BanditVersion) != "null" {
 		var v int
 		if err := json.Unmarshal(raw.BanditVersion, &v); err == nil {
 			d.BanditVersion = &v

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -1,17 +1,64 @@
 package growthbook
 
 import (
+	"bytes"
 	"encoding/json"
+	"slices"
 
 	"github.com/growthbook/growthbook-golang/internal/condition"
 )
 
 // ContextualBanditContext is one leaf of a contextual bandit definition: a
-// targeting condition and the variation weights to use when it matches.
+// targeting condition and the variation weights to use when it matches. An
+// absent condition is a catch-all leaf.
 type ContextualBanditContext struct {
-	LeafId    int            `json:"leafId"`
+	// LeafId is nil when the payload's leafId is absent or not an integer;
+	// such a leaf cannot be attributed and demotes to the fallback.
+	LeafId    *int           `json:"leafId"`
 	Condition condition.Base `json:"condition"`
-	Weights   []float64      `json:"weights"`
+	// Weights is nil when the payload's weights are absent or type-malformed.
+	Weights []float64 `json:"weights"`
+
+	// malformed marks a context that was not a JSON object, or whose
+	// condition could not be parsed. It is kept in place rather than dropped:
+	// routing cannot know whether it would have matched, so reaching it
+	// aborts leaf selection (Python SDK parity).
+	malformed bool
+}
+
+// UnmarshalJSON never fails: field-level junk zeroes the field, and a
+// non-object context (or one with an unparseable condition) is kept as a
+// malformed marker instead of being dropped, so routing order is preserved.
+func (c *ContextualBanditContext) UnmarshalJSON(data []byte) error {
+	*c = ContextualBanditContext{}
+	var raw struct {
+		LeafId    json.RawMessage `json:"leafId"`
+		Condition json.RawMessage `json:"condition"`
+		Weights   json.RawMessage `json:"weights"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		c.malformed = true
+		return nil
+	}
+	if raw.LeafId != nil {
+		var id int
+		if err := json.Unmarshal(raw.LeafId, &id); err == nil {
+			c.LeafId = &id
+		}
+	}
+	if raw.Condition != nil && string(raw.Condition) != "null" {
+		if err := json.Unmarshal(raw.Condition, &c.Condition); err != nil {
+			c.malformed = true
+		}
+	}
+	if raw.Weights != nil {
+		// A partially numeric array must not survive as a prefix: reject the
+		// vector wholesale unless every element decodes.
+		if err := json.Unmarshal(raw.Weights, &c.Weights); err != nil {
+			c.Weights = nil
+		}
+	}
+	return nil
 }
 
 // ContextualBanditDefinition holds the per-context variation weights for one
@@ -19,26 +66,59 @@ type ContextualBanditContext struct {
 type ContextualBanditDefinition struct {
 	BanditVersion *int                      `json:"banditVersion"`
 	Contexts      []ContextualBanditContext `json:"contexts"`
+
+	// falsy marks a definition that was JSON null, false, 0, or "" — the JS
+	// SDK's `!cbDefinition` check treats those like a missing definition
+	// (dangling ref, no bandit metadata), where truthy junk takes the
+	// fallback-leaf path.
+	falsy bool
 }
 
-// UnmarshalJSON drops malformed contexts instead of erroring, so one bad
-// leaf does not discard a definition's parseable ones.
+// UnmarshalJSON never fails: a junk banditVersion is omitted without
+// dropping the definition, junk contexts decode to none, and a non-object
+// definition is kept, distinguishing JS-falsy values from truthy junk.
 func (d *ContextualBanditDefinition) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		BanditVersion *int              `json:"banditVersion"`
-		Contexts      []json.RawMessage `json:"contexts"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	d.BanditVersion = raw.BanditVersion
-	d.Contexts = nil
-	for _, rawCtx := range raw.Contexts {
-		var c ContextualBanditContext
-		if err := json.Unmarshal(rawCtx, &c); err != nil {
-			continue
+	*d = ContextualBanditDefinition{}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		// Not an object. JS-falsy values behave like a missing definition
+		// (`!cbDefinition`); truthy junk keeps an empty definition, which
+		// takes the fallback-leaf path.
+		var v any
+		if err := json.Unmarshal(trimmed, &v); err != nil {
+			return nil
 		}
-		d.Contexts = append(d.Contexts, c)
+		switch val := v.(type) {
+		case nil:
+			d.falsy = true
+		case bool:
+			d.falsy = !val
+		case float64:
+			d.falsy = val == 0
+		case string:
+			d.falsy = val == ""
+		}
+		return nil
+	}
+	var raw struct {
+		BanditVersion json.RawMessage `json:"banditVersion"`
+		Contexts      json.RawMessage `json:"contexts"`
+	}
+	if err := json.Unmarshal(trimmed, &raw); err != nil {
+		return nil
+	}
+	if raw.BanditVersion != nil {
+		var v int
+		if err := json.Unmarshal(raw.BanditVersion, &v); err == nil {
+			d.BanditVersion = &v
+		}
+	}
+	if raw.Contexts != nil {
+		// Non-array contexts decode to none; per-context junk is handled by
+		// the context decoder, which never fails.
+		if err := json.Unmarshal(raw.Contexts, &d.Contexts); err != nil {
+			d.Contexts = nil
+		}
 	}
 	return nil
 }
@@ -46,22 +126,22 @@ func (d *ContextualBanditDefinition) UnmarshalJSON(data []byte) error {
 // ContextualBanditDefinitions maps bandit refs to their definitions.
 type ContextualBanditDefinitions map[string]ContextualBanditDefinition
 
-// UnmarshalJSON decodes leniently, dropping malformed definitions instead of
-// erroring: a bandit blob the SDK cannot parse (e.g. a future schema) must
-// not block the feature update it arrived with. Affected rules fall back to
-// their aggregate weights.
+// UnmarshalJSON decodes leniently: a bandit blob the SDK cannot parse (e.g.
+// a future schema) must not block the feature update it arrived with.
+// Definition- and context-level junk degrades per entry at evaluation time;
+// map-level junk yields an empty map, so every ref dangles (debug-logged at
+// use).
 func (defs *ContextualBanditDefinitions) UnmarshalJSON(data []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
-		*defs = nil
+		*defs = ContextualBanditDefinitions{}
 		return nil
 	}
 	out := make(ContextualBanditDefinitions, len(raw))
 	for ref, rawDef := range raw {
 		var def ContextualBanditDefinition
-		if err := json.Unmarshal(rawDef, &def); err != nil {
-			continue
-		}
+		// The definition decoder never fails; junk degrades per entry.
+		_ = json.Unmarshal(rawDef, &def)
 		out[ref] = def
 	}
 	*defs = out
@@ -82,26 +162,35 @@ const contextualBanditFallbackLeafId = -1
 
 // buildContextualBanditExperiment applies a bandit definition to exp: the
 // first leaf whose condition passes supplies the variation weights; with no
-// matching leaf the aggregate weights stay and the exposure is attributed to
-// the fallback leaf. A missing definition leaves exp untouched.
+// matching (valid) leaf the aggregate weights stay and the exposure is
+// attributed to the fallback leaf. A missing or JS-falsy definition leaves
+// exp untouched — a plain experiment with no bandit metadata.
 func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string, featureId string) {
 	def, ok := e.contextualBandits[ref]
-	if !ok {
+	if !ok || def.falsy {
 		e.client.logger.DebugContext(e.ctx, "Contextual bandit ref not found in payload, using aggregate weights",
 			"id", featureId, "contextualBanditRef", ref)
 		return
 	}
 
-	for _, leaf := range def.Contexts {
-		if !leaf.Condition.Eval(e.client.attributes, e.savedGroups) {
-			continue
-		}
-		// Sanitize so the reported weights always equal the weights the
-		// assignment uses — bandit analysis reweights by these propensities.
-		weights := normalizedWeights(len(exp.Variations), leaf.Weights, e.client.logger)
+	leaf := e.selectContextualBanditLeaf(def.Contexts, featureId, ref)
+	if leaf != nil && (leaf.LeafId == nil || !isValidWeightVector(leaf.Weights, len(exp.Variations))) {
+		// Demote rather than repair: substituting weights would report a
+		// leaf whose propensities differ from the vector bucketing uses,
+		// and keeping its leafId would attribute an assignment the leaf's
+		// weights did not produce.
+		e.client.logger.DebugContext(e.ctx, "Contextual bandit: matched leaf is malformed, using fallback weights",
+			"id", featureId, "contextualBanditRef", ref)
+		leaf = nil
+	}
+
+	if leaf != nil {
+		// Clone: payload-owned slices must never alias into experiments and
+		// results handed to callbacks and subscribers.
+		weights := slices.Clone(leaf.Weights)
 		exp.Weights = weights
 		exp.ContextualBandit = &ContextualBanditAssignment{
-			LeafId:           leaf.LeafId,
+			LeafId:           *leaf.LeafId,
 			VariationWeights: weights,
 			BanditVersion:    def.BanditVersion,
 		}
@@ -112,7 +201,26 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 		"id", featureId, "contextualBanditRef", ref)
 	exp.ContextualBandit = &ContextualBanditAssignment{
 		LeafId:           contextualBanditFallbackLeafId,
-		VariationWeights: normalizedWeights(len(exp.Variations), exp.Weights, e.client.logger),
+		VariationWeights: slices.Clone(normalizedWeights(len(exp.Variations), exp.Weights, e.client.logger)),
 		BanditVersion:    def.BanditVersion,
 	}
+}
+
+// selectContextualBanditLeaf returns the first leaf whose condition matches
+// the client's attributes. Reaching a malformed context aborts selection —
+// evaluation cannot know whether it would have matched, so later leaves must
+// not be consulted (Python SDK parity: a failed leaf lookup falls back).
+func (e *evaluator) selectContextualBanditLeaf(contexts []ContextualBanditContext, featureId string, ref string) *ContextualBanditContext {
+	for i := range contexts {
+		leaf := &contexts[i]
+		if leaf.malformed {
+			e.client.logger.DebugContext(e.ctx, "Contextual bandit: leaf selection stopped at a malformed context",
+				"id", featureId, "contextualBanditRef", ref)
+			return nil
+		}
+		if leaf.Condition.Eval(e.client.attributes, e.savedGroups) {
+			return leaf
+		}
+	}
+	return nil
 }

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -210,6 +210,13 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 // the client's attributes. Reaching a malformed context aborts selection —
 // evaluation cannot know whether it would have matched, so later leaves must
 // not be consulted (Python SDK parity: a failed leaf lookup falls back).
+//
+// "Malformed" here means structurally unusable: a non-object context or an
+// unparseable condition. A condition that parses but carries semantic junk
+// (an unknown operator, `$in` with a non-array argument, an invalid regex)
+// deliberately evaluates false and routing continues — that is how the JS
+// and Python SDKs evaluate the same payload, and diverging here would assign
+// the same user different variations across SDKs.
 func (e *evaluator) selectContextualBanditLeaf(contexts []ContextualBanditContext, featureId string, ref string) *ContextualBanditContext {
 	for i := range contexts {
 		leaf := &contexts[i]

--- a/contextual_bandit.go
+++ b/contextual_bandit.go
@@ -68,8 +68,11 @@ func (defs *ContextualBanditDefinitions) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// CBContext is the contextual bandit context an assignment was made with.
-type CBContext struct {
+// ContextualBanditAssignment is what a contextual bandit assignment was
+// made with: the chosen leaf (or the fallback -1) and the variation weights
+// bucketing used. Distinct from ContextualBanditContext, which is a payload
+// leaf (a targeting condition plus candidate weights).
+type ContextualBanditAssignment struct {
 	LeafId           int       `json:"leafId"`
 	VariationWeights []float64 `json:"variationWeights"`
 	BanditVersion    *int      `json:"banditVersion,omitempty"`
@@ -97,7 +100,7 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 		// assignment uses — bandit analysis reweights by these propensities.
 		weights := e.client.effectiveWeights(len(exp.Variations), leaf.Weights)
 		exp.Weights = weights
-		exp.ContextualBandit = &CBContext{
+		exp.ContextualBandit = &ContextualBanditAssignment{
 			LeafId:           leaf.LeafId,
 			VariationWeights: weights,
 			BanditVersion:    def.BanditVersion,
@@ -107,7 +110,7 @@ func (e *evaluator) buildContextualBanditExperiment(exp *Experiment, ref string,
 
 	e.client.logger.DebugContext(e.ctx, "Contextual bandit: no matching leaf, using fallback weights",
 		"id", featureId, "contextualBanditRef", ref)
-	exp.ContextualBandit = &CBContext{
+	exp.ContextualBandit = &ContextualBanditAssignment{
 		LeafId:           contextualBanditFallbackLeafId,
 		VariationWeights: e.client.effectiveWeights(len(exp.Variations), exp.Weights),
 		BanditVersion:    def.BanditVersion,

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -1,0 +1,385 @@
+package growthbook
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The bandit rules carry variations only under contextualVariations, pinning
+// that bandit-aware SDKs evaluate them while older SDKs skip them. Leaf
+// weights of [1,0]/[0,1] make assignments deterministic.
+const banditFeaturesJSON = `{
+  "bandit-flag": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "bandit-exp",
+        "coverage": 1,
+        "contextualBanditRef": "cb-1",
+        "contextualVariations": ["a", "b"],
+        "weights": [0.5, 0.5],
+        "meta": [{"key": "0"}, {"key": "1"}]
+      }
+    ]
+  },
+  "bandit-no-match": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "bandit-nm",
+        "coverage": 1,
+        "contextualBanditRef": "cb-us-only",
+        "contextualVariations": ["a", "b"],
+        "weights": [0, 1]
+      }
+    ]
+  },
+  "bandit-missing-ref": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "bandit-mr",
+        "coverage": 1,
+        "contextualBanditRef": "cb-nope",
+        "contextualVariations": ["a", "b"],
+        "weights": [0, 1]
+      }
+    ]
+  },
+  "bandit-no-weights": {
+    "defaultValue": "default",
+    "rules": [
+      {
+        "key": "bandit-nw",
+        "coverage": 1,
+        "contextualBanditRef": "cb-us-only",
+        "contextualVariations": ["a", "b"]
+      }
+    ]
+  }
+}`
+
+const banditDefsJSON = `{
+  "cb-1": {
+    "banditVersion": 3,
+    "contexts": [
+      {"leafId": 10, "condition": {"country": "us"}, "weights": [1, 0]},
+      {"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]},
+      {"leafId": 30, "condition": {}, "weights": [1, 0]}
+    ]
+  },
+  "cb-us-only": {
+    "contexts": [
+      {"leafId": 10, "condition": {"country": "us"}, "weights": [1, 0]}
+    ]
+  }
+}`
+
+func mustBanditDefs(t *testing.T, raw string) ContextualBanditDefinitions {
+	t.Helper()
+	var defs ContextualBanditDefinitions
+	require.NoError(t, json.Unmarshal([]byte(raw), &defs))
+	return defs
+}
+
+func newBanditTestClient(t *testing.T, attrs Attributes, extra ...ClientOption) *Client {
+	t.Helper()
+	opts := []ClientOption{
+		WithJsonFeatures(banditFeaturesJSON),
+		WithContextualBandits(mustBanditDefs(t, banditDefsJSON)),
+		WithAttributes(attrs),
+	}
+	client, err := NewClient(context.Background(), append(opts, extra...)...)
+	require.NoError(t, err)
+	return client
+}
+
+func TestContextualBanditLeafSelection(t *testing.T) {
+	ctx := context.Background()
+	three := 3
+
+	t.Run("first leaf whose condition passes supplies the weights", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"})
+		res := client.EvalFeature(ctx, "bandit-flag")
+
+		require.Equal(t, "a", res.Value)
+		require.True(t, res.InExperiment())
+		r := res.ExperimentResult
+		require.Equal(t, 10, *r.LeafId)
+		require.Equal(t, []float64{1, 0}, r.VariationWeights)
+		require.Equal(t, three, *r.BanditVersion)
+	})
+
+	t.Run("a later leaf matches a different user", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"})
+		res := client.EvalFeature(ctx, "bandit-flag")
+
+		require.Equal(t, "b", res.Value)
+		require.Equal(t, 20, *res.ExperimentResult.LeafId)
+		require.Equal(t, []float64{0, 1}, res.ExperimentResult.VariationWeights)
+	})
+
+	t.Run("an empty condition acts as a catch-all leaf", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "de"})
+		res := client.EvalFeature(ctx, "bandit-flag")
+
+		require.Equal(t, "a", res.Value)
+		require.Equal(t, 30, *res.ExperimentResult.LeafId)
+	})
+
+	t.Run("no matching leaf assigns with aggregate weights under the fallback leaf", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "de"})
+		res := client.EvalFeature(ctx, "bandit-no-match")
+
+		require.Equal(t, "b", res.Value)
+		r := res.ExperimentResult
+		require.Equal(t, -1, *r.LeafId)
+		require.Equal(t, []float64{0, 1}, r.VariationWeights)
+		require.Nil(t, r.BanditVersion)
+	})
+
+	t.Run("a missing definition assigns with aggregate weights and no bandit fields", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"})
+		res := client.EvalFeature(ctx, "bandit-missing-ref")
+
+		require.Equal(t, "b", res.Value)
+		require.True(t, res.InExperiment())
+		require.Nil(t, res.ExperimentResult.LeafId)
+		require.Nil(t, res.ExperimentResult.VariationWeights)
+		require.Nil(t, res.Experiment.ContextualBandit)
+	})
+
+	t.Run("no matching leaf and no rule weights falls back to equal weights", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "de"})
+		res := client.EvalFeature(ctx, "bandit-no-weights")
+
+		require.True(t, res.InExperiment())
+		require.Equal(t, -1, *res.ExperimentResult.LeafId)
+		require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights)
+	})
+
+	t.Run("client-forced variations carry no bandit fields", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithForcedVariations(ForcedVariationsMap{"bandit-exp": 1}))
+		res := client.EvalFeature(ctx, "bandit-flag")
+
+		require.Equal(t, "b", res.Value)
+		require.False(t, res.ExperimentResult.HashUsed)
+		require.Nil(t, res.ExperimentResult.LeafId)
+		require.Nil(t, res.Experiment.ContextualBandit)
+	})
+}
+
+func TestContextualBanditTracking(t *testing.T) {
+	ctx := context.Background()
+	client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"}, WithDeferredTracking())
+
+	client.EvalFeature(ctx, "bandit-flag")
+	calls := client.DeferredTrackingCalls()
+	require.Len(t, calls, 1)
+	require.Equal(t, 10, *calls[0].Result.LeafId)
+	require.Equal(t, 10, calls[0].Experiment.ContextualBandit.LeafId)
+
+	b, err := json.Marshal(calls[0])
+	require.NoError(t, err)
+	var m map[string]map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &m))
+	require.Equal(t, "10", string(m["result"]["leafId"]))
+	require.Equal(t, "[1,0]", string(m["result"]["variationWeights"]))
+	require.Equal(t, "3", string(m["result"]["banditVersion"]))
+
+	client.ClearDeferredTrackingCalls()
+	client.EvalFeature(ctx, "bandit-missing-ref")
+	calls = client.DeferredTrackingCalls()
+	require.Len(t, calls, 1)
+	nb, err := json.Marshal(calls[0])
+	require.NoError(t, err)
+	require.NotContains(t, string(nb), "leafId")
+}
+
+func TestContextualBanditRobustness(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty contextualVariations falls through without panicking", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithJsonFeatures(`{"f": {"defaultValue": "d", "rules": [
+				{"contextualBanditRef": "x", "contextualVariations": []},
+				{"force": "next-rule"}
+			]}}`),
+			WithAttributes(Attributes{"id": "u"}))
+		require.NoError(t, err)
+		res := client.EvalFeature(ctx, "f")
+		require.Equal(t, "next-rule", res.Value)
+	})
+
+	t.Run("RunExperiment with no variations does not panic", func(t *testing.T) {
+		client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u"}))
+		require.NoError(t, err)
+		res := client.RunExperiment(ctx, &Experiment{Key: "empty"})
+		require.False(t, res.InExperiment)
+		require.Nil(t, res.Value)
+	})
+
+	t.Run("leaf weights of the wrong length are sanitized and reported as used", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithContextualBandits(mustBanditDefs(t, `{
+				"cb-1": {"contexts": [{"leafId": 5, "condition": {}, "weights": [1, 0, 0]}]}
+			}`)))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res.InExperiment())
+		require.Equal(t, 5, *res.ExperimentResult.LeafId)
+		require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights)
+	})
+
+	t.Run("a malformed context is dropped without discarding its siblings", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"},
+			WithContextualBandits(mustBanditDefs(t, `{
+				"cb-1": {"contexts": [
+					{"leafId": "junk", "condition": {}, "weights": [1, 0]},
+					{"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]}
+				]}
+			}`)))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.Equal(t, "b", res.Value)
+		require.Equal(t, 20, *res.ExperimentResult.LeafId)
+	})
+
+	t.Run("sticky-bucketed assignments carry no bandit fields", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithStickyBucketService(NewInMemoryStickyBucketService()),
+			WithDeferredTracking())
+
+		first := client.EvalFeature(ctx, "bandit-flag")
+		require.False(t, first.ExperimentResult.StickyBucketUsed)
+		require.Equal(t, 10, *first.ExperimentResult.LeafId)
+		client.ClearDeferredTrackingCalls()
+
+		second := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, second.ExperimentResult.StickyBucketUsed)
+		require.Nil(t, second.ExperimentResult.LeafId)
+		require.Nil(t, second.ExperimentResult.VariationWeights)
+		require.Nil(t, second.Experiment.ContextualBandit)
+
+		calls := client.DeferredTrackingCalls()
+		require.Len(t, calls, 1)
+		require.Nil(t, calls[0].Experiment.ContextualBandit)
+		require.Nil(t, calls[0].Result.LeafId)
+	})
+
+	t.Run("undecodable encrypted bandits do not block the feature update", func(t *testing.T) {
+		client, err := NewClient(ctx,
+			WithAttributes(Attributes{"id": "u"}),
+			WithDecryptionKey("Ns04T5n9+59rl2x3SlNHtQ=="))
+		require.NoError(t, err)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": {"f": {"defaultValue": 1}},
+			"encryptedContextualBandits": "not-a-valid-blob",
+			"dateUpdated": "2030-01-01T00:00:00Z"
+		}`))
+		res := client.EvalFeature(ctx, "f")
+		require.Equal(t, 1.0, res.Value)
+	})
+}
+
+func TestFeatureRuleMarshalRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(`{
+			"exp": {"defaultValue": "d", "rules": [{"key": "e", "coverage": 1, "variations": ["a", "b"], "weights": [1, 0]}]},
+			"null-force": {"defaultValue": "d", "rules": [{"force": null}]},
+			"gated": {"defaultValue": "d", "rules": [{"force": "forced", "condition": {"country": "us"}}]}
+		}`),
+		WithAttributes(Attributes{"id": "u"}))
+	require.NoError(t, err)
+
+	b, err := json.Marshal(client.Features())
+	require.NoError(t, err)
+	reloaded, err := NewClient(ctx, WithAttributes(Attributes{"id": "u"}))
+	require.NoError(t, err)
+	require.NoError(t, reloaded.SetJSONFeatures(string(b)))
+
+	res := reloaded.EvalFeature(ctx, "exp")
+	require.Equal(t, "a", res.Value)
+	require.Equal(t, ExperimentResultSource, res.Source)
+
+	gated := reloaded.EvalFeature(ctx, "gated")
+	require.Equal(t, "d", gated.Value, "rule conditions survive the round trip")
+
+	nf := reloaded.EvalFeature(ctx, "null-force")
+	require.Nil(t, nf.Value)
+	require.Equal(t, ForceResultSource, nf.Source)
+}
+
+func TestSetContextualBandits(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx,
+		WithJsonFeatures(banditFeaturesJSON),
+		WithAttributes(Attributes{"id": "u1", "country": "nz"}),
+	)
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Nil(t, res.ExperimentResult.LeafId, "no definitions set yet")
+
+	require.NoError(t, client.SetContextualBandits(mustBanditDefs(t, banditDefsJSON)))
+
+	res = client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, 20, *res.ExperimentResult.LeafId)
+}
+
+func TestFeatureRuleUnmarshalErrors(t *testing.T) {
+	var rule FeatureRule
+	require.Error(t, json.Unmarshal([]byte(`{"force": }`), &rule))
+	require.Error(t, json.Unmarshal([]byte(`"not-an-object"`), &rule))
+}
+
+func TestLooseContextualBanditPayloads(t *testing.T) {
+	// A bandit blob the SDK cannot parse must not block the feature update
+	// it arrived with; parseable definitions survive alongside broken ones.
+	ctx := context.Background()
+	client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1", "country": "nz"}))
+	require.NoError(t, err)
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(`{
+		"features": `+banditFeaturesJSON+`,
+		"contextualBandits": {
+			"cb-broken": {"contexts": [{"leafId": "not-a-number"}]},
+			"cb-1": `+`{
+				"contexts": [{"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]}]
+			}`+`
+		},
+		"dateUpdated": "2030-01-01T00:00:00Z"
+	}`))
+
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, 20, *res.ExperimentResult.LeafId, "parseable definition survives")
+
+	client2, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1"}))
+	require.NoError(t, err)
+	require.NoError(t, client2.UpdateFromApiResponseJSON(`{
+		"features": {"f": {"defaultValue": 1}},
+		"contextualBandits": ["entirely-wrong-shape"],
+		"dateUpdated": "2030-01-01T00:00:00Z"
+	}`))
+	res2 := client2.EvalFeature(ctx, "f")
+	require.Equal(t, 1.0, res2.Value, "features still update")
+}
+
+func TestContextualBanditsFromApiResponse(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1", "country": "nz"}))
+	require.NoError(t, err)
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(`{
+		"features": `+banditFeaturesJSON+`,
+		"contextualBandits": `+banditDefsJSON+`,
+		"dateUpdated": "2030-01-01T00:00:00Z"
+	}`))
+
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, "b", res.Value)
+	require.Equal(t, 20, *res.ExperimentResult.LeafId)
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -447,3 +447,60 @@ func TestContextualBanditsFromApiResponse(t *testing.T) {
 	require.Equal(t, "b", res.Value)
 	require.Equal(t, 20, *res.ExperimentResult.LeafId)
 }
+
+func TestContextualBanditRangesAndResync(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("explicit ranges suppress bandit metadata; bucketing follows the ranges", func(t *testing.T) {
+		// The leaf's weights [0, 1] would force variation 1; the explicit
+		// ranges force variation 0. Step 9 buckets on ranges, so there is no
+		// truthful propensity vector to report.
+		features := `{"ranged": {"defaultValue": "default", "rules": [{
+			"key": "ranged-exp",
+			"contextualBanditRef": "cb-us-only",
+			"contextualVariations": ["a", "b"],
+			"ranges": [[0, 1], [0, 0]]
+		}]}}`
+		client, err := NewClient(ctx,
+			WithJsonFeatures(features),
+			WithContextualBandits(mustBanditDefs(t, `{
+				"cb-us-only": {"contexts": [{"leafId": 10, "condition": {"country": "us"}, "weights": [0, 1]}]}
+			}`)),
+			WithAttributes(Attributes{"id": "u1", "country": "us"}))
+		require.NoError(t, err)
+
+		res := client.EvalFeature(ctx, "ranged")
+		require.True(t, res.InExperiment())
+		require.Equal(t, "a", res.Value, "ranges govern bucketing, not the leaf weights")
+		require.Nil(t, res.ExperimentResult.LeafId)
+		require.Nil(t, res.ExperimentResult.VariationWeights)
+		require.Nil(t, res.ExperimentResult.BanditVersion)
+		require.Nil(t, res.Experiment.ContextualBandit)
+	})
+
+	t.Run("inline experiments report the weights bucketing uses", func(t *testing.T) {
+		client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1"}))
+		require.NoError(t, err)
+
+		two := 2
+		exp := Experiment{
+			Key:        "inline-bandit",
+			Variations: []FeatureValue{"a", "b"},
+			Weights:    []float64{1, 0},
+			ContextualBandit: &ContextualBanditAssignment{
+				LeafId:           7,
+				VariationWeights: []float64{0, 1}, // inconsistent with Weights
+				BanditVersion:    &two,
+			},
+		}
+		res := client.RunExperiment(ctx, &exp)
+		require.True(t, res.InExperiment)
+		require.Equal(t, "a", res.Value)
+		require.Equal(t, 7, *res.LeafId)
+		require.Equal(t, []float64{1, 0}, res.VariationWeights,
+			"reported propensities must be the weights bucketing used")
+
+		// The caller's experiment is never mutated.
+		require.Equal(t, []float64{0, 1}, exp.ContextualBandit.VariationWeights)
+	})
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -775,3 +775,27 @@ func TestInlineBanditWithoutWeightsReportsEqualWeights(t *testing.T) {
 	require.Equal(t, []float64{0.5, 0.5}, res.VariationWeights,
 		"reported propensities must be the equal weights bucketing used")
 }
+
+func TestBanditVersionPointersAreIndependent(t *testing.T) {
+	// The version reaches three independently mutable owners: the client-wide
+	// definitions map, the experiment's assignment, and the result. Writing
+	// through one must not be visible through the others.
+	ctx := context.Background()
+	defs := mustBanditDefs(t, banditDefsJSON)
+	client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+		WithContextualBandits(defs))
+
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, 3, *res.ExperimentResult.BanditVersion)
+
+	*res.ExperimentResult.BanditVersion = 99
+	require.Equal(t, 3, *res.Experiment.ContextualBandit.BanditVersion,
+		"result must not share the assignment's pointer")
+	def := defs["cb-1"]
+	require.Equal(t, 3, *def.BanditVersion,
+		"assignment must not share the definitions map's pointer")
+
+	again := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, 3, *again.ExperimentResult.BanditVersion,
+		"later evaluations must be unaffected by consumer writes")
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -870,3 +870,42 @@ func TestBanditDefinitionsSurviveJSONRoundTrips(t *testing.T) {
 		require.Equal(t, 3, *res.ExperimentResult.BanditVersion)
 	})
 }
+
+func TestMutatedDecodedDefinitionsSerializeCurrentFields(t *testing.T) {
+	// A caller who decodes definitions and updates fields must see those
+	// updates in serialized output — evaluation and serialization always
+	// agree on non-degenerate values.
+	ctx := context.Background()
+	defs := mustBanditDefs(t, `{"cb-1": {"banditVersion": 3, "contexts": [
+		{"leafId": 10, "condition": {"country": "us"}, "weights": [1, 0]}
+	]}}`)
+
+	def := defs["cb-1"]
+	def.Contexts[0].Weights = []float64{0, 1} // flip the leaf's weights
+	*def.BanditVersion = 4
+
+	b, err := json.Marshal(defs)
+	require.NoError(t, err)
+	var back ContextualBanditDefinitions
+	require.NoError(t, json.Unmarshal(b, &back))
+
+	client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+		WithContextualBandits(back))
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, "b", res.Value, "the mutated weights must govern after a round trip")
+	require.Equal(t, []float64{0, 1}, res.ExperimentResult.VariationWeights)
+	require.Equal(t, 4, *res.ExperimentResult.BanditVersion)
+}
+
+func TestExplicitNullLeafIdDemotes(t *testing.T) {
+	// json.Unmarshal("null", &int) is a successful no-op; without an explicit
+	// guard an explicit "leafId": null would attribute to leaf 0.
+	ctx := context.Background()
+	client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+		WithContextualBandits(mustBanditDefs(t, `{
+			"cb-1": {"contexts": [{"leafId": null, "condition": {}, "weights": [1, 0]}]}
+		}`)))
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.True(t, res.InExperiment())
+	require.Equal(t, -1, *res.ExperimentResult.LeafId)
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -724,3 +724,32 @@ func TestBanditPropensitySlicesAreIndependent(t *testing.T) {
 	again := client.EvalFeature(ctx, "bandit-flag")
 	require.Equal(t, []float64{1, 0}, again.ExperimentResult.VariationWeights)
 }
+
+func TestSemanticallyJunkConditionsRouteLikeJSAndPython(t *testing.T) {
+	// A condition that parses but carries semantic junk evaluates false and
+	// routing continues to the next leaf — verified byte-identical against
+	// the Python SDK for all three cases (JS evaluates the same way).
+	// Aborting instead would assign the same user different variations
+	// across SDKs on the same payload.
+	ctx := context.Background()
+	for name, cond := range map[string]string{
+		"junk $in argument": `{"country": {"$in": "not-an-array"}}`,
+		"unknown operator":  `{"country": {"$frobnicate": "us"}}`,
+		"invalid regex":     `{"country": {"$regex": "([invalid"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+				WithContextualBandits(mustBanditDefs(t, `{
+					"cb-1": {"contexts": [
+						{"leafId": 1, "condition": `+cond+`, "weights": [1, 0]},
+						{"leafId": 2, "condition": {}, "weights": [0, 1]}
+					]}
+				}`)))
+			res := client.EvalFeature(ctx, "bandit-flag")
+			require.True(t, res.InExperiment())
+			require.Equal(t, 2, *res.ExperimentResult.LeafId,
+				"the junk condition evaluates false; the catch-all sibling matches")
+			require.Equal(t, []float64{0, 1}, res.ExperimentResult.VariationWeights)
+		})
+	}
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -704,3 +704,23 @@ func TestContextualBanditPayloadSectionSemantics(t *testing.T) {
 		require.True(t, banditAssigned(t, client), "failed decrypt must not wipe the previous map")
 	})
 }
+
+func TestBanditPropensitySlicesAreIndependent(t *testing.T) {
+	// The result and the experiment's assignment reach independent consumers
+	// (callbacks, subscribers, the caller); mutating one propensity slice
+	// must not be visible through the other.
+	ctx := context.Background()
+	client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"})
+
+	res := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, []float64{1, 0}, res.ExperimentResult.VariationWeights)
+	require.Equal(t, []float64{1, 0}, res.Experiment.ContextualBandit.VariationWeights)
+
+	res.ExperimentResult.VariationWeights[0] = 99
+	require.Equal(t, []float64{1, 0}, res.Experiment.ContextualBandit.VariationWeights,
+		"result and assignment must not share a backing array")
+
+	// Payload definitions are never aliased either.
+	again := client.EvalFeature(ctx, "bandit-flag")
+	require.Equal(t, []float64{1, 0}, again.ExperimentResult.VariationWeights)
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -909,3 +909,54 @@ func TestExplicitNullLeafIdDemotes(t *testing.T) {
 	require.True(t, res.InExperiment())
 	require.Equal(t, -1, *res.ExperimentResult.LeafId)
 }
+
+func TestPartialPayloadUpdatesPreserveOmittedSections(t *testing.T) {
+	// A partial payload must never wipe sections it did not carry: absent
+	// preserves, explicit empty clears — for every section.
+	ctx := context.Background()
+
+	seed := func(t *testing.T) *Client {
+		t.Helper()
+		client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1", "country": "us"}))
+		require.NoError(t, err)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": {
+				"grouped": {"defaultValue": "off", "rules": [{"force": "on", "condition": {"id": {"$inGroup": "beta"}}}]}
+			},
+			"savedGroups": {"beta": ["u1"]},
+			"contextualBandits": {},
+			"dateUpdated": "2030-01-01T00:00:00Z"
+		}`))
+		require.Equal(t, "on", client.EvalFeature(ctx, "grouped").Value)
+		return client
+	}
+
+	t.Run("a bandit-only update preserves features and saved groups", func(t *testing.T) {
+		client := seed(t)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"contextualBandits": {},
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		res := client.EvalFeature(ctx, "grouped")
+		require.Equal(t, "on", res.Value, "features and saved groups must survive a payload that omits them")
+	})
+
+	t.Run("an explicitly empty features section clears features", func(t *testing.T) {
+		client := seed(t)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": {},
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		require.Equal(t, UnknownFeatureResultSource, client.EvalFeature(ctx, "grouped").Source)
+	})
+
+	t.Run("an explicitly empty savedGroups section clears groups", func(t *testing.T) {
+		client := seed(t)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"savedGroups": {},
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		require.Equal(t, "off", client.EvalFeature(ctx, "grouped").Value,
+			"the $inGroup condition no longer matches once groups are cleared")
+	})
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -960,3 +960,37 @@ func TestPartialPayloadUpdatesPreserveOmittedSections(t *testing.T) {
 			"the $inGroup condition no longer matches once groups are cleared")
 	})
 }
+
+func TestSubscribersCannotCorruptTrackingSnapshots(t *testing.T) {
+	// Subscribers run mid-evaluation on the live experiment and result. A
+	// misbehaving subscriber mutating bandit metadata must not alter what
+	// the tracking pipeline reports — corrupted propensities poison the
+	// bandit's training data.
+	ctx := context.Background()
+	client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+		WithDeferredTracking())
+	client.Subscribe(func(_ context.Context, exp *Experiment, res *ExperimentResult) {
+		if exp.ContextualBandit != nil {
+			exp.ContextualBandit.VariationWeights[0] = 99
+			if exp.ContextualBandit.BanditVersion != nil {
+				*exp.ContextualBandit.BanditVersion = 99
+			}
+		}
+		if res.VariationWeights != nil {
+			res.VariationWeights[0] = 88
+		}
+		if res.BanditVersion != nil {
+			*res.BanditVersion = 88
+		}
+	})
+
+	client.EvalFeature(ctx, "bandit-flag")
+	calls := client.DeferredTrackingCalls()
+	require.Len(t, calls, 1)
+	require.Equal(t, []float64{1, 0}, calls[0].Experiment.ContextualBandit.VariationWeights,
+		"the buffered assignment must carry the propensities bucketing used")
+	require.Equal(t, 3, *calls[0].Experiment.ContextualBandit.BanditVersion)
+	require.Equal(t, []float64{1, 0}, calls[0].Result.VariationWeights,
+		"the buffered result must carry the propensities bucketing used")
+	require.Equal(t, 3, *calls[0].Result.BanditVersion)
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -223,18 +223,31 @@ func TestContextualBanditRobustness(t *testing.T) {
 		require.Nil(t, res.Value)
 	})
 
-	t.Run("leaf weights of the wrong length are sanitized and reported as used", func(t *testing.T) {
-		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
-			WithContextualBandits(mustBanditDefs(t, `{
-				"cb-1": {"contexts": [{"leafId": 5, "condition": {}, "weights": [1, 0, 0]}]}
-			}`)))
-		res := client.EvalFeature(ctx, "bandit-flag")
-		require.True(t, res.InExperiment())
-		require.Equal(t, 5, *res.ExperimentResult.LeafId)
-		require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights)
+	t.Run("a matched leaf with invalid weights demotes to the fallback leaf", func(t *testing.T) {
+		// Substituting repaired weights would report a leaf whose
+		// propensities differ from the vector bucketing used; the Python SDK
+		// demotes to leafId -1 and keeps the rule's aggregate weights.
+		for name, weights := range map[string]string{
+			"wrong length": `[1, 0, 0]`,
+			"negative":     `[1.2, -0.2]`,
+			"sum not ~1":   `[0.4, 0.1]`,
+			"missing":      `null`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+					WithContextualBandits(mustBanditDefs(t, `{
+						"cb-1": {"contexts": [{"leafId": 5, "condition": {}, "weights": `+weights+`}]}
+					}`)))
+				res := client.EvalFeature(ctx, "bandit-flag")
+				require.True(t, res.InExperiment())
+				require.Equal(t, -1, *res.ExperimentResult.LeafId)
+				require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights,
+					"reported weights must be the aggregate weights bucketing used")
+			})
+		}
 	})
 
-	t.Run("a malformed context is dropped without discarding its siblings", func(t *testing.T) {
+	t.Run("a matched leaf with a junk leafId demotes instead of routing to a sibling", func(t *testing.T) {
 		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"},
 			WithContextualBandits(mustBanditDefs(t, `{
 				"cb-1": {"contexts": [
@@ -243,8 +256,59 @@ func TestContextualBanditRobustness(t *testing.T) {
 				]}
 			}`)))
 		res := client.EvalFeature(ctx, "bandit-flag")
-		require.Equal(t, "b", res.Value)
-		require.Equal(t, 20, *res.ExperimentResult.LeafId)
+		require.True(t, res.InExperiment())
+		require.Equal(t, -1, *res.ExperimentResult.LeafId,
+			"the catch-all leaf matched; its junk leafId demotes it rather than skipping to the sibling")
+		require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights)
+	})
+
+	t.Run("a type-malformed context aborts leaf selection", func(t *testing.T) {
+		// Selection cannot know whether the junk context would have matched,
+		// so a later valid leaf must not be used (Python SDK parity).
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"},
+			WithContextualBandits(mustBanditDefs(t, `{
+				"cb-1": {"contexts": [
+					"garbage",
+					{"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]}
+				]}
+			}`)))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res.InExperiment())
+		require.Equal(t, -1, *res.ExperimentResult.LeafId)
+		require.Equal(t, []float64{0.5, 0.5}, res.ExperimentResult.VariationWeights)
+	})
+
+	t.Run("a junk banditVersion is omitted without dropping the definition", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithContextualBandits(mustBanditDefs(t, `{
+				"cb-1": {"banditVersion": "not-a-number", "contexts": [
+					{"leafId": 10, "condition": {"country": "us"}, "weights": [1, 0]}
+				]}
+			}`)))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.Equal(t, "a", res.Value)
+		require.Equal(t, 10, *res.ExperimentResult.LeafId)
+		require.Nil(t, res.ExperimentResult.BanditVersion)
+	})
+
+	t.Run("JS-falsy definitions dangle; truthy junk takes the fallback leaf", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithContextualBandits(mustBanditDefs(t, `{"cb-1": null, "cb-truthy": 5}`)))
+
+		// null definition == missing definition: plain experiment, no metadata.
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res.InExperiment())
+		require.Nil(t, res.ExperimentResult.LeafId)
+		require.Nil(t, res.ExperimentResult.VariationWeights)
+
+		// A truthy non-object definition counts as found with no leaves:
+		// fallback attribution.
+		client2 := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithContextualBandits(mustBanditDefs(t, `{"cb-1": 5}`)))
+		res2 := client2.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res2.InExperiment())
+		require.Equal(t, -1, *res2.ExperimentResult.LeafId)
+		require.Equal(t, []float64{0.5, 0.5}, res2.ExperimentResult.VariationWeights)
 	})
 
 	t.Run("sticky-bucketed assignments carry no bandit fields", func(t *testing.T) {

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -753,3 +753,25 @@ func TestSemanticallyJunkConditionsRouteLikeJSAndPython(t *testing.T) {
 		})
 	}
 }
+
+func TestInlineBanditWithoutWeightsReportsEqualWeights(t *testing.T) {
+	// A caller-built experiment with bandit metadata but no Weights buckets
+	// on equal weights; the reported propensities must say so, not echo the
+	// caller's stale vector.
+	ctx := context.Background()
+	client, err := NewClient(ctx, WithAttributes(Attributes{"id": "u1"}))
+	require.NoError(t, err)
+
+	exp := Experiment{
+		Key:        "inline-no-weights",
+		Variations: []FeatureValue{"a", "b"},
+		ContextualBandit: &ContextualBanditAssignment{
+			LeafId:           7,
+			VariationWeights: []float64{1, 0}, // stale: bucketing uses equal weights
+		},
+	}
+	res := client.RunExperiment(ctx, &exp)
+	require.True(t, res.InExperiment)
+	require.Equal(t, []float64{0.5, 0.5}, res.VariationWeights,
+		"reported propensities must be the equal weights bucketing used")
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -970,6 +970,9 @@ func TestSubscribersCannotCorruptTrackingSnapshots(t *testing.T) {
 	client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
 		WithDeferredTracking())
 	client.Subscribe(func(_ context.Context, exp *Experiment, res *ExperimentResult) {
+		if exp.Weights != nil {
+			exp.Weights[0] = 77
+		}
 		if exp.ContextualBandit != nil {
 			exp.ContextualBandit.VariationWeights[0] = 99
 			if exp.ContextualBandit.BanditVersion != nil {
@@ -993,6 +996,8 @@ func TestSubscribersCannotCorruptTrackingSnapshots(t *testing.T) {
 	require.Equal(t, []float64{1, 0}, calls[0].Result.VariationWeights,
 		"the buffered result must carry the propensities bucketing used")
 	require.Equal(t, 3, *calls[0].Result.BanditVersion)
+	require.Equal(t, []float64{1, 0}, calls[0].Experiment.Weights,
+		"the buffered experiment weights must be the ones bucketing used")
 }
 
 func TestParseContextualBandits(t *testing.T) {

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -799,3 +799,74 @@ func TestBanditVersionPointersAreIndependent(t *testing.T) {
 	require.Equal(t, 3, *again.ExperimentResult.BanditVersion,
 		"later evaluations must be unaffected by consumer writes")
 }
+
+func TestBanditDefinitionsSurviveJSONRoundTrips(t *testing.T) {
+	// Routing depends on tolerant-decoder state (malformed contexts abort
+	// selection; falsy definitions dangle). Persisting or forwarding decoded
+	// definitions as JSON must not change routing: marshaling emits the
+	// original payload form.
+	ctx := context.Background()
+
+	roundTrip := func(t *testing.T, defs ContextualBanditDefinitions) ContextualBanditDefinitions {
+		t.Helper()
+		b, err := json.Marshal(defs)
+		require.NoError(t, err)
+		var back ContextualBanditDefinitions
+		require.NoError(t, json.Unmarshal(b, &back))
+		return back
+	}
+
+	leafOf := func(t *testing.T, defs ContextualBanditDefinitions) *int {
+		t.Helper()
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"},
+			WithContextualBandits(defs))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res.InExperiment())
+		return res.ExperimentResult.LeafId
+	}
+
+	t.Run("a malformed context still aborts selection after a round trip", func(t *testing.T) {
+		defs := mustBanditDefs(t, `{"cb-1": {"contexts": [
+			"garbage",
+			{"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]}
+		]}}`)
+		require.Equal(t, -1, *leafOf(t, defs))
+		require.Equal(t, -1, *leafOf(t, roundTrip(t, defs)),
+			"round trip must not launder a malformed context into a valid leaf")
+	})
+
+	t.Run("a falsy definition still dangles after a round trip", func(t *testing.T) {
+		defs := mustBanditDefs(t, `{"cb-1": null}`)
+		require.Nil(t, leafOf(t, defs))
+		require.Nil(t, leafOf(t, roundTrip(t, defs)),
+			"round trip must not turn a falsy definition into a fallback definition")
+	})
+
+	t.Run("a junk banditVersion stays omitted after a round trip", func(t *testing.T) {
+		defs := mustBanditDefs(t, `{"cb-1": {"banditVersion": "junk", "contexts": [
+			{"leafId": 20, "condition": {"country": "nz"}, "weights": [0, 1]}
+		]}}`)
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"},
+			WithContextualBandits(roundTrip(t, defs)))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.Equal(t, 20, *res.ExperimentResult.LeafId)
+		require.Nil(t, res.ExperimentResult.BanditVersion)
+	})
+
+	t.Run("programmatically built definitions marshal from their fields", func(t *testing.T) {
+		three := 3
+		ten := 10
+		defs := ContextualBanditDefinitions{
+			"cb-1": {BanditVersion: &three, Contexts: []ContextualBanditContext{
+				{LeafId: &ten, Weights: []float64{0, 1}},
+			}},
+		}
+		back := roundTrip(t, defs)
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "nz"},
+			WithContextualBandits(back))
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.Equal(t, 10, *res.ExperimentResult.LeafId, "zero condition is a catch-all")
+		require.Equal(t, []float64{0, 1}, res.ExperimentResult.VariationWeights)
+		require.Equal(t, 3, *res.ExperimentResult.BanditVersion)
+	})
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -504,3 +504,135 @@ func TestContextualBanditRangesAndResync(t *testing.T) {
 		require.Equal(t, []float64{0, 1}, exp.ContextualBandit.VariationWeights)
 	})
 }
+
+func TestContextualBanditSubscriberVisibility(t *testing.T) {
+	ctx := context.Background()
+
+	subscribeBandit := func(t *testing.T, attrs Attributes, extra ...ClientOption) (*Client, *[]*Experiment) {
+		t.Helper()
+		var seen []*Experiment
+		client := newBanditTestClient(t, attrs, extra...)
+		client.Subscribe(func(_ context.Context, exp *Experiment, _ *ExperimentResult) {
+			seen = append(seen, exp)
+		})
+		return client, &seen
+	}
+
+	t.Run("a real bandit assignment reaches subscribers with its context", func(t *testing.T) {
+		client, seen := subscribeBandit(t, Attributes{"id": "u1", "country": "us"})
+		client.EvalFeature(ctx, "bandit-flag")
+		require.Len(t, *seen, 1)
+		require.NotNil(t, (*seen)[0].ContextualBandit)
+		require.Equal(t, 10, (*seen)[0].ContextualBandit.LeafId)
+	})
+
+	t.Run("a forced variation reaches subscribers with the context stripped", func(t *testing.T) {
+		client, seen := subscribeBandit(t, Attributes{"id": "u1", "country": "us"},
+			WithForcedVariations(ForcedVariationsMap{"bandit-exp": 1}))
+		client.EvalFeature(ctx, "bandit-flag")
+		require.Len(t, *seen, 1)
+		require.Nil(t, (*seen)[0].ContextualBandit,
+			"subscribers must see the same stripped experiment tracking records")
+	})
+
+	t.Run("a sticky-bucketed assignment reaches subscribers with the context stripped", func(t *testing.T) {
+		client, seen := subscribeBandit(t, Attributes{"id": "u1", "country": "us"},
+			WithStickyBucketService(NewInMemoryStickyBucketService()))
+		client.EvalFeature(ctx, "bandit-flag")
+		client.EvalFeature(ctx, "bandit-flag")
+		require.Len(t, *seen, 1, "the unchanged second assignment does not re-notify")
+
+		// Re-subscribe records the sticky-bucketed eval on a fresh client
+		// sharing the same service via a child with the same attributes.
+		client2, seen2 := subscribeBandit(t, Attributes{"id": "u1", "country": "us"},
+			WithStickyBucketService(NewInMemoryStickyBucketService()))
+		first := client2.EvalFeature(ctx, "bandit-flag")
+		require.False(t, first.ExperimentResult.StickyBucketUsed)
+		require.NotNil(t, (*seen2)[0].ContextualBandit)
+	})
+}
+
+func TestContextualBanditTrackingRoundTrip(t *testing.T) {
+	// detachTrackingData deep-copies via a JSON round trip — the mechanism
+	// that silently lost Namespace in the deferred-tracking release. Pin that
+	// bandit fields survive it, including the falsy-looking leafId values 0
+	// and -1.
+	ctx := context.Background()
+
+	t.Run("a real leaf with leafId 0 survives the detach", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "us"},
+			WithContextualBandits(mustBanditDefs(t, `{
+				"cb-1": {"banditVersion": 0, "contexts": [
+					{"leafId": 0, "condition": {"country": "us"}, "weights": [1, 0]}
+				]}
+			}`)),
+			WithDeferredTracking())
+		client.EvalFeature(ctx, "bandit-flag")
+
+		calls := client.DeferredTrackingCalls()
+		require.Len(t, calls, 1)
+		require.Equal(t, 0, *calls[0].Result.LeafId)
+		require.Equal(t, 0, *calls[0].Result.BanditVersion)
+		require.NotNil(t, calls[0].Experiment.ContextualBandit)
+		require.Equal(t, 0, calls[0].Experiment.ContextualBandit.LeafId)
+		require.Equal(t, []float64{1, 0}, calls[0].Experiment.ContextualBandit.VariationWeights)
+
+		b, err := json.Marshal(calls[0])
+		require.NoError(t, err)
+		var m map[string]map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(b, &m))
+		require.Equal(t, "0", string(m["result"]["leafId"]))
+		require.Contains(t, m["experiment"], "contextualBandit")
+		var cb ContextualBanditAssignment
+		require.NoError(t, json.Unmarshal(m["experiment"]["contextualBandit"], &cb))
+		require.Equal(t, 0, cb.LeafId)
+		require.Equal(t, []float64{1, 0}, cb.VariationWeights)
+		require.Equal(t, 0, *cb.BanditVersion)
+	})
+
+	t.Run("the fallback leaf -1 survives the detach", func(t *testing.T) {
+		client := newBanditTestClient(t, Attributes{"id": "u1", "country": "de"}, WithDeferredTracking())
+		client.EvalFeature(ctx, "bandit-no-match")
+
+		calls := client.DeferredTrackingCalls()
+		require.Len(t, calls, 1)
+		require.Equal(t, -1, *calls[0].Result.LeafId)
+		require.Equal(t, -1, calls[0].Experiment.ContextualBandit.LeafId)
+	})
+}
+
+func TestContextualBanditPrerequisiteExposure(t *testing.T) {
+	// A bandit rule deciding a prerequisite feature must land in the buffer
+	// and callbacks with its real leaf attribution.
+	ctx := context.Background()
+	features := `{
+		"parent-bandit": {"defaultValue": "default", "rules": [{
+			"key": "parent-bandit-exp",
+			"coverage": 1,
+			"contextualBanditRef": "cb-us-only",
+			"contextualVariations": ["a", "b"],
+			"weights": [0.5, 0.5]
+		}]},
+		"gated-child": {"defaultValue": "off", "rules": [{
+			"parentConditions": [{"id": "parent-bandit", "condition": {"value": "a"}}],
+			"force": "on"
+		}]}
+	}`
+	client, err := NewClient(ctx,
+		WithJsonFeatures(features),
+		WithContextualBandits(mustBanditDefs(t, banditDefsJSON)),
+		WithAttributes(Attributes{"id": "u1", "country": "us"}),
+		WithDeferredTracking())
+	require.NoError(t, err)
+
+	res := client.EvalFeature(ctx, "gated-child")
+	require.Equal(t, "on", res.Value)
+
+	calls := client.DeferredTrackingCalls()
+	require.Len(t, calls, 1)
+	require.Equal(t, "parent-bandit-exp", calls[0].Experiment.Key)
+	require.Equal(t, "parent-bandit", calls[0].Result.FeatureId)
+	require.Equal(t, 10, *calls[0].Result.LeafId)
+	require.Equal(t, []float64{1, 0}, calls[0].Result.VariationWeights)
+	require.Equal(t, 10, calls[0].Experiment.ContextualBandit.LeafId)
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -997,8 +997,10 @@ func TestSubscribersCannotCorruptTrackingSnapshots(t *testing.T) {
 
 func TestParseContextualBandits(t *testing.T) {
 	t.Run("rejects a non-object top level", func(t *testing.T) {
-		_, err := ParseContextualBandits([]byte(`["entirely-wrong-shape"]`))
-		require.Error(t, err)
+		for _, blob := range []string{`["entirely-wrong-shape"]`, `null`, `5`, `"junk"`} {
+			_, err := ParseContextualBandits([]byte(blob))
+			require.Error(t, err, blob)
+		}
 	})
 
 	t.Run("parses an object with the same tolerant per-entry semantics", func(t *testing.T) {

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -636,3 +636,71 @@ func TestContextualBanditPrerequisiteExposure(t *testing.T) {
 	require.Equal(t, []float64{1, 0}, calls[0].Result.VariationWeights)
 	require.Equal(t, 10, calls[0].Experiment.ContextualBandit.LeafId)
 }
+
+func TestContextualBanditPayloadSectionSemantics(t *testing.T) {
+	// Absent section = preserve, explicit empty (or null) = clear, failed
+	// decrypt = preserve — so a broken or bandit-less refresh never wipes a
+	// coherent previous map (Python SDK parity).
+	ctx := context.Background()
+
+	banditAssigned := func(t *testing.T, client *Client) bool {
+		t.Helper()
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res.InExperiment())
+		return res.ExperimentResult.LeafId != nil
+	}
+
+	seed := func(t *testing.T, opts ...ClientOption) *Client {
+		t.Helper()
+		client, err := NewClient(ctx, append([]ClientOption{
+			WithAttributes(Attributes{"id": "u1", "country": "us"}),
+		}, opts...)...)
+		require.NoError(t, err)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": `+banditFeaturesJSON+`,
+			"contextualBandits": `+banditDefsJSON+`,
+			"dateUpdated": "2030-01-01T00:00:00Z"
+		}`))
+		require.True(t, banditAssigned(t, client), "seed payload must assign a leaf")
+		return client
+	}
+
+	t.Run("a refresh without the bandit section preserves the previous map", func(t *testing.T) {
+		client := seed(t)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": `+banditFeaturesJSON+`,
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		require.True(t, banditAssigned(t, client), "absent section must not clear definitions")
+	})
+
+	t.Run("an explicit empty section clears the map", func(t *testing.T) {
+		client := seed(t)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": `+banditFeaturesJSON+`,
+			"contextualBandits": {},
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		require.False(t, banditAssigned(t, client), "explicit empty section must clear definitions")
+	})
+
+	t.Run("an explicit null section clears the map", func(t *testing.T) {
+		client := seed(t)
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": `+banditFeaturesJSON+`,
+			"contextualBandits": null,
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		require.False(t, banditAssigned(t, client))
+	})
+
+	t.Run("a failed bandit decryption preserves the previous map", func(t *testing.T) {
+		client := seed(t, WithDecryptionKey("Ns04T5n9+59rl2x3SlNHtQ=="))
+		require.NoError(t, client.UpdateFromApiResponseJSON(`{
+			"features": `+banditFeaturesJSON+`,
+			"encryptedContextualBandits": "not-a-valid-blob",
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		require.True(t, banditAssigned(t, client), "failed decrypt must not wipe the previous map")
+	})
+}

--- a/contextual_bandit_test.go
+++ b/contextual_bandit_test.go
@@ -994,3 +994,20 @@ func TestSubscribersCannotCorruptTrackingSnapshots(t *testing.T) {
 		"the buffered result must carry the propensities bucketing used")
 	require.Equal(t, 3, *calls[0].Result.BanditVersion)
 }
+
+func TestParseContextualBandits(t *testing.T) {
+	t.Run("rejects a non-object top level", func(t *testing.T) {
+		_, err := ParseContextualBandits([]byte(`["entirely-wrong-shape"]`))
+		require.Error(t, err)
+	})
+
+	t.Run("parses an object with the same tolerant per-entry semantics", func(t *testing.T) {
+		defs, err := ParseContextualBandits([]byte(`{
+			"cb-1": {"contexts": [{"leafId": 10, "condition": {}, "weights": [1, 0]}]},
+			"cb-junk": 5
+		}`))
+		require.NoError(t, err)
+		require.Len(t, defs, 2)
+		require.Len(t, defs["cb-1"].Contexts, 1)
+	})
+}

--- a/datasource_poll.go
+++ b/datasource_poll.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -109,7 +110,11 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 		ds.mu.Unlock()
 	}
 
-	if resp.Features == nil {
+	// Skip only genuine no-update responses. A 200 payload always applies:
+	// UpdateFromApiResponse preserves omitted sections, so a bandit-only or
+	// saved-groups-only response updates just what it carries (a features-only
+	// guard here used to drop those updates entirely).
+	if resp.Status == http.StatusNotModified {
 		return nil
 	}
 

--- a/datasource_poll_test.go
+++ b/datasource_poll_test.go
@@ -224,3 +224,55 @@ func startEtagServer(response []byte) *testServer {
 	}))
 	return &ts
 }
+
+func TestPollingAppliesPartialResponses(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("a bandit-only response updates definitions and preserves features", func(t *testing.T) {
+		ts := startServer(http.StatusOK, []byte(`{
+			"contextualBandits": {
+				"cb-1": {"contexts": [{"leafId": 10, "condition": {}, "weights": [1, 0]}]}
+			},
+			"dateUpdated": "2030-01-02T00:00:00Z"
+		}`))
+		defer ts.http.Close()
+		logger, _ := testLogger(slog.LevelError, t)
+		client, err := NewClient(ctx,
+			WithLogger(logger),
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithJsonFeatures(`{"bandit-flag": {"defaultValue": "default", "rules": [{
+				"key": "bandit-exp", "coverage": 1, "contextualBanditRef": "cb-1",
+				"contextualVariations": ["a", "b"], "weights": [0.5, 0.5]
+			}]}}`),
+			WithAttributes(Attributes{"id": "u1"}),
+			WithPollDataSource(100*time.Millisecond),
+		)
+		require.Nil(t, err)
+		defer client.Close()
+		require.Nil(t, client.EnsureLoaded(ctx))
+
+		res := client.EvalFeature(ctx, "bandit-flag")
+		require.True(t, res.InExperiment(), "features must survive a bandit-only poll response")
+		require.Equal(t, 10, *res.ExperimentResult.LeafId, "the polled definitions must apply")
+	})
+
+	t.Run("a 304 response changes nothing", func(t *testing.T) {
+		ts := startServer(http.StatusNotModified, nil)
+		defer ts.http.Close()
+		logger, _ := testLogger(slog.LevelError, t)
+		client, err := NewClient(ctx,
+			WithLogger(logger),
+			WithHttpClient(ts.http.Client()),
+			WithApiHost(ts.http.URL),
+			WithClientKey("somekey"),
+			WithJsonFeatures(`{"foo": {"defaultValue": "kept"}}`),
+			WithPollDataSource(100*time.Millisecond),
+		)
+		require.Nil(t, err)
+		defer client.Close()
+		require.Nil(t, client.EnsureLoaded(ctx))
+		require.Equal(t, "kept", client.EvalFeature(ctx, "foo").Value)
+	})
+}

--- a/datasource_sse.go
+++ b/datasource_sse.go
@@ -149,10 +149,11 @@ func (ds *SseDataSource) loadData(ctx context.Context) error {
 		return fmt.Errorf("sse is not supported")
 	}
 
-	if resp.Features == nil {
-		return nil
-	}
-
+	// A 200 payload always applies: UpdateFromApiResponse preserves omitted
+	// sections, so partial responses update just what they carry (a
+	// features-only guard here used to drop bandit- or saved-groups-only
+	// updates entirely). This path never sends an ETag, so there is no 304
+	// to skip.
 	err = ds.client.UpdateFromApiResponse(resp)
 	if err != nil {
 		return err

--- a/evaluator.go
+++ b/evaluator.go
@@ -406,7 +406,7 @@ func (e *evaluator) getExperimentResult(
 		// consumers (callbacks, subscribers, the caller); one mutating its
 		// slice must not skew the propensities another observes.
 		res.VariationWeights = slices.Clone(cb.VariationWeights)
-		res.BanditVersion = cb.BanditVersion
+		res.BanditVersion = clonedBanditVersion(cb.BanditVersion)
 	}
 
 	return &res

--- a/evaluator.go
+++ b/evaluator.go
@@ -312,13 +312,6 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 		)
 	}
 
-	// 14. Record the assignment for reporting. Earlier returns (forced
-	// variations, overrides) are deliberately not recorded; passthrough
-	// assignments are.
-	if result.InExperiment {
-		e.recordExperiment(exp, result)
-	}
-
 	return result
 }
 
@@ -340,6 +333,15 @@ func (e *evaluator) experimentResult(
 	// experiment.contextualBandit before onExperimentEval.
 	if exp.ContextualBandit != nil && result.LeafId == nil {
 		exp.ContextualBandit = nil
+	}
+	// Record the assignment for reporting BEFORE notifying subscribers:
+	// subscriber code runs mid-evaluation on the live experiment and result,
+	// and must not be able to alter what the tracking pipeline reports.
+	// HashUsed is true only on the hashed-assignment path (step 14) — forced
+	// variations and overrides are deliberately not recorded; passthrough
+	// and sticky assignments are.
+	if result.InExperiment && result.HashUsed {
+		e.recordExperiment(exp, result)
 	}
 	if featureId != "" && e.client.data.subscribers.hasSubscribers() {
 		e.client.notifySubscribers(e.ctx, exp, result)

--- a/evaluator.go
+++ b/evaluator.go
@@ -61,10 +61,11 @@ func (e *evaluator) runExperiment(exp *Experiment, featureId string) *Experiment
 			// describe a distribution bucketing ignored. Bucketing itself is
 			// untouched (same assignment as the JS SDK).
 			exp.ContextualBandit = nil
-		} else if exp.Weights != nil {
+		} else {
 			// Resync reported propensities to the weights bucketing will
-			// actually use — a no-op for payload-built bandit experiments,
-			// defense for caller-built inline experiments.
+			// actually use — including equal weights when Weights is nil.
+			// A no-op for payload-built bandit experiments, defense for
+			// caller-built inline experiments.
 			cb := *exp.ContextualBandit
 			cb.VariationWeights = slices.Clone(normalizedWeights(len(exp.Variations), exp.Weights, e.client.logger))
 			exp.ContextualBandit = &cb

--- a/evaluator.go
+++ b/evaluator.go
@@ -330,6 +330,16 @@ func (e *evaluator) experimentResult(
 	isStickyBucketUsed bool,
 ) *ExperimentResult {
 	result := e.getExperimentResult(exp, variationId, hashUsed, featureId, bucket, isStickyBucketUsed)
+	// The result is the truth for bandit attribution: when it carries no
+	// leaf (forced, QA, sticky-bucketed, not included), the experiment must
+	// not claim one either. The experiment is evaluator-owned on every path
+	// (evalRule builds it; RunExperiment copies the caller's), so this
+	// single strip covers subscribers, tracking snapshots, and the returned
+	// FeatureResult alike — matching the JS SDK, which deletes
+	// experiment.contextualBandit before onExperimentEval.
+	if exp.ContextualBandit != nil && result.LeafId == nil {
+		exp.ContextualBandit = nil
+	}
 	if featureId != "" && e.client.data.subscribers.hasSubscribers() {
 		e.client.notifySubscribers(e.ctx, exp, result)
 	}
@@ -446,13 +456,6 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 		e.buildContextualBanditExperiment(exp, rule.ContextualBanditRef, featureId)
 	}
 	res := e.runExperiment(exp, featureId)
-	if exp.ContextualBandit != nil && res.LeafId == nil {
-		// Detach via copy: subscribers already hold exp, so mutating it here
-		// would race with them.
-		expCopy := *exp
-		expCopy.ContextualBandit = nil
-		exp = &expCopy
-	}
 	if !res.InExperiment || res.Passthrough {
 		return nil
 	}

--- a/evaluator.go
+++ b/evaluator.go
@@ -3,6 +3,7 @@ package growthbook
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/growthbook/growthbook-golang/internal/condition"
 	"github.com/growthbook/growthbook-golang/internal/value"
@@ -53,6 +54,23 @@ func (e *evaluator) doEvalFeature(key string) *FeatureResult {
 }
 
 func (e *evaluator) runExperiment(exp *Experiment, featureId string) *ExperimentResult {
+	if exp.ContextualBandit != nil {
+		if len(exp.Ranges) > 0 {
+			// Explicit ranges govern bucketing (step 9), so no truthful
+			// propensity vector exists: drop the bandit metadata rather than
+			// describe a distribution bucketing ignored. Bucketing itself is
+			// untouched (same assignment as the JS SDK).
+			exp.ContextualBandit = nil
+		} else if exp.Weights != nil {
+			// Resync reported propensities to the weights bucketing will
+			// actually use — a no-op for payload-built bandit experiments,
+			// defense for caller-built inline experiments.
+			cb := *exp.ContextualBandit
+			cb.VariationWeights = slices.Clone(normalizedWeights(len(exp.Variations), exp.Weights, e.client.logger))
+			exp.ContextualBandit = &cb
+		}
+	}
+
 	// 1. If experiment.variations has fewer than 2 variations, return getExperimentResult(experiment)
 	if len(exp.Variations) < 2 {
 		e.client.logger.DebugContext(e.ctx, "Invalid experiment", "id", exp.Key)

--- a/evaluator.go
+++ b/evaluator.go
@@ -401,7 +401,10 @@ func (e *evaluator) getExperimentResult(
 	if cb := exp.ContextualBandit; cb != nil && hashUsed && inExperiment && !isStickyBucketUsed {
 		leafId := cb.LeafId
 		res.LeafId = &leafId
-		res.VariationWeights = cb.VariationWeights
+		// Clone: the result and the experiment's assignment go to independent
+		// consumers (callbacks, subscribers, the caller); one mutating its
+		// slice must not skew the propensities another observes.
+		res.VariationWeights = slices.Clone(cb.VariationWeights)
 		res.BanditVersion = cb.BanditVersion
 	}
 

--- a/evaluator.go
+++ b/evaluator.go
@@ -9,11 +9,12 @@ import (
 )
 
 type evaluator struct {
-	features    FeatureMap
-	savedGroups condition.SavedGroups
-	evaluated   stack[string]
-	client      *Client
-	ctx         context.Context
+	features          FeatureMap
+	savedGroups       condition.SavedGroups
+	contextualBandits ContextualBanditDefinitions
+	evaluated         stack[string]
+	client            *Client
+	ctx               context.Context
 
 	recording          bool // false when no callbacks, plugins, or buffer consume tracking
 	userCtx            *TrackingUserContext
@@ -367,6 +368,15 @@ func (e *evaluator) getExperimentResult(
 		res.Passthrough = meta.Passthrough
 	}
 
+	// A sticky-bucketed assignment did not use the leaf weights, so
+	// reporting them would corrupt the bandit's propensity estimates.
+	if cb := exp.ContextualBandit; cb != nil && hashUsed && inExperiment && !isStickyBucketUsed {
+		leafId := cb.LeafId
+		res.LeafId = &leafId
+		res.VariationWeights = cb.VariationWeights
+		res.BanditVersion = cb.BanditVersion
+	}
+
 	return &res
 }
 
@@ -409,12 +419,22 @@ func (e *evaluator) evalRule(featureId string, rule *FeatureRule) *FeatureResult
 		return getFeatureResult(rule.Force, ForceResultSource, rule.Id, nil, nil)
 	}
 
-	if len(rule.Variations) == 0 {
+	if len(rule.Variations) == 0 && rule.ContextualVariations == nil {
 		return nil
 	}
 
 	exp := experimentFromFeatureRule(featureId, rule)
+	if rule.ContextualBanditRef != "" {
+		e.buildContextualBanditExperiment(exp, rule.ContextualBanditRef, featureId)
+	}
 	res := e.runExperiment(exp, featureId)
+	if exp.ContextualBandit != nil && res.LeafId == nil {
+		// Detach via copy: subscribers already hold exp, so mutating it here
+		// would race with them.
+		expCopy := *exp
+		expCopy.ContextualBandit = nil
+		exp = &expCopy
+	}
 	if !res.InExperiment || res.Passthrough {
 		return nil
 	}

--- a/experiment.go
+++ b/experiment.go
@@ -65,6 +65,9 @@ type Experiment struct {
 	Groups []string `json:"groups"`
 	// Status controls eval: "draft" is skipped unless qaMode/forced, "stopped" only honors Force, "running" is normal.
 	Status ExperimentStatus `json:"status"`
+	// ContextualBandit is set during evaluation when a contextual bandit
+	// decided this experiment's weights.
+	ContextualBandit *CBContext `json:"contextualBandit,omitempty"`
 }
 
 // NewExperiment creates an experiment with default settings: active,
@@ -81,13 +84,18 @@ func experimentFromFeatureRule(featureId string, rule *FeatureRule) *Experiment 
 		expKey = featureId
 	}
 
+	variations := rule.Variations
+	if rule.ContextualVariations != nil {
+		variations = rule.ContextualVariations
+	}
+
 	// Copy only the fields the JS SDK forwards when building the inline
 	// experiment (sdk-js core.ts evalFeature). ParentConditions are already
 	// evaluated by evalRule, so forwarding them would evaluate prerequisites
 	// twice; URLPatterns/URL/Groups/Status don't exist on JS feature rules.
 	exp := Experiment{
 		Key:                    expKey,
-		Variations:             rule.Variations,
+		Variations:             variations,
 		Coverage:               rule.Coverage,
 		Weights:                rule.Weights,
 		HashAttribute:          rule.HashAttribute,

--- a/experiment.go
+++ b/experiment.go
@@ -67,7 +67,7 @@ type Experiment struct {
 	Status ExperimentStatus `json:"status"`
 	// ContextualBandit is set during evaluation when a contextual bandit
 	// decided this experiment's weights.
-	ContextualBandit *CBContext `json:"contextualBandit,omitempty"`
+	ContextualBandit *ContextualBanditAssignment `json:"contextualBandit,omitempty"`
 }
 
 // NewExperiment creates an experiment with default settings: active,

--- a/experiment_result.go
+++ b/experiment_result.go
@@ -25,4 +25,10 @@ type ExperimentResult struct {
 	Passthrough bool `json:"passthrough"`
 	// If sticky bucketing was used to assign a variation
 	StickyBucketUsed bool `json:"stickyBucketUsed"`
+	// The contextual bandit leaf used for this assignment
+	LeafId *int `json:"leafId,omitempty"`
+	// The variation weights the contextual bandit assigned with
+	VariationWeights []float64 `json:"variationWeights,omitempty"`
+	// The version of the contextual bandit definition used
+	BanditVersion *int `json:"banditVersion,omitempty"`
 }

--- a/feature_api.go
+++ b/feature_api.go
@@ -12,13 +12,15 @@ import (
 )
 
 type FeatureApiResponse struct {
-	Status            int                   `json:"status"`
-	Features          FeatureMap            `json:"features"`
-	DateUpdated       time.Time             `json:"dateUpdated"`
-	SavedGroups       condition.SavedGroups `json:"savedGroups"`
-	EncryptedFeatures string                `json:"encryptedFeatures"`
-	SseSupport        bool
-	Etag              string
+	Status                     int                         `json:"status"`
+	Features                   FeatureMap                  `json:"features"`
+	DateUpdated                time.Time                   `json:"dateUpdated"`
+	SavedGroups                condition.SavedGroups       `json:"savedGroups"`
+	EncryptedFeatures          string                      `json:"encryptedFeatures"`
+	ContextualBandits          ContextualBanditDefinitions `json:"contextualBandits"`
+	EncryptedContextualBandits string                      `json:"encryptedContextualBandits"`
+	SseSupport                 bool
+	Etag                       string
 }
 
 const userAgent = "Growhthbook Go SDK client"

--- a/feature_rule.go
+++ b/feature_rule.go
@@ -52,6 +52,11 @@ type FeatureRule struct {
 	Name string `json:"name"`
 	// The phase id of the experiment
 	Phase string `json:"phase"`
+	// Reference to a contextual bandit definition in the payload
+	ContextualBanditRef string `json:"contextualBanditRef"`
+	// Variations for a contextual bandit rule, carried separately from
+	// Variations so SDKs without bandit support skip the rule
+	ContextualVariations []FeatureValue `json:"contextualVariations"`
 	// Deprecated: ignored during evaluation. Feature rules never carried URL
 	// targeting in the JS SDK; use Experiment.URLPatterns with RunExperiment.
 	URLPatterns []URLTarget `json:"urlPatterns"`
@@ -65,8 +70,8 @@ type FeatureRule struct {
 	// status in the JS SDK; use Experiment.Status with RunExperiment.
 	Status ExperimentStatus `json:"status"`
 
-	// forcePresent distinguishes {"force": null} from an absent force: the
-	// JS SDK serves the null (it checks key presence), so Go must too.
+	// forcePresent distinguishes {"force": null} from an absent force, so a
+	// rule forcing null serves it instead of being skipped.
 	forcePresent bool
 }
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -70,6 +70,9 @@ func (r *subscriberRegistry) subscribersForResult(exp *Experiment, res *Experime
 // Subscribe registers a callback fired when an experiment assignment changes.
 // The returned function unregisters it. Subscribers are shared across child
 // clients created via With* methods - register once on the root client.
+// Subscribers are notified during evaluation, so the experiment may carry
+// in-flight state (e.g. a bandit context) the outcome did not use; the
+// result is the authoritative record of the assignment.
 func (client *Client) Subscribe(fn ExperimentSubscriber) (unsubscribe func()) {
 	if fn == nil {
 		return func() {}

--- a/subscribe.go
+++ b/subscribe.go
@@ -70,9 +70,9 @@ func (r *subscriberRegistry) subscribersForResult(exp *Experiment, res *Experime
 // Subscribe registers a callback fired when an experiment assignment changes.
 // The returned function unregisters it. Subscribers are shared across child
 // clients created via With* methods - register once on the root client.
-// Subscribers are notified during evaluation, so the experiment may carry
-// in-flight state (e.g. a bandit context) the outcome did not use; the
-// result is the authoritative record of the assignment.
+// Subscribers observe the same experiment state the tracking pipeline
+// records: bandit metadata is stripped before notification whenever the
+// result carries no leaf attribution, matching the JS and Python SDKs.
 func (client *Client) Subscribe(fn ExperimentSubscriber) (unsubscribe func()) {
 	if fn == nil {
 		return func() {}

--- a/tests/scripts/check_corpus_freshness.py
+++ b/tests/scripts/check_corpus_freshness.py
@@ -55,9 +55,9 @@ SKIPLIST = REPO_ROOT / "tests" / "scripts" / "corpus_skiplist.json"
 DEFAULT_JS_URL = "https://raw.githubusercontent.com/growthbook/growthbook/main/packages/sdk-js/test/cases.json"
 
 # Top-level keys to diff. Other keys in cases.json (specVersion, decrypt
-# binary blobs, urlRedirect which Go doesn't yet wire, contextualBandit which
-# Go doesn't implement) are skipped either because they're scalar metadata or
-# because the divergence is tracked separately.
+# binary blobs, urlRedirect which Go doesn't yet wire) are skipped either
+# because they're scalar metadata or because the divergence is tracked
+# separately.
 KEYS_TO_DIFF = (
     "evalCondition",
     "feature",
@@ -69,6 +69,7 @@ KEYS_TO_DIFF = (
     "inNamespace",
     "getEqualWeights",
     "stickyBucket",
+    "contextualBandit",
 )
 
 

--- a/tests/scripts/corpus_skiplist.json
+++ b/tests/scripts/corpus_skiplist.json
@@ -1,15 +1,6 @@
 {
-  "_doc": "Skiplist for the corpus freshness check (tests/scripts/check_corpus_freshness.py). Two buckets:\n  * \"missing\" — case names JS has and Go deliberately doesn't carry yet. Use when JS adds a case for a feature Go doesn't (yet) support.\n  * \"drift\"   — case names where Go deliberately keeps a different body from JS. Use sparingly — body-drift on a shared case is usually a bug.\nExtras (Go has, JS doesn't) are reported but never fail CI, so they don't need an entry here.\nAdd a brief reason in `_reasons` whenever you add an entry so future maintainers know why.",
-  "missing": {
-    "feature": [
-      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
-      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
-      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
-      "CB rule with empty contexts is overridden by forced variation like a normal experiment"
-    ]
-  },
+  "_doc": "Skiplist for the corpus freshness check (tests/scripts/check_corpus_freshness.py). Two buckets:\n  * \"missing\" \u2014 case names JS has and Go deliberately doesn't carry yet. Use when JS adds a case for a feature Go doesn't (yet) support.\n  * \"drift\"   \u2014 case names where Go deliberately keeps a different body from JS. Use sparingly \u2014 body-drift on a shared case is usually a bug.\nExtras (Go has, JS doesn't) are reported but never fail CI, so they don't need an entry here.\nAdd a brief reason in `_reasons` whenever you add an entry so future maintainers know why.",
+  "missing": {},
   "drift": {},
-  "_reasons": {
-    "feature::CB rule *": "Contextual Bandit (multi-armed-bandit) rule support is not implemented in the Go SDK (spec 0.8.0: contextualBandits payload). The related non-CB cases (multi-armed-bandit/standard type treated as standard experiment, unknown bandit fields ignored) already pass in Go and are carried in cases.json; only the four cases that require CB bucketing are skiplisted. Tracked as a roadmap item; skiplisting keeps the freshness check green while still flagging future non-bandit drift."
-  }
+  "_reasons": {}
 }

--- a/tracking.go
+++ b/tracking.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"sync"
 )
@@ -221,6 +222,18 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 		e.userCtx = e.client.trackingUserContext()
 	}
 	expCopy, resCopy := *exp, *res
+	// Deep-clone the bandit metadata: subscribers and callbacks receive the
+	// live experiment and result after this snapshot is taken, and the
+	// buffer's JSON detach happens later at flush — shared mutables would
+	// let third-party code alter recorded propensities.
+	if cb := expCopy.ContextualBandit; cb != nil {
+		cbCopy := *cb
+		cbCopy.VariationWeights = slices.Clone(cb.VariationWeights)
+		cbCopy.BanditVersion = clonedBanditVersion(cb.BanditVersion)
+		expCopy.ContextualBandit = &cbCopy
+	}
+	resCopy.VariationWeights = slices.Clone(resCopy.VariationWeights)
+	resCopy.BanditVersion = clonedBanditVersion(resCopy.BanditVersion)
 	e.experiments = append(e.experiments, TrackingData{Experiment: &expCopy, Result: &resCopy, User: e.userCtx})
 }
 

--- a/tracking.go
+++ b/tracking.go
@@ -221,6 +221,11 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 		e.userCtx = e.client.trackingUserContext()
 	}
 	expCopy, resCopy := *exp, *res
+	// The result is the truth for bandit attribution: a snapshot must not
+	// claim a context the assignment did not use (e.g. sticky-bucketed).
+	if res.LeafId == nil {
+		expCopy.ContextualBandit = nil
+	}
 	e.experiments = append(e.experiments, TrackingData{Experiment: &expCopy, Result: &resCopy, User: e.userCtx})
 }
 

--- a/tracking.go
+++ b/tracking.go
@@ -221,11 +221,6 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 		e.userCtx = e.client.trackingUserContext()
 	}
 	expCopy, resCopy := *exp, *res
-	// The result is the truth for bandit attribution: a snapshot must not
-	// claim a context the assignment did not use (e.g. sticky-bucketed).
-	if res.LeafId == nil {
-		expCopy.ContextualBandit = nil
-	}
 	e.experiments = append(e.experiments, TrackingData{Experiment: &expCopy, Result: &resCopy, User: e.userCtx})
 }
 

--- a/tracking.go
+++ b/tracking.go
@@ -222,10 +222,15 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 		e.userCtx = e.client.trackingUserContext()
 	}
 	expCopy, resCopy := *exp, *res
-	// Deep-clone the bandit metadata: subscribers and callbacks receive the
-	// live experiment and result after this snapshot is taken, and the
-	// buffer's JSON detach happens later at flush — shared mutables would
-	// let third-party code alter recorded propensities.
+	// Deep-clone what describes the assignment: subscribers and callbacks
+	// receive the live experiment and result after this snapshot is taken,
+	// and the buffer's JSON detach happens later at flush — shared mutables
+	// would let third-party code alter recorded propensities or bucketing
+	// semantics. (Other experiment fields — meta, filters, conditions —
+	// remain shallow-copied, a pre-existing trade-off; they don't feed
+	// bandit training.)
+	expCopy.Weights = slices.Clone(expCopy.Weights)
+	expCopy.Ranges = slices.Clone(expCopy.Ranges)
 	if cb := expCopy.ContextualBandit; cb != nil {
 		cbCopy := *cb
 		cbCopy.VariationWeights = slices.Clone(cb.VariationWeights)


### PR DESCRIPTION
Closes #82
Closes #85

## Summary

Contextual bandit support (JS parity), superseding #82 and #85. Stacked on #88 and #89 — merge those first; GitHub retargets automatically.

The base commit is #85's work squashed (original author: @bryce-fitzsimons);  Why supersede rather than amend:
- **#82**: bandit fields are stamped on the result *after* `runExperiment` has already snapshotted tracking data, so attribution never reaches callbacks, the deferred buffer, or plugins; sticky-bucketed assignments report propensities the assignment did not use; strict JSON decoding lets one malformed bandit number reject the entire payload update (features included).
- **#85**: the right architecture, adopted here as the base, with the gaps below fixed on top and its three unrelated bug fixes moved to #89.

## Behavioral change (vs #85's tip)

- A matched leaf with a junk `leafId` or unusable weights **demotes to the fallback leaf (-1) with the rule's aggregate weights** (Python parity), instead of substituting equal weights under the real leafId — reported propensities always describe the vector bucketing used.
- A type-malformed context **aborts leaf selection** (evaluation cannot know whether it would have matched) instead of being silently dropped at decode with routing continuing past it.
- A rule pairing explicit `ranges` with a `contextualBanditRef` buckets on the ranges (assignment identical to JS) but **reports no bandit metadata** — this case was unhandled and reported leaf weights bucketing ignored.
- Payload semantics: an **absent `contextualBandits` section preserves** the previous definitions, an explicit `{}`/`null` clears them, and a failed decrypt preserves them (previously any of these wiped the map). `savedGroups`/`features` still overwrite-on-absent — pre-existing, flagged as a follow-up.
- The unused-attribution strip happens **once, in `experimentResult`**, replacing three coordinated compensation sites — subscribers now observe the same stripped experiment the tracking pipeline records (JS/Python parity), and `RunExperiment` evaluates a copy so the caller's experiment is never mutated.
- Strict weight validation (finite, non-negative, right length, sum ~1) shared by bucketing and reported propensities; NaN previously passed the sum check. Disclosed divergence from JS (which buckets on the inverted ranges of `[1.2, -0.2]`), same as Python.
- `CBContext` renamed `ContextualBanditAssignment` (payload leaf vs assignment record were both called "context").
- Payload slices are cloned at assignment build, so callbacks can never mutate the client-wide definitions map through an aliased weights slice.

## Verification

- [x] 35 shared `contextualBandit` conformance cases (spec 0.8.0) pass; corpus freshness clean with an empty skiplist
- [x] Cross-SDK: 18 crafted malformed-payload scenarios run through Go and Python — 17/18 byte-identical outputs (assignment + reported metadata); the 18th is a live Python crash on empty variation lists that #89's guard prevents in Go, filed separately for Python
- [x] E2E: `DeferredTrackingCalls()` JSON fired through the published JS SDK 1.7.0 via `setDeferredTrackingCalls`/`fireDeferredTrackingCalls` — bandit attribution (result and experiment), prerequisite bandit exposures, targeting conditions (no longer `{}`), and NUL-byte attributes all arrive and fire
- [x] `go test ./...` + `-race` green across the stack

## Follow-ups

- Main repo: declare the `contextualBandits` capability for Go in sdk-versioning once released
- `savedGroups`/`features` overwrite-on-absent in `UpdateFromApiResponse` (pre-existing divergence from JS `setPayload`)
- Remote-eval `rule.tracks` bandit validation is N/A — the Go SDK has no remote evaluation mode