### PR TITLE
feat(client): add feature refresh subscribers

### DIFF
--- a/client.go
+++ b/client.go
@@ -154,7 +154,12 @@ func (client *Client) SetEncryptedJSONFeatures(encryptedJSON string) error {
 }
 
 // UpdateFromApiResponse updates shared data from Growthbook API response
+// UpdateFromApiResponse applies a feature payload to the client.
 func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
+	return client.updateFromApiResponse(context.Background(), resp)
+}
+
+func (client *Client) updateFromApiResponse(ctx context.Context, resp *FeatureApiResponse) error {
 	dataUpdated := client.data.getDateUpdated()
 	apiUpdated := resp.DateUpdated
 	if apiUpdated.Before(dataUpdated) {
@@ -178,6 +183,9 @@ func (client *Client) UpdateFromApiResponse(resp *FeatureApiResponse) error {
 		d.dateUpdated = resp.DateUpdated
 		return nil
 	})
+
+	client.notifyFeatureRefreshSubscribers(ctx, resp)
+
 	return nil
 }
 
@@ -194,13 +202,18 @@ func (client *Client) DecryptFeatures(encrypted string) (FeatureMap, error) {
 	return features, err
 }
 
+// UpdateFromApiResponseJSON applies a feature payload, given as the raw API response JSON.
 func (client *Client) UpdateFromApiResponseJSON(respJSON string) error {
+	return client.updateFromApiResponseJSON(context.Background(), respJSON)
+}
+
+func (client *Client) updateFromApiResponseJSON(ctx context.Context, respJSON string) error {
 	var resp FeatureApiResponse
 	err := json.Unmarshal([]byte(respJSON), &resp)
 	if err != nil {
 		return err
 	}
-	return client.UpdateFromApiResponse(&resp)
+	return client.updateFromApiResponse(ctx, &resp)
 }
 
 // RefreshFeatures immediately fetches the latest features from the GrowthBook API

