### PR TITLE
Skip feature-value serialization unless a feature-usage consumer needs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- **Fixed:** `EvalFeature` no longer JSON-encodes every evaluated feature
+  value (the requested key and each prerequisite parent) on every call once
+  any tracking consumer is attached. Feature-usage bookkeeping is skipped
+  entirely when only exposure consumers (`ExperimentCallback`,
+  `TrackingBuffer`) are present, and when a `FeatureUsageCallback`, plugin
+  or event logger is present a value is encoded only if its key repeats
+  within the evaluation. Object-valued features were paying a `json.Marshal`
+  per evaluation; what is reported to callbacks, plugins and the event
+  logger is unchanged.
+
 ## [v0.5.0](https://pkg.go.dev/github.com/growthbook/growthbook-golang@v0.5.0) - 2026-09-08
 
 - **Added: contextual bandit support** (JS parity): feature rules carrying a

--- a/client.go
+++ b/client.go
@@ -394,9 +394,13 @@ func (client *Client) evaluator(ctx context.Context) *evaluator {
 		contextualBandits: client.data.contextualBandits,
 		client:            client,
 		ctx:               ctx,
-		recording: client.experimentCallback != nil || client.featureUsageCallback != nil ||
-			client.eventLogger != nil || client.trackingBuffer != nil || len(client.data.plugins) > 0,
 	}
+	// Plugins and the event logger consume both exposures and feature usage;
+	// the tracking buffer and ExperimentCallback only exposures, and
+	// FeatureUsageCallback only feature usage (see fireTracking).
+	both := client.eventLogger != nil || len(client.data.plugins) > 0
+	e.recordingExperiments = both || client.experimentCallback != nil || client.trackingBuffer != nil
+	e.recordingFeatureUsage = both || client.featureUsageCallback != nil
 	client.data.mu.RUnlock()
 	return &e
 }

--- a/evaluator.go
+++ b/evaluator.go
@@ -17,12 +17,16 @@ type evaluator struct {
 	client            *Client
 	ctx               context.Context
 
-	recording          bool // false when no callbacks, plugins, or buffer consume tracking
-	userCtx            *TrackingUserContext
-	experiments        []TrackingData
-	featureUsage       []featureUsage
-	trackedExperiments map[trackingKey]bool
-	trackedFeatures    map[string]string
+	// recordingExperiments / recordingFeatureUsage are false when nothing
+	// consumes exposures / feature-usage reports, so evaluation skips that
+	// bookkeeping.
+	recordingExperiments  bool
+	recordingFeatureUsage bool
+	userCtx               *TrackingUserContext
+	experiments           []TrackingData
+	featureUsage          []featureUsage
+	trackedExperiments    map[trackingKey]bool
+	trackedFeatures       map[string]trackedValue
 }
 
 func (e *evaluator) evalFeature(key string) *FeatureResult {

--- a/evaluator_bench_test.go
+++ b/evaluator_bench_test.go
@@ -54,6 +54,46 @@ func BenchmarkEvalFeature_Warm(b *testing.B) {
 	}
 }
 
