### PR TITLE
fix(client): apply WithEncryptedJsonFeatures after all options

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	featureUsageCallback FeatureUsageCallback
 	eventLogger          EventLogger
 	logger               *slog.Logger
+	pendingEncryptedFeatures string
 	extraData            any
 	// StickyBucketService for storing experiment assignments
 	stickyBucketService StickyBucketService
@@ -68,6 +69,16 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 	for _, opt := range opts {
 		err := opt(client)
 		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Decrypted here rather than inside the option, so a decryption key supplied by a later option
+	// still applies.
+	if client.pendingEncryptedFeatures != "" {
+		encrypted := client.pendingEncryptedFeatures
+		client.pendingEncryptedFeatures = ""
+		if err := client.SetEncryptedJSONFeatures(encrypted); err != nil {
 			return nil, err
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -19,19 +19,19 @@ var (
 
 // Client is a GrowthBook SDK client.
 type Client struct {
-	data                 *data
-	enabled              bool
-	attributes           value.ObjValue
-	url                  *url.URL
-	forcedVariations     ForcedVariationsMap
-	groups               map[string]bool
-	qaMode               bool
-	experimentCallback   ExperimentCallback
-	featureUsageCallback FeatureUsageCallback
-	eventLogger          EventLogger
-	logger               *slog.Logger
-	pendingEncryptedFeatures string
-	extraData            any
+	data                     *data
+	enabled                  bool
+	attributes               value.ObjValue
+	url                      *url.URL
+	forcedVariations         ForcedVariationsMap
+	groups                   map[string]bool
+	qaMode                   bool
+	experimentCallback       ExperimentCallback
+	featureUsageCallback     FeatureUsageCallback
+	eventLogger              EventLogger
+	logger                   *slog.Logger
+	pendingEncryptedFeatures []string
+	extraData                any
 	// StickyBucketService for storing experiment assignments
 	stickyBucketService StickyBucketService
 
@@ -74,10 +74,12 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 	}
 
 	// Decrypted here rather than inside the option, so a decryption key supplied by a later option
-	// still applies.
-	if client.pendingEncryptedFeatures != "" {
-		encrypted := client.pendingEncryptedFeatures
-		client.pendingEncryptedFeatures = ""
+	// still applies. Payloads a later plain feature option superseded were dropped by that option, so
+	// what remains is in order and every one of it is validated.
+	pending := client.pendingEncryptedFeatures
+	client.pendingEncryptedFeatures = nil
+
+	for _, encrypted := range pending {
 		if err := client.SetEncryptedJSONFeatures(encrypted); err != nil {
 			return nil, err
 		}

--- a/client_option.go
+++ b/client_option.go
@@ -75,6 +75,7 @@ func WithUrl(rawUrl string) ClientOption {
 // WithFeatures sets features definitions (usually pulled from an API or cache).
 func WithFeatures(features FeatureMap) ClientOption {
 	return func(c *Client) error {
+		c.pendingEncryptedFeatures = nil
 		return c.SetFeatures(features)
 	}
 }
@@ -82,14 +83,20 @@ func WithFeatures(features FeatureMap) ClientOption {
 // WithJsonFeatures sets features definitions from JSON string.
 func WithJsonFeatures(featuresJson string) ClientOption {
 	return func(c *Client) error {
+		c.pendingEncryptedFeatures = nil
 		return c.SetJSONFeatures(featuresJson)
 	}
 }
 
 // WithEncryptedJsonFeatures sets features definitions from encrypted JSON string.
+//
+// Decryption is deferred until every option has run, so a decryption key given by a later option still
+// applies. A later plain feature option discards the payload, keeping the last feature option the one
+// that wins, and every deferred payload is still decrypted, so an invalid one fails construction even
+// if a valid one follows it.
 func WithEncryptedJsonFeatures(featuresJson string) ClientOption {
 	return func(c *Client) error {
-		c.pendingEncryptedFeatures = featuresJson
+		c.pendingEncryptedFeatures = append(c.pendingEncryptedFeatures, featuresJson)
 		return nil
 	}
 }

--- a/client_option.go
+++ b/client_option.go
@@ -89,7 +89,8 @@ func WithJsonFeatures(featuresJson string) ClientOption {
 // WithEncryptedJsonFeatures sets features definitions from encrypted JSON string.
 func WithEncryptedJsonFeatures(featuresJson string) ClientOption {
 	return func(c *Client) error {
-		return c.SetEncryptedJSONFeatures(featuresJson)
+		c.pendingEncryptedFeatures = featuresJson
+		return nil
 	}
 }
 

--- a/encrypted_features_test.go
+++ b/encrypted_features_test.go
@@ -1,0 +1,89 @@
+package growthbook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDecryptionKey  = "Zvwv/+uhpFDznZ6SX28Yjg=="
+	testEncryptedFeats = "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj"
+)
+
+func TestEncryptedFeaturesWorkWithTheKeyOptionListedSecond(t *testing.T) {
+	client, err := NewClient(ctx,
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+		WithDecryptionKey(testDecryptionKey),
+	)
+
+	require.NoError(t, err, "option order must not decide whether a supplied decryption key is used")
+	require.NotNil(t, client)
+}
+
+func TestEncryptedFeaturesWorkWithTheKeyOptionListedFirst(t *testing.T) {
+	client, err := NewClient(ctx,
+		WithDecryptionKey(testDecryptionKey),
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestBothOptionOrdersProduceTheSameFeatures(t *testing.T) {
+	keyFirst, err := NewClient(ctx,
+		WithDecryptionKey(testDecryptionKey),
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+	)
+	require.NoError(t, err)
+
+	featuresFirst, err := NewClient(ctx,
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+		WithDecryptionKey(testDecryptionKey),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, keyFirst.data.getFeatures(), featuresFirst.data.getFeatures())
+}
+
+func TestEncryptedFeaturesWithoutAnyKeyStillFails(t *testing.T) {
+	_, err := NewClient(ctx, WithEncryptedJsonFeatures(testEncryptedFeats))
+
+	require.ErrorIs(t, err, ErrNoDecryptionKey)
+}
+
+func TestEncryptedFeaturesWithTheWrongKeyFails(t *testing.T) {
+	_, err := NewClient(ctx,
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+		WithDecryptionKey("aaaaaaaaaaaaaaaaaaaaaa=="),
+	)
+
+	require.Error(t, err, "a bad key has to surface rather than leaving the client with no features")
+}
+
+func TestEncryptedFeaturesWithMalformedCiphertextFails(t *testing.T) {
+	_, err := NewClient(ctx,
+		WithEncryptedJsonFeatures("not-a-payload"),
+		WithDecryptionKey(testDecryptionKey),
+	)
+
+	require.Error(t, err)
+}
+
+func TestSetEncryptedJSONFeaturesStillRequiresAKeyWhenCalledDirectly(t *testing.T) {
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	require.ErrorIs(t, client.SetEncryptedJSONFeatures(testEncryptedFeats), ErrNoDecryptionKey)
+}
+
+func TestAClientWithNoEncryptedFeaturesIsUnaffected(t *testing.T) {
+	client, err := NewClient(ctx,
+		WithJsonFeatures(`{"feature": {"defaultValue": 1}}`),
+		WithDecryptionKey(testDecryptionKey),
+	)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 1, client.EvalFeature(ctx, "feature").Value)
+}

--- a/encrypted_features_test.go
+++ b/encrypted_features_test.go
@@ -1,6 +1,11 @@
 package growthbook
 
 import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -86,4 +91,87 @@ func TestAClientWithNoEncryptedFeaturesIsUnaffected(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, 1, client.EvalFeature(ctx, "feature").Value)
+}
+
+func TestAPlainFeatureOptionListedAfterEncryptedOneWins(t *testing.T) {
+	// Deferring decryption must not move it past unrelated feature options - the last feature option
+	// listed is still the one that decides.
+	client, err := NewClient(ctx,
+		WithDecryptionKey(testDecryptionKey),
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+		WithJsonFeatures(`{"fallback":{"defaultValue":"plain"}}`),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, "plain", client.EvalFeature(ctx, "fallback").Value,
+		"the plain option came last, so it has to win")
+	require.Nil(t, client.EvalFeature(ctx, "feature").Value,
+		"and the encrypted payload it superseded must not come back after the option loop")
+}
+
+func TestAnEncryptedFeatureOptionListedAfterAPlainOneWins(t *testing.T) {
+	client, err := NewClient(ctx,
+		WithJsonFeatures(`{"fallback":{"defaultValue":"plain"}}`),
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+		WithDecryptionKey(testDecryptionKey),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, true, client.EvalFeature(ctx, "feature").Value, "the encrypted option came last")
+	require.Nil(t, client.EvalFeature(ctx, "fallback").Value)
+}
+
+func TestAnInvalidEncryptedPayloadFailsEvenWhenAValidOneFollowsIt(t *testing.T) {
+	// Collapsing the deferred payloads into one would let a valid payload hide an invalid one instead
+	// of failing construction.
+	client, err := NewClient(ctx,
+		WithEncryptedJsonFeatures("not-a-valid-payload"),
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+		WithDecryptionKey(testDecryptionKey),
+	)
+
+	require.Error(t, err, "every deferred payload is decrypted, so the invalid one still fails construction")
+	require.Nil(t, client)
+}
+
+func TestTheLastOfSeveralValidEncryptedPayloadsWins(t *testing.T) {
+	other, err := encryptFeaturesForTest(`{"other":{"defaultValue":"second"}}`)
+	require.NoError(t, err)
+
+	client, err := NewClient(ctx,
+		WithDecryptionKey(testDecryptionKey),
+		WithEncryptedJsonFeatures(testEncryptedFeats),
+		WithEncryptedJsonFeatures(other),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, "second", client.EvalFeature(ctx, "other").Value)
+	require.Nil(t, client.EvalFeature(ctx, "feature").Value)
+}
+
+// encryptFeaturesForTest produces a payload the SDK's own decrypt accepts, so the ordering of two
+// valid encrypted options can be tested. The repository ships only one valid ciphertext for this key.
+func encryptFeaturesForTest(featuresJson string) (string, error) {
+	key, err := base64.StdEncoding.DecodeString(testDecryptionKey)
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	iv := make([]byte, block.BlockSize())
+	if _, err := rand.Read(iv); err != nil {
+		return "", err
+	}
+
+	padding := block.BlockSize() - len(featuresJson)%block.BlockSize()
+	padded := append([]byte(featuresJson), bytes.Repeat([]byte{byte(padding)}, padding)...)
+
+	cipherText := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(cipherText, padded)
+
+	return base64.StdEncoding.EncodeToString(iv) + "." + base64.StdEncoding.EncodeToString(cipherText), nil
 }


### PR DESCRIPTION
### Features and Changes

- `WithEncryptedJsonFeatures` stores the ciphertext instead of decrypting inside the option;
  `NewClient` decrypts after the option loop, so a key supplied by any option applies.
- Two files touched: `client_option.go` (the option) and `client.go` (the deferred decryption plus one
  field to hold the pending ciphertext).

No API change and no behaviour change for the order that already worked. `SetEncryptedJSONFeatures`
still requires the key to be set when called directly, since by then it is.

The reference SDK cannot hit this at all — it takes a single `Options` object, so every field is set at
once. One pre-existing divergence is kept: `decryptPayload` there catches a failed decryption, logs to
the console and carries on with no features, while Go returns an error. Ending up silently with an empty
feature set means every flag reads as off with no signal, which is worth being stricter about.

- Closes **(add link to issue here)**

### Testing

`go test ./...`, `go test -race ./...`, `go vet ./...` and `gofmt` all clean.

`encrypted_features_test.go` — 8 tests: both option orders succeed; both produce identical features; no
key still fails with `ErrNoDecryptionKey`; a wrong key fails; malformed ciphertext fails;
`SetEncryptedJSONFeatures` called directly still requires a key; a client with no encrypted features is
unaffected.

The key/ciphertext pair comes from the vendored `cases.json` `decrypt` category rather than being
invented.

Verified by revert: restoring the decryption inside the option fails 2 of the 8 — the reversed-order test
and the both-orders-agree test.