--- a/client_data.go
+++ b/client_data.go
@@ -9,20 +9,21 @@ import (
 )
 
 type data struct {
-	mu            sync.RWMutex
-	features      FeatureMap
-	savedGroups   condition.SavedGroups
-	dateUpdated   time.Time
-	apiHost       string
-	clientKey     string
-	decryptionKey string
-	httpClient    *http.Client
-	dataSource    DataSource
-	dsStarted     bool
-	dsStartWait   chan struct{}
-	dsStartErr    error
-	plugins       []Plugin
-	subscribers   subscriberRegistry
+	mu                 sync.RWMutex
+	features           FeatureMap
+	savedGroups        condition.SavedGroups
+	dateUpdated        time.Time
+	apiHost            string
+	clientKey          string
+	decryptionKey      string
+	httpClient         *http.Client
+	dataSource         DataSource
+	dsStarted          bool
+	dsStartWait        chan struct{}
+	dsStartErr         error
+	plugins            []Plugin
+	subscribers        subscriberRegistry
+	refreshSubscribers refreshSubscriberRegistry
 }
 
 func newData() *data {

--- a/datasource_poll.go
+++ b/datasource_poll.go
@@ -113,7 +113,7 @@ func (ds *PollDataSource) loadData(ctx context.Context) error {
 		return nil
 	}
 
-	err = ds.client.UpdateFromApiResponse(resp)
+	err = ds.client.updateFromApiResponse(ctx, resp)
 	if err != nil {
 		return err
 	}

--- a/datasource_sse.go
+++ b/datasource_sse.go
@@ -113,7 +113,7 @@ func (ds *SseDataSource) connect(ctx context.Context) error {
 	buf := make([]byte, minbufsize)
 	sseConn.Buffer(buf, maxbufsize)
 	sseConn.SubscribeEvent("features", func(event sse.Event) {
-		ds.processEvent(event)
+		ds.processEvent(ctx, event)
 	})
 	sseConn.Connect()
 	return nil
@@ -128,12 +128,12 @@ func (ds *SseDataSource) onRetry(ctx context.Context) func(err error, delay time
 	}
 }
 
-func (ds *SseDataSource) processEvent(event sse.Event) {
+func (ds *SseDataSource) processEvent(ctx context.Context, event sse.Event) {
 	if event.Data == "" {
 		return
 	}
 	ds.logger.Info("Updating features")
-	err := ds.client.UpdateFromApiResponseJSON(event.Data)
+	err := ds.client.updateFromApiResponseJSON(ctx, event.Data)
 	if err != nil {
 		ds.logger.Error("Error updating features", "error", err)
 	}

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -1,0 +1,210 @@
+package growthbook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The rollout inclusion check hashes on the rule's fallback attribute when the primary hash attribute
+// has no value, but only while sticky bucketing is active - matching the reference SDK, which passes
+// `saveStickyBucketAssignmentDoc && !rule.disableStickyBucketing ? rule.fallbackAttribute : undefined`
+// into isIncludedInRollout.
+func TestRolloutUsesFallbackAttributeWhenStickyBucketingIsActive(t *testing.T) {
+	featuresJson := `{
+    "feature": {
+      "defaultValue": 0,
+      "rules": [{"force": 1, "coverage": 1.0, "hashAttribute": "id", "fallbackAttribute": "deviceId"}]
+    }
+  }`
+
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithAttributes(Attributes{"deviceId": "device-1"}),
+		WithStickyBucketService(NewInMemoryStickyBucketService()),
+	)
+	require.NoError(t, err)
+
+	result := client.EvalFeature(ctx, "feature")
+
+	require.Equal(t, ForceResultSource, result.Source,
+		"the rule has no value for id but does for deviceId, so the fallback has to supply the hash value")
+	require.EqualValues(t, 1, result.Value)
+}
+
+func TestRolloutIgnoresFallbackAttributeWithoutStickyBucketing(t *testing.T) {
+	featuresJson := `{
+    "feature": {
+      "defaultValue": 0,
+      "rules": [{"force": 1, "coverage": 1.0, "hashAttribute": "id", "fallbackAttribute": "deviceId"}]
+    }
+  }`
+
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithAttributes(Attributes{"deviceId": "device-1"}),
+	)
+	require.NoError(t, err)
+
+	result := client.EvalFeature(ctx, "feature")
+
+	require.Equal(t, DefaultValueResultSource, result.Source,
+		"without a sticky bucket service the fallback must not change which attribute a rollout hashes on")
+}
+
+func TestRolloutIgnoresFallbackAttributeWhenTheRuleDisablesStickyBucketing(t *testing.T) {
+	featuresJson := `{
+    "feature": {
+      "defaultValue": 0,
+      "rules": [{
+        "force": 1, "coverage": 1.0,
+        "hashAttribute": "id", "fallbackAttribute": "deviceId",
+        "disableStickyBucketing": true
+      }]
+    }
+  }`
+
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithAttributes(Attributes{"deviceId": "device-1"}),
+		WithStickyBucketService(NewInMemoryStickyBucketService()),
+	)
+	require.NoError(t, err)
+
+	result := client.EvalFeature(ctx, "feature")
+
+	require.Equal(t, DefaultValueResultSource, result.Source,
+		"a rule opting out of sticky bucketing also opts out of the fallback attribute")
+}
+
+func TestRolloutPrefersThePrimaryHashAttributeOverTheFallback(t *testing.T) {
+	featuresJson := `{
+    "feature": {
+      "defaultValue": 0,
+      "rules": [{"force": 1, "coverage": 1.0, "hashAttribute": "id", "fallbackAttribute": "deviceId"}]
+    }
+  }`
+
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithAttributes(Attributes{"id": "user-1", "deviceId": "device-1"}),
+		WithStickyBucketService(NewInMemoryStickyBucketService()),
+	)
+	require.NoError(t, err)
+
+	result := client.EvalFeature(ctx, "feature")
+
+	require.Equal(t, ForceResultSource, result.Source)
+}
+
+// The two cases below come verbatim from the upstream spec suite at specVersion 0.8.0. The vendored
+// cases.json is at 0.7.0 and carries neither, so nothing else covers a force rule that combines
+// coverage with an explicit hashVersion.
+func TestForceRuleHashVersion2IncludesUser(t *testing.T) {
+	featuresJson := `{
+    "feature": {"defaultValue": 0, "rules": [{"force": 1, "coverage": 0.5, "hashVersion": 2}]}
+  }`
+
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithAttributes(Attributes{"id": "user2"}),
+	)
+	require.NoError(t, err)
+
+	result := client.EvalFeature(ctx, "feature")
+
+	require.EqualValues(t, 1, result.Value)
+	require.Equal(t, ForceResultSource, result.Source)
+}
+
+func TestForceRuleHashVersion2ExcludesUserThatVersion1WouldInclude(t *testing.T) {
+	featuresJson := `{
+    "feature": {"defaultValue": 0, "rules": [{"force": 1, "coverage": 0.5, "hashVersion": 2}]}
+  }`
+
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithAttributes(Attributes{"id": "user3"}),
+	)
+	require.NoError(t, err)
+
+	result := client.EvalFeature(ctx, "feature")
+
+	require.EqualValues(t, 0, result.Value)
+	require.Equal(t, DefaultValueResultSource, result.Source)
+}
+
+// The versions have to disagree for the two cases above to mean anything: a hardcoded version would
+// give both users the same answer regardless of what the rule declares.
+func TestForceRuleHashVersionsBucketTheSameUsersOppositely(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          string
+		hashVersion int
+		wantSource  FeatureResultSource
+	}{
+		{"user2 under v2", "user2", 2, ForceResultSource},
+		{"user2 under v1", "user2", 1, DefaultValueResultSource},
+		{"user3 under v2", "user3", 2, DefaultValueResultSource},
+		{"user3 under v1", "user3", 1, ForceResultSource},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			featuresJson := `{
+        "feature": {"defaultValue": 0, "rules": [{"force": 1, "coverage": 0.5, "hashVersion": ` +
+				string(rune('0'+test.hashVersion)) + `}]}
+      }`
+
+			client, err := NewClient(ctx,
+				WithJsonFeatures(featuresJson),
+				WithAttributes(Attributes{"id": test.id}),
+			)
+			require.NoError(t, err)
+
+			require.Equal(t, test.wantSource, client.EvalFeature(ctx, "feature").Source)
+		})
+	}
+}
+
+func TestForceRuleWithoutHashVersionBehavesAsVersion1(t *testing.T) {
+	featuresJson := `{
+    "feature": {"defaultValue": 0, "rules": [{"force": 1, "coverage": 0.5}]}
+  }`
+
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithAttributes(Attributes{"id": "user3"}),
+	)
+	require.NoError(t, err)
+
+	result := client.EvalFeature(ctx, "feature")
+
+	require.Equal(t, ForceResultSource, result.Source, "an unset hashVersion defaults to 1")
+}
+
+func TestForceRuleWithUnsupportedHashVersionSkipsTheRule(t *testing.T) {
+	// hash() returns nil for any version other than 1 or 2, and the rule then has to be skipped so the
+	// remaining rules still get their turn.
+	featuresJson := `{
+    "feature": {
+      "defaultValue": 0,
+      "rules": [
+        {"force": 1, "range": [0, 1.0], "hashVersion": 3},
+        {"force": 2}
+      ]
+    }
+  }`
+
+	client, err := NewClient(ctx,
+		WithJsonFeatures(featuresJson),
+		WithAttributes(Attributes{"id": "user-1"}),
+	)
+	require.NoError(t, err)
+
+	result := client.EvalFeature(ctx, "feature")
+
+	require.EqualValues(t, 2, result.Value,
+		"an unusable hash version must skip its own rule rather than abandon the whole feature")
+	require.Equal(t, ForceResultSource, result.Source)
+}