+func objectValuedBenchClient(b *testing.B, opt ClientOption) *Client {
+	b.Helper()
+	payload := map[string]any{}
+	for i := 0; i < 40; i++ {
+		payload[fmt.Sprintf("key-%d", i)] = map[string]any{"enabled": i%2 == 0, "weight": float64(i), "label": "value"}
+	}
+	c, err := NewClient(context.Background(),
+		WithAttributes(Attributes{"id": "bench-user"}),
+		WithFeatures(FeatureMap{"config": {DefaultValue: payload}}),
+		opt,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return c
+}
+
+// An object-valued feature on a client whose only tracking consumer is an
+// ExperimentCallback.
+func BenchmarkEvalFeature_ObjectValue_ExperimentCallback(b *testing.B) {
+	c := objectValuedBenchClient(b, WithExperimentCallback(func(context.Context, *Experiment, *ExperimentResult, *TrackingUserContext, any) {}))
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.EvalFeature(ctx, "config")
+	}
+}
+
+// The same feature on a client with a FeatureUsageCallback.
+func BenchmarkEvalFeature_ObjectValue_FeatureUsageCallback(b *testing.B) {
+	c := objectValuedBenchClient(b, WithFeatureUsageCallback(func(context.Context, string, *FeatureResult, any) {}))
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.EvalFeature(ctx, "config")
+	}
+}
+
 func BenchmarkRunExperiment(b *testing.B) {
 	c, err := NewClient(context.Background(),
 		WithAttributes(Attributes{"id": "bench-user"}),

--- a/tracking.go
+++ b/tracking.go
@@ -207,7 +207,7 @@ func (client *Client) trackingUserContext() *TrackingUserContext {
 }
 
 func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
-	if !e.recording {
+	if !e.recordingExperiments {
 		return
 	}
 	if e.trackedExperiments == nil {
@@ -242,20 +242,39 @@ func (e *evaluator) recordExperiment(exp *Experiment, res *ExperimentResult) {
 	e.experiments = append(e.experiments, TrackingData{Experiment: &expCopy, Result: &resCopy, User: e.userCtx})
 }
 
+// trackedValue is a feature value whose JSON encoding is computed at most
+// once, on first comparison.
+type trackedValue struct {
+	value   FeatureValue
+	enc     string
+	encoded bool
+}
+
+func (t *trackedValue) encoding() string {
+	if !t.encoded {
+		t.enc, t.encoded = stringifyFeatureValue(t.value), true
+	}
+	return t.enc
+}
+
 // recordFeatureUsage reports a feature once per evaluation unless its value
-// changed.
+// changed, using the same JSON-encoding comparison as the JS SDK. Values are
+// only encoded when a key repeats within the evaluation, so the common path
+// serializes nothing.
 func (e *evaluator) recordFeatureUsage(key string, res *FeatureResult) {
-	if !e.recording {
+	if !e.recordingFeatureUsage {
 		return
 	}
 	if e.trackedFeatures == nil {
-		e.trackedFeatures = make(map[string]string)
+		e.trackedFeatures = make(map[string]trackedValue)
 	}
-	stringified := stringifyFeatureValue(res.Value)
-	if prev, ok := e.trackedFeatures[key]; ok && prev == stringified {
+	cur := trackedValue{value: res.Value}
+	prev, seen := e.trackedFeatures[key]
+	if seen && prev.encoding() == cur.encoding() {
+		e.trackedFeatures[key] = prev // keep the encoding for the next repeat
 		return
 	}
-	e.trackedFeatures[key] = stringified
+	e.trackedFeatures[key] = cur
 	e.featureUsage = append(e.featureUsage, featureUsage{key: key, result: res})
 }
 

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -834,3 +834,71 @@ func TestTakeTrackingCalls(t *testing.T) {
 		}
 	})
 }
+
+// marshalCounting is a feature value that counts its JSON encodings, so
+// tests can observe when evaluation serializes feature values.
+type marshalCounting struct{ calls *int }
+
+func (m marshalCounting) MarshalJSON() ([]byte, error) {
+	*m.calls++
+	return []byte(`"counted"`), nil
+}
+
+// serializationProbeFeatures returns a "parent" whose value counts its own
+// encodings and a "child" whose two rules each read the parent (and skip),
+// so a single EvalFeature("child") evaluates "parent" twice.
+func serializationProbeFeatures(t *testing.T, calls *int) FeatureMap {
+	t.Helper()
+	var first, second FeatureRule
+	for _, r := range []*FeatureRule{&first, &second} {
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"parentConditions": [{"id": "parent", "condition": {"value": "other"}}],
+			"force": "unreachable"
+		}`), r))
+	}
+	return FeatureMap{
+		"parent": {DefaultValue: marshalCounting{calls}},
+		"child":  {DefaultValue: "child-default", Rules: []FeatureRule{first, second}},
+	}
+}
+
+func TestFeatureUsageValueSerialization(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("exposure-only consumers never serialize feature values", func(t *testing.T) {
+		var encodings int
+		client, err := NewClient(ctx,
+			WithFeatures(serializationProbeFeatures(t, &encodings)),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithTrackingBuffer(NewTrackingBuffer()),
+			WithExperimentCallback(func(context.Context, *Experiment, *ExperimentResult, *TrackingUserContext, any) {}),
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, marshalCounting{&encodings}, client.EvalFeature(ctx, "parent").Value)
+		require.Equal(t, "child-default", client.EvalFeature(ctx, "child").Value)
+		require.Zero(t, encodings)
+	})
+
+	t.Run("a feature-usage consumer serializes only when a key repeats within one evaluation", func(t *testing.T) {
+		var encodings int
+		var usage []string
+		client, err := NewClient(ctx,
+			WithFeatures(serializationProbeFeatures(t, &encodings)),
+			WithAttributes(Attributes{"id": "user-1"}),
+			WithFeatureUsageCallback(func(_ context.Context, key string, _ *FeatureResult, _ any) {
+				usage = append(usage, key)
+			}),
+		)
+		require.NoError(t, err)
+
+		client.EvalFeature(ctx, "parent")
+		require.Zero(t, encodings, "a key seen once is not serialized")
+		require.Equal(t, []string{"parent"}, usage)
+
+		usage = nil
+		require.Equal(t, "child-default", client.EvalFeature(ctx, "child").Value)
+		require.Equal(t, 2, encodings, "each occurrence of the repeated parent is encoded once")
+		require.Equal(t, []string{"parent", "child"}, usage, "the unchanged repeat is still reported once")
+	})
+}


### PR DESCRIPTION
### Features and Changes

`EvalFeature` was JSON-serializing every evaluated feature value — the requested key and each prerequisite parent it recursed into — on every call, as soon as *any* tracking consumer was attached to the client. The serialization lives in `recordFeatureUsage`, where it builds the "once per evaluation unless the value changed" dedupe key, but that key is only ever read when a feature-usage consumer exists (`FeatureUsageCallback`, a plugin's `OnFeatureEvaluated`, or the event logger). A server-side client that only sets an `ExperimentCallback` or attaches a `TrackingBuffer` paid for it on every evaluation and got nothing back, and for object-valued features the cost dominates evaluation.

Two changes, no change to what is reported:

- The evaluator's single `recording` flag becomes `recordingExperiments` / `recordingFeatureUsage`, derived from which consumers are actually attached (plugins and the event logger count for both; `ExperimentCallback` and `TrackingBuffer` only for exposures; `FeatureUsageCallback` only for usage). Exposure-only clients skip usage bookkeeping entirely.
- When usage *is* recorded, the dedupe map keeps the `FeatureValue` itself and compares by JSON encoding only when the same key shows up again within the evaluation (a parent read by more than one rule), caching each encoding so a parent read K times is encoded K times, as before. That keeps the JS SDK's "value changed" comparison while the common path encodes nothing.

An observation, not changed here: `recordExperiment` still builds a fresh `TrackingUserContext` (converting the whole attribute map) in every `EvalFeature` call that records an exposure, since the evaluator is per call. That is per experiment hit rather than per feature, so much smaller, but a client-level cache would remove it too if you think it's worth it.

### Testing

- `TestFeatureUsageValueSerialization` (new) uses a feature value that counts its own `MarshalJSON` calls: an exposure-only client evaluating it, directly and then twice via a child's two parent conditions, encodes it zero times; a client with a `FeatureUsageCallback` encodes nothing for a key seen once and encodes the repeated parent once per occurrence, while still reporting `parent` once and `child` once. Both subtests fail on `main` (3 and 1 encodings where 0 are expected) and pass here.
- Existing tracking, plugin, event-logger and feature-usage tests pass unchanged (`go test ./...`, also under `-race`).
- `BenchmarkEvalFeature_ObjectValue_{ExperimentCallback,FeatureUsageCallback}` (new; a 40-key object value, one consumer attached), `go test -bench ObjectValue -count 2`:

  | | ns/op | B/op | allocs/op |
  |---|---|---|---|
  | main, ExperimentCallback | ~33,800 | 17,334 | 369 |
  | this PR, ExperimentCallback | ~215 | 256 | 3 |
  | main, FeatureUsageCallback | ~33,000 | 17,334 | 369 |
  | this PR, FeatureUsageCallback | ~580 | 808 | 6 |

  The existing `Cold`/`Warm` benchmarks (no consumers attached) are unchanged.
- On a real ~10k-feature payload evaluated key-by-key with an `ExperimentCallback` attached, a full pass went from ~33 ms / 20 MB allocated to ~9.2 ms / 3.7 MB (the no-callback baseline is ~9.1 ms), with identical exposure and usage callback counts and identical served values.
- `CHANGELOG.md`: added an Unreleased entry.