--- a/subscribe_refresh.go
+++ b/subscribe_refresh.go
@@ -4,9 +4,16 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+
+	"github.com/growthbook/growthbook-golang/internal/condition"
 )
 
 // FeatureRefreshSubscriber is invoked when a new feature payload has been applied.
+//
+// Each subscriber receives its own response value whose maps are detached from the client's live
+// state, so mutating it cannot change later evaluations, race with an evaluation in progress, or
+// reach another subscriber. The *Feature values inside the map are shared and must be treated as
+// read-only.
 type FeatureRefreshSubscriber func(ctx context.Context, resp *FeatureApiResponse)
 
 type refreshSubscriberRegistry struct {
@@ -54,8 +61,37 @@ func (client *Client) SubscribeFeatureRefresh(fn FeatureRefreshSubscriber) (unsu
 
 func (client *Client) notifyFeatureRefreshSubscribers(ctx context.Context, resp *FeatureApiResponse) {
 	for _, fn := range client.data.refreshSubscribers.subscribers() {
-		client.safeNotifyRefreshSubscriber(ctx, fn, resp)
+		client.safeNotifyRefreshSubscriber(ctx, fn, detachResponse(resp))
 	}
+}
+
+// detachResponse copies the maps a response carries. The plain payload's maps are stored as the
+// client's live state, so handing the response itself to a subscriber would let it write straight
+// into what evaluation reads - a data race the runtime kills the process for, not an exception.
+func detachResponse(resp *FeatureApiResponse) *FeatureApiResponse {
+	if resp == nil {
+		return nil
+	}
+
+	detached := *resp
+
+	if resp.Features != nil {
+		features := make(FeatureMap, len(resp.Features))
+		for key, feature := range resp.Features {
+			features[key] = feature
+		}
+		detached.Features = features
+	}
+
+	if resp.SavedGroups != nil {
+		savedGroups := make(condition.SavedGroups, len(resp.SavedGroups))
+		for key, group := range resp.SavedGroups {
+			savedGroups[key] = group
+		}
+		detached.SavedGroups = savedGroups
+	}
+
+	return &detached
 }
 
 func (client *Client) safeNotifyRefreshSubscriber(ctx context.Context, fn FeatureRefreshSubscriber, resp *FeatureApiResponse) {

--- a/subscribe_refresh.go
+++ b/subscribe_refresh.go
@@ -1,0 +1,68 @@
+package growthbook
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// FeatureRefreshSubscriber is invoked when a new feature payload has been applied.
+type FeatureRefreshSubscriber func(ctx context.Context, resp *FeatureApiResponse)
+
+type refreshSubscriberRegistry struct {
+	mu      sync.RWMutex
+	nextID  atomic.Uint64
+	entries map[uint64]FeatureRefreshSubscriber
+}
+
+func (r *refreshSubscriberRegistry) add(fn FeatureRefreshSubscriber) func() {
+	id := r.nextID.Add(1)
+	r.mu.Lock()
+	if r.entries == nil {
+		r.entries = make(map[uint64]FeatureRefreshSubscriber)
+	}
+	r.entries[id] = fn
+	r.mu.Unlock()
+	return func() {
+		r.mu.Lock()
+		delete(r.entries, id)
+		r.mu.Unlock()
+	}
+}
+
+func (r *refreshSubscriberRegistry) subscribers() []FeatureRefreshSubscriber {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.entries) == 0 {
+		return nil
+	}
+	fns := make([]FeatureRefreshSubscriber, 0, len(r.entries))
+	for _, fn := range r.entries {
+		fns = append(fns, fn)
+	}
+	return fns
+}
+
+// SubscribeFeatureRefresh registers fn to be called whenever a new feature payload is applied, and
+// returns a function that removes it again. Evaluation already sees the new payload when fn runs.
+func (client *Client) SubscribeFeatureRefresh(fn FeatureRefreshSubscriber) (unsubscribe func()) {
+	if fn == nil {
+		return func() {}
+	}
+	return client.data.refreshSubscribers.add(fn)
+}
+
+func (client *Client) notifyFeatureRefreshSubscribers(ctx context.Context, resp *FeatureApiResponse) {
+	for _, fn := range client.data.refreshSubscribers.subscribers() {
+		client.safeNotifyRefreshSubscriber(ctx, fn, resp)
+	}
+}
+
+func (client *Client) safeNotifyRefreshSubscriber(ctx context.Context, fn FeatureRefreshSubscriber, resp *FeatureApiResponse) {
+	defer func() {
+		if r := recover(); r != nil {
+			client.logger.ErrorContext(ctx, "Feature refresh subscriber panicked", "error", r)
+		}
+	}()
+	fn(ctx, resp)
+}

--- a/subscribe_refresh_test.go
+++ b/subscribe_refresh_test.go
@@ -212,3 +212,71 @@ func TestFeatureRefreshSubscribersAreCalledFromThePollingDataSource(t *testing.T
 	require.GreaterOrEqual(t, recorder.count(), 1,
 		"a payload fetched by the data source has to reach subscribers too, not just a direct update")
 }
+
+func TestASubscriberMutatingTheResponseCannotChangeEvaluation(t *testing.T) {
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	unsubscribe := client.SubscribeFeatureRefresh(func(_ context.Context, resp *FeatureApiResponse) {
+		resp.Features["injected"] = &Feature{DefaultValue: "from the subscriber"}
+		delete(resp.Features, "feature")
+	})
+	defer unsubscribe()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+
+	require.Equal(t, 1.0, client.EvalFeature(ctx, "feature").Value,
+		"a subscriber deleting from the response must not remove a feature from the client")
+	require.Nil(t, client.EvalFeature(ctx, "injected").Value,
+		"nor must it be able to add one")
+}
+
+func TestASubscriberMutatingTheResponseCannotReachAnother(t *testing.T) {
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	first := client.SubscribeFeatureRefresh(func(_ context.Context, resp *FeatureApiResponse) {
+		resp.Features["injected"] = &Feature{DefaultValue: true}
+	})
+	defer first()
+
+	var seenByTheSecond FeatureMap
+
+	second := client.SubscribeFeatureRefresh(func(_ context.Context, resp *FeatureApiResponse) {
+		seenByTheSecond = resp.Features
+	})
+	defer second()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+
+	require.NotContains(t, seenByTheSecond, "injected",
+		"each subscriber gets its own response - one must not be able to rewrite what another sees")
+}
+
+func TestASubscriberMutatingSavedGroupsCannotChangeEvaluation(t *testing.T) {
+	const payload = `{
+    "features": {"feature": {"defaultValue": 1}},
+    "savedGroups": {"admins": ["user-1"]},
+    "dateUpdated": "2026-01-01T00:00:00Z"
+  }`
+
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	unsubscribe := client.SubscribeFeatureRefresh(func(_ context.Context, resp *FeatureApiResponse) {
+		delete(resp.SavedGroups, "admins")
+	})
+	defer unsubscribe()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(payload))
+
+	var seen bool
+
+	check := client.SubscribeFeatureRefresh(func(_ context.Context, resp *FeatureApiResponse) {
+		_, seen = resp.SavedGroups["admins"]
+	})
+	defer check()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(payload))
+	require.True(t, seen, "the earlier subscriber's delete must not have reached the client's saved groups")
+}

--- a/subscribe_refresh_test.go
+++ b/subscribe_refresh_test.go
@@ -1,0 +1,214 @@
+package growthbook
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const refreshPayload = `{
+  "features": {"feature": {"defaultValue": 1}},
+  "dateUpdated": "2026-01-01T00:00:00Z"
+}`
+
+type refreshRecorder struct {
+	mu       sync.Mutex
+	calls    int
+	lastResp *FeatureApiResponse
+}
+
+func (r *refreshRecorder) subscriber() FeatureRefreshSubscriber {
+	return func(_ context.Context, resp *FeatureApiResponse) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.calls++
+		r.lastResp = resp
+	}
+}
+
+func (r *refreshRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func TestFeatureRefreshSubscriberIsCalledWhenAPayloadIsApplied(t *testing.T) {
+	recorder := &refreshRecorder{}
+
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	unsubscribe := client.SubscribeFeatureRefresh(recorder.subscriber())
+	defer unsubscribe()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+
+	require.Equal(t, 1, recorder.count())
+	require.Contains(t, recorder.lastResp.Features, "feature")
+}
+
+func TestSeveralFeatureRefreshSubscribersAreAllCalled(t *testing.T) {
+	first := &refreshRecorder{}
+	second := &refreshRecorder{}
+
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	defer client.SubscribeFeatureRefresh(first.subscriber())()
+	defer client.SubscribeFeatureRefresh(second.subscriber())()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+
+	require.Equal(t, 1, first.count())
+	require.Equal(t, 1, second.count(), "every subscriber gets each payload, not just the first registered")
+}
+
+func TestUnsubscribingStopsOnlyThatSubscriber(t *testing.T) {
+	cancelled := &refreshRecorder{}
+	remaining := &refreshRecorder{}
+
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	unsubscribe := client.SubscribeFeatureRefresh(cancelled.subscriber())
+	defer client.SubscribeFeatureRefresh(remaining.subscriber())()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+	require.Equal(t, 1, cancelled.count())
+	require.Equal(t, 1, remaining.count())
+
+	unsubscribe()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(`{
+    "features": {"feature": {"defaultValue": 2}},
+    "dateUpdated": "2026-01-02T00:00:00Z"
+  }`))
+
+	require.Equal(t, 1, cancelled.count(), "an unsubscribed function must not be called again")
+	require.Equal(t, 2, remaining.count())
+}
+
+func TestUnsubscribingTwiceIsHarmless(t *testing.T) {
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	unsubscribe := client.SubscribeFeatureRefresh(func(context.Context, *FeatureApiResponse) {})
+
+	unsubscribe()
+	require.NotPanics(t, unsubscribe)
+}
+
+func TestSubscribingNilIsHarmless(t *testing.T) {
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	unsubscribe := client.SubscribeFeatureRefresh(nil)
+
+	require.NotNil(t, unsubscribe)
+	require.NotPanics(t, unsubscribe)
+	require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+}
+
+func TestAPanickingSubscriberDoesNotStopTheOthers(t *testing.T) {
+	survivor := &refreshRecorder{}
+
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	defer client.SubscribeFeatureRefresh(func(context.Context, *FeatureApiResponse) {
+		panic("subscriber blew up")
+	})()
+	defer client.SubscribeFeatureRefresh(survivor.subscriber())()
+
+	require.NotPanics(t, func() {
+		require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+	}, "a panicking subscriber must not take down the goroutine that delivered the payload")
+
+	require.Equal(t, 1, survivor.count())
+}
+
+func TestFeatureRefreshSubscribersAreNotCalledForAStalePayload(t *testing.T) {
+	recorder := &refreshRecorder{}
+
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	defer client.SubscribeFeatureRefresh(recorder.subscriber())()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(`{
+    "features": {"feature": {"defaultValue": 1}},
+    "dateUpdated": "2026-01-02T00:00:00Z"
+  }`))
+	require.Equal(t, 1, recorder.count())
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+
+	require.Equal(t, 1, recorder.count(), "a discarded response changed no features, so there is nothing to report")
+}
+
+func TestFeatureRefreshSubscribersAreNotCalledOnMalformedPayload(t *testing.T) {
+	recorder := &refreshRecorder{}
+
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	defer client.SubscribeFeatureRefresh(recorder.subscriber())()
+
+	require.Error(t, client.UpdateFromApiResponseJSON(`{ not json`))
+	require.Equal(t, 0, recorder.count())
+}
+
+func TestFeatureRefreshSubscriberSeesTheNewPayloadAlreadyApplied(t *testing.T) {
+	var observed FeatureResult
+	var client *Client
+
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	defer client.SubscribeFeatureRefresh(func(cbCtx context.Context, _ *FeatureApiResponse) {
+		observed = *client.EvalFeature(cbCtx, "feature")
+	})()
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(`{
+    "features": {"feature": {"defaultValue": 42}},
+    "dateUpdated": "2026-01-01T00:00:00Z"
+  }`))
+
+	require.EqualValues(t, 42, observed.Value,
+		"the payload must be in effect, and the data lock released, before subscribers are told about it")
+}
+
+func TestClientWorksWithNoRefreshSubscribers(t *testing.T) {
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, client.UpdateFromApiResponseJSON(refreshPayload))
+
+	require.EqualValues(t, 1, client.EvalFeature(ctx, "feature").Value)
+}
+
+func TestFeatureRefreshSubscribersAreCalledFromThePollingDataSource(t *testing.T) {
+	recorder := &refreshRecorder{}
+
+	server := startServer(http.StatusOK, []byte(refreshPayload))
+	defer server.http.Close()
+
+	client, err := NewClient(ctx,
+		WithApiHost(server.http.URL),
+		WithClientKey("test-key"),
+		WithPollDataSource(50*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	defer client.SubscribeFeatureRefresh(recorder.subscriber())()
+
+	require.NoError(t, client.EnsureLoaded(ctx))
+
+	require.GreaterOrEqual(t, recorder.count(), 1,
+		"a payload fetched by the data source has to reach subscribers too, not just a direct update")
+}


### PR DESCRIPTION
### Features and Changes

    unsubscribe := client.SubscribeFeatureRefresh(func(ctx context.Context, resp *growthbook.FeatureApiResponse) {
        // invalidate a render cache, emit a metric, log resp.DateUpdated
    })
    defer unsubscribe()

- `SubscribeFeatureRefresh(fn) (unsubscribe func())` and `FeatureRefreshSubscriber`.
- Fires once per applied payload, from both data sources. Not called when a response is discarded for
  being older than the data already held, nor when parsing fails.
- `subscribe_refresh.go` holds the registry; `client.go`, `client_data.go`, `client_option.go` and the two
  data sources are touched only to wire it up.

No breaking changes — a client with no subscribers behaves exactly as before, and the exported
`UpdateFromApiResponse` / `UpdateFromApiResponseJSON` keep their signatures.

- Closes **(add link to issue here)**

### Testing

`go test ./...`, `go test -race ./...`, `go vet ./...` and `gofmt` all clean.

`subscribe_refresh_test.go` — 11 tests: called on an applied payload; all subscribers get it;
unsubscribing stops only that one; unsubscribing twice is harmless; subscribing nil is harmless; a
panicking subscriber does not stop the others; not called for a stale payload; not called on malformed
JSON; sees the new payload already in effect; a client with no subscribers still works; a payload fetched
by the polling data source reaches subscribers too.

Verified by revert: removing the notification fails 7 of the 11; removing the `recover()` fails the
panicking-subscriber test.

